### PR TITLE
Fix the **kern translation for figure 6 with a backslash

### DIFF
--- a/src/tool-musicxml2hum.cpp
+++ b/src/tool-musicxml2hum.cpp
@@ -1989,7 +1989,12 @@ string Tool_musicxml2hum::convertFiguredBassNumber(const xml_node& figure) {
 	if (suffix == "cross" || prefix == "cross") {
 		slash = "|";
 	} else if ((suffix == "backslash") || (prefix == "backslash")) {
-		slash = "\\";
+		if (number == "6")
+		{
+			accidental = "#";
+			slash = "|";
+		}
+		else slash = "\\";
 	} else if ((suffix == "slash") || (prefix == "slash")) {
 		slash = "/";
 	}


### PR DESCRIPTION
Hi Craig,

I tried to solve #15 by forking the repo and working on it. In this pull request, I managed to solve the second (small) problem of #15, which is "The slashed 6 is not translated properly (it should be `#6|` in **kern, not `6\`)".

However, for the first (main) problem of #15, which is "Figures under a stationary bass (mm.2 and mm.3) are partially missing", I found it pretty hard to fix. It seems to me that I need to change how figured bass is attached (currently, it seems to attach under each bass note, but there can be multiple figures associated with one bass note, and in these cases "musicxml2hum" won't work) in your code. 

It will be great if you can help me with this, since I am working on adding figured bass to some of Bach's works (in musicXML) and trying to release it as a symbolic dataset for academic use in the near future, and I want to provide the **kern format as well (and MEI once the **kern version works). As you can see, "musicxml2hum" will be a really big help to this project.

Thank you in advance! Please let me know if there is any update in the future.

Cheers,
Yaolong

