### PR TITLE
[myank] Add `-l` flag to select line range and improve cutting null tokens

### DIFF
--- a/include/HumdrumToken.h
+++ b/include/HumdrumToken.h
@@ -195,6 +195,12 @@ class HumdrumToken : public std::string, public HumHash {
 		HumNum   getDurationToEnd          (void);
 		HumNum   getDurationToEnd          (HumNum scale);
 
+		HumNum   getDurationFromNoteStart  (void);
+		HumNum   getDurationFromNoteStart  (HumNum scale);
+
+		HumNum   getDurationToNoteEnd      (void);
+		HumNum   getDurationToNoteEnd      (HumNum scale);
+
 		HumNum   getDurationFromBarline    (void);
 		HumNum   getDurationFromBarline    (HumNum scale);
 

--- a/include/humlib.h
+++ b/include/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Di 24 Jan 2023 22:28:46 CET
+// Last Modified: Mi 25 Jan 2023 16:23:25 CET
 // Filename:      humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/include/humlib.h
 // Syntax:        C++11

--- a/include/humlib.h
+++ b/include/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Do 26 Jan 2023 15:01:06 CET
+// Last Modified: Di  7 Feb 2023 15:00:18 CET
 // Filename:      humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/include/humlib.h
 // Syntax:        C++11

--- a/include/humlib.h
+++ b/include/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Di  7 Feb 2023 15:20:03 CET
+// Last Modified: Di  7 Feb 2023 18:58:16 CET
 // Filename:      humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/include/humlib.h
 // Syntax:        C++11

--- a/include/humlib.h
+++ b/include/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Di  7 Feb 2023 15:00:18 CET
+// Last Modified: Di  7 Feb 2023 15:04:23 CET
 // Filename:      humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/include/humlib.h
 // Syntax:        C++11

--- a/include/humlib.h
+++ b/include/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mi 25 Jan 2023 23:37:27 CET
+// Last Modified: Do 26 Jan 2023 15:01:06 CET
 // Filename:      humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/include/humlib.h
 // Syntax:        C++11
@@ -9207,6 +9207,8 @@ class Tool_myank : public HumTool {
 
 		string      m_lineRange;              // used with -l option
 		vector<int> m_barNumbersPerLine;      // used with -l option
+		bool m_hideStarting;                  // used with --hide-starting option
+		bool m_hideEnding;                    // used with --hide-ending option
 
 };
 

--- a/include/humlib.h
+++ b/include/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mo 23 Jan 2023 17:51:36 CET
+// Last Modified: Di 24 Jan 2023 22:28:46 CET
 // Filename:      humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/include/humlib.h
 // Syntax:        C++11
@@ -1618,6 +1618,12 @@ class HumdrumToken : public std::string, public HumHash {
 
 		HumNum   getDurationToEnd          (void);
 		HumNum   getDurationToEnd          (HumNum scale);
+
+		HumNum   getDurationFromNoteStart  (void);
+		HumNum   getDurationFromNoteStart  (HumNum scale);
+
+		HumNum   getDurationToNoteEnd      (void);
+		HumNum   getDurationToNoteEnd      (HumNum scale);
 
 		HumNum   getDurationFromBarline    (void);
 		HumNum   getDurationFromBarline    (HumNum scale);
@@ -9173,25 +9179,34 @@ class Tool_myank : public HumTool {
 		void      printMeasureStart    (HumdrumFile& infile, int line, const string& style);
 		std::string expandMultipliers  (const string& inputstring);
 
+		vector<int> analyzeBarNumbers  (HumdrumFile& infile);
+		int         getBarNumberForLineNumber(int lineNumber);
+		int         getStartLineNumber (void);
+		int         getEndLineNumber   (void);
+		void        printDataLine      (HLp line, bool& startLineHandled, const vector<int>& lastLineResolvedTokenLineIndex, const vector<HumNum>& lastLineDurationsFromNoteStart);
+
 	private:
-		int    debugQ      = 0;             // used with --debug option
-		// int    inputlist   = 0;             // used with --inlist option
-		int    inlistQ     = 0;             // used with --inlist option
-		int    outlistQ    = 0;             // used with --outlist option
-		int    verboseQ    = 0;             // used with -v option
-		int    invisibleQ  = 1;             // used with --visible option
-		int    maxQ        = 0;             // used with --max option
-		int    minQ        = 0;             // used with --min option
-		int    instrumentQ = 0;             // used with -I option
-		int    nolastbarQ  = 0;             // used with -B option
-		int    markQ       = 0;             // used with --mark option
-		int    doubleQ     = 0;             // used with --mdsep option
-		int    barnumtextQ = 0;             // used with -T option
-		int    Section     = 0;             // used with --section option
-		int    sectionCountQ = 0;           // used with --section-count option
-		vector<MeasureInfo> MeasureOutList; // used with -m option
-		vector<MeasureInfo> MeasureInList;  // used with -m option
-		vector<vector<MyCoord> > metstates;
+		int    m_debugQ      = 0;             // used with --debug option
+		// int    inputlist     = 0;             // used with --inlist option
+		int    m_inlistQ     = 0;             // used with --inlist option
+		int    m_outlistQ    = 0;             // used with --outlist option
+		int    m_verboseQ    = 0;             // used with -v option
+		int    m_invisibleQ  = 1;             // used with --visible option
+		int    m_maxQ        = 0;             // used with --max option
+		int    m_minQ        = 0;             // used with --min option
+		int    m_instrumentQ = 0;             // used with -I option
+		int    m_nolastbarQ  = 0;             // used with -B option
+		int    m_markQ       = 0;             // used with --mark option
+		int    m_doubleQ     = 0;             // used with --mdsep option
+		int    m_barnumtextQ = 0;             // used with -T option
+		int    m_section     = 0;             // used with --section option
+		int    m_sectionCountQ = 0;           // used with --section-count option
+		vector<MeasureInfo> m_measureOutList; // used with -m option
+		vector<MeasureInfo> m_measureInList;  // used with -m option
+		vector<vector<MyCoord> > m_metstates;
+
+		string      m_lineRange;              // used with -l option
+		vector<int> m_barNumbersPerLine;      // used with -l option
 
 };
 

--- a/include/humlib.h
+++ b/include/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mi 25 Jan 2023 16:23:25 CET
+// Last Modified: Mi 25 Jan 2023 23:37:27 CET
 // Filename:      humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/include/humlib.h
 // Syntax:        C++11

--- a/include/tool-myank.h
+++ b/include/tool-myank.h
@@ -156,9 +156,9 @@ class Tool_myank : public HumTool {
 		std::string expandMultipliers  (const string& inputstring);
 
 		vector<int> analyzeBarNumbers  (HumdrumFile& infile);
-		int         getBarNumberForLine(int line);
-		int         getStartLine       (void);
-		int         getEndLine         (void);
+		int         getBarNumberForLineNumber(int lineNumber);
+		int         getStartLineNumber (void);
+		int         getEndLineNumber   (void);
 
 	private:
 		int    m_debugQ      = 0;             // used with --debug option

--- a/include/tool-myank.h
+++ b/include/tool-myank.h
@@ -155,10 +155,10 @@ class Tool_myank : public HumTool {
 		void      printMeasureStart    (HumdrumFile& infile, int line, const string& style);
 		std::string expandMultipliers  (const string& inputstring);
 
-		vector<int> analyzeBarNumbers(HumdrumFile& infile);
-		int getBarNumberForLine(int line);
-		int getStartLine();
-		int getEndLine();
+		vector<int> analyzeBarNumbers  (HumdrumFile& infile);
+		int         getBarNumberForLine(int line);
+		int         getStartLine       (void);
+		int         getEndLine         (void);
 
 	private:
 		int    m_debugQ      = 0;             // used with --debug option

--- a/include/tool-myank.h
+++ b/include/tool-myank.h
@@ -161,27 +161,27 @@ class Tool_myank : public HumTool {
 		int getEndLine();
 
 	private:
-		int    debugQ      = 0;             // used with --debug option
-		// int    inputlist   = 0;             // used with --inlist option
-		int    inlistQ     = 0;             // used with --inlist option
-		int    outlistQ    = 0;             // used with --outlist option
-		int    verboseQ    = 0;             // used with -v option
-		int    invisibleQ  = 1;             // used with --visible option
-		int    maxQ        = 0;             // used with --max option
-		int    minQ        = 0;             // used with --min option
-		int    instrumentQ = 0;             // used with -I option
-		int    nolastbarQ  = 0;             // used with -B option
-		int    markQ       = 0;             // used with --mark option
-		int    doubleQ     = 0;             // used with --mdsep option
-		int    barnumtextQ = 0;             // used with -T option
-		int    Section     = 0;             // used with --section option
-		int    sectionCountQ = 0;           // used with --section-count option
-		vector<MeasureInfo> MeasureOutList; // used with -m option
-		vector<MeasureInfo> MeasureInList;  // used with -m option
-		vector<vector<MyCoord> > metstates;
+		int    m_debugQ      = 0;             // used with --debug option
+		// int    inputlist     = 0;             // used with --inlist option
+		int    m_inlistQ     = 0;             // used with --inlist option
+		int    m_outlistQ    = 0;             // used with --outlist option
+		int    m_verboseQ    = 0;             // used with -v option
+		int    m_invisibleQ  = 1;             // used with --visible option
+		int    m_maxQ        = 0;             // used with --max option
+		int    m_minQ        = 0;             // used with --min option
+		int    m_instrumentQ = 0;             // used with -I option
+		int    m_nolastbarQ  = 0;             // used with -B option
+		int    m_markQ       = 0;             // used with --mark option
+		int    m_doubleQ     = 0;             // used with --mdsep option
+		int    m_barnumtextQ = 0;             // used with -T option
+		int    m_section     = 0;             // used with --section option
+		int    m_sectionCountQ = 0;           // used with --section-count option
+		vector<MeasureInfo> m_measureOutList; // used with -m option
+		vector<MeasureInfo> m_measureInList;  // used with -m option
+		vector<vector<MyCoord> > m_metstates;
 
-		string linesQ;
-		vector<int> BarNumbers;             // used with -l option
+		string      m_lineRange;              // used with -l option
+		vector<int> m_barNumbersPerLine;      // used with -l option
 
 };
 

--- a/include/tool-myank.h
+++ b/include/tool-myank.h
@@ -159,6 +159,7 @@ class Tool_myank : public HumTool {
 		int         getBarNumberForLineNumber(int lineNumber);
 		int         getStartLineNumber (void);
 		int         getEndLineNumber   (void);
+		void        printDataLine      (HLp line, bool& startLineHandled, const vector<int>& lastLineResolvedTokenLineIndex, const vector<HumNum>& lastLineDurationsFromNoteStart);
 
 	private:
 		int    m_debugQ      = 0;             // used with --debug option

--- a/include/tool-myank.h
+++ b/include/tool-myank.h
@@ -155,6 +155,11 @@ class Tool_myank : public HumTool {
 		void      printMeasureStart    (HumdrumFile& infile, int line, const string& style);
 		std::string expandMultipliers  (const string& inputstring);
 
+		vector<int> analyzeBarNumbers(HumdrumFile& infile);
+		int getBarNumberForLine(int line);
+		int getStartLine();
+		int getEndLine();
+
 	private:
 		int    debugQ      = 0;             // used with --debug option
 		// int    inputlist   = 0;             // used with --inlist option
@@ -174,6 +179,9 @@ class Tool_myank : public HumTool {
 		vector<MeasureInfo> MeasureOutList; // used with -m option
 		vector<MeasureInfo> MeasureInList;  // used with -m option
 		vector<vector<MyCoord> > metstates;
+
+		string linesQ;
+		vector<int> BarNumbers;             // used with -l option
 
 };
 

--- a/include/tool-myank.h
+++ b/include/tool-myank.h
@@ -183,6 +183,8 @@ class Tool_myank : public HumTool {
 
 		string      m_lineRange;              // used with -l option
 		vector<int> m_barNumbersPerLine;      // used with -l option
+		bool m_hideStarting;                  // used with --hide-starting option
+		bool m_hideEnding;                    // used with --hide-ending option
 
 };
 

--- a/src/HumdrumToken.cpp
+++ b/src/HumdrumToken.cpp
@@ -1092,6 +1092,52 @@ HumNum HumdrumToken::getDurationToEnd(HumNum scale) {
 
 //////////////////////////////
 //
+// HumdrumToken::getDurationFromNoteStart -- Returns the duration from the start
+//   of the resolved HumdrumToken to the starting time of this token. This is
+//   useful to get the pased duration of a null token.
+//
+
+HumNum HumdrumToken::getDurationFromNoteStart(void) {
+	HumNum dur = HumNum();
+	HTp resolvedToken = this->resolveNull();
+	HumdrumFile* infile = getLine()->getOwner();
+	int startLineIndex = resolvedToken->getLineIndex();
+	int thisLineIndex = getLineIndex();
+	for (int i = startLineIndex; i < thisLineIndex; i++) {
+		dur += infile->getLine(i)->getDuration();
+	}
+	// TODO handle tied notes
+	return dur;
+}
+
+
+HumNum HumdrumToken::getDurationFromNoteStart(HumNum scale) {
+	return this->getDurationFromNoteStart() * scale;
+}
+
+
+
+//////////////////////////////
+//
+// HumdrumToken::getDurationToNoteEnd -- Returns the duration from this token to
+//   the end of the resolved HumdrumToken duration. This is useful to get the
+//   remaining duration of a null token.
+//
+
+HumNum HumdrumToken::getDurationToNoteEnd(void) {
+	// TODO handle tied notes
+	return this->resolveNull()->getDuration() - getDurationFromNoteStart();
+}
+
+
+HumNum HumdrumToken::getDurationToNoteEnd(HumNum scale) {
+	return this->getDurationToNoteEnd() * scale;
+}
+
+
+
+//////////////////////////////
+//
 // HumdrumToken::getBarlineDuration -- Returns the duration between
 //   the next and previous barline.  If the token is a barline token,
 //   then return the duration to the next barline.  The barline duration data

--- a/src/humlib.cpp
+++ b/src/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Do 26 Jan 2023 15:01:06 CET
+// Last Modified: Di  7 Feb 2023 15:00:18 CET
 // Filename:      /include/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/src/humlib.cpp
 // Syntax:        C++11
@@ -103587,6 +103587,10 @@ void Tool_myank::printStarting(HumdrumFile& infile) {
 		}
 		if (!m_hideStarting) {
 			m_humdrum_text << infile[i] << "\n";
+		} else {
+			if (infile[i].rfind("!!!RDF", 0) == 0) {
+				m_humdrum_text << infile[i] << "\n";
+			}
 		}
 	}
 
@@ -103679,9 +103683,12 @@ void Tool_myank::printEnding(HumdrumFile& infile, int lastline, int adjlin) {
 
 	if (startline >= 0) {
 		for (i=startline; i<infile.getLineCount(); i++) {
-			m_humdrum_text << infile[i] << "\n";
 			if (m_hideEnding && (i >= ending)) {
-				break;
+				if (infile[i].rfind("!!!RDF", 0) == 0) {
+					m_humdrum_text << infile[i] << "\n";
+				}
+			} else {
+				m_humdrum_text << infile[i] << "\n";
 			}
 		}
 	}

--- a/src/humlib.cpp
+++ b/src/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mi 25 Jan 2023 23:37:27 CET
+// Last Modified: Do 26 Jan 2023 15:01:06 CET
 // Filename:      /include/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/src/humlib.cpp
 // Syntax:        C++11
@@ -101957,6 +101957,8 @@ Tool_myank::Tool_myank(void) {
 	define("version=b",       "Program version");
 	define("example=b",       "Program examples");
 	define("h|help=b",        "Short description");
+	define("hide-starting=b", "Prevent printStarting");
+	define("hide-ending=b",   "Prevent printEnding");
 }
 
 
@@ -102125,6 +102127,9 @@ void Tool_myank::initialize(HumdrumFile& infile) {
 	m_section       =  getInteger("section");
 
 	m_lineRange     = getString("lines");
+	m_hideStarting  = getBoolean("hide-starting");
+	m_hideEnding    = getBoolean("hide-ending");
+
 
 	if (!m_section) {
 		if (!(getBoolean("measures") || m_markQ) && !getBoolean("lines")) {
@@ -103580,7 +103585,9 @@ void Tool_myank::printStarting(HumdrumFile& infile) {
 			exi = i;
 			break;
 		}
-		m_humdrum_text << infile[i] << "\n";
+		if (!m_hideStarting) {
+			m_humdrum_text << infile[i] << "\n";
+		}
 	}
 
 	int hasI = 0;
@@ -103673,6 +103680,9 @@ void Tool_myank::printEnding(HumdrumFile& infile, int lastline, int adjlin) {
 	if (startline >= 0) {
 		for (i=startline; i<infile.getLineCount(); i++) {
 			m_humdrum_text << infile[i] << "\n";
+			if (m_hideEnding && (i >= ending)) {
+				break;
+			}
 		}
 	}
 

--- a/src/humlib.cpp
+++ b/src/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Di  7 Feb 2023 15:00:18 CET
+// Last Modified: Di  7 Feb 2023 15:04:23 CET
 // Filename:      /include/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/src/humlib.cpp
 // Syntax:        C++11
@@ -103285,7 +103285,7 @@ void Tool_myank::printDataLine(HLp line, bool& startLineHandled, const vector<in
 		}
 	}
 	if (lineChange) {
-		line->getOwner()->createLinesFromTokens();
+		line->createLineFromTokens();
 	}
 	m_humdrum_text << line << "\n";
 }

--- a/src/humlib.cpp
+++ b/src/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Di  7 Feb 2023 15:20:03 CET
+// Last Modified: Di  7 Feb 2023 18:58:16 CET
 // Filename:      /include/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/src/humlib.cpp
 // Syntax:        C++11
@@ -102673,7 +102673,8 @@ void Tool_myank::myank(HumdrumFile& infile, vector<MeasureInfo>& outmeasures) {
 		lastbarnum = barnum;
 	}
 
-	if (getBoolean("lines") && (lastDataLine >= 0) && (infile.getLine(lastDataLine)->getDurationToBarline() > infile.getLine(lastDataLine)->getDuration())) {
+	if (getBoolean("lines") && (lastDataLine >= 0) &&
+			(infile.getLine(lastDataLine)->getDurationToBarline() > infile.getLine(lastDataLine)->getDuration())) {
 		m_nolastbarQ = true;
 	}
 
@@ -103227,7 +103228,10 @@ void Tool_myank::adjustGlobalInterpretationsStart(HumdrumFile& infile, int ii,
 // Tool_myank::printDataLine -- Print line with data tokens of selected section
 //
 
-void Tool_myank::printDataLine(HLp line, bool& startLineHandled, const vector<int>& lastLineResolvedTokenLineIndex, const vector<HumNum>& lastLineDurationsFromNoteStart) {
+void Tool_myank::printDataLine(HLp line,
+		bool& startLineHandled,
+		const vector<int>& lastLineResolvedTokenLineIndex,
+		const vector<HumNum>& lastLineDurationsFromNoteStart) {
 	bool lineChange = false;
 	// Handle cutting the previeous token of a note that hangs into the selected
 	// section
@@ -103257,7 +103261,8 @@ void Tool_myank::printDataLine(HLp line, bool& startLineHandled, const vector<in
 	// Handle cutting the last attacked note of the selected section
 	} else {
 		// Check if line has a note that needs to be handled
-		if (std::find(lastLineResolvedTokenLineIndex.begin(), lastLineResolvedTokenLineIndex.end(), line->getLineIndex()) != lastLineResolvedTokenLineIndex.end()) {
+		if (std::find(lastLineResolvedTokenLineIndex.begin(), lastLineResolvedTokenLineIndex.end(), line->getLineIndex()) !=
+				lastLineResolvedTokenLineIndex.end()) {
 			for (int i = 0; i < line->getTokenCount(); i++) {
 				HTp token = line->token(i);
 				// Check if token need the be handled and is of type **kern

--- a/src/humlib.cpp
+++ b/src/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mo 23 Jan 2023 17:51:36 CET
+// Last Modified: Di 24 Jan 2023 22:28:46 CET
 // Filename:      /include/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/src/humlib.cpp
 // Syntax:        C++11
@@ -32901,6 +32901,52 @@ HumNum HumdrumToken::getDurationToEnd(void) {
 
 HumNum HumdrumToken::getDurationToEnd(HumNum scale) {
 	return getLine()->getDurationToEnd() * scale;
+}
+
+
+
+//////////////////////////////
+//
+// HumdrumToken::getDurationFromNoteStart -- Returns the duration from the start
+//   of the resolved HumdrumToken to the starting time of this token. This is
+//   useful to get the pased duration of a null token.
+//
+
+HumNum HumdrumToken::getDurationFromNoteStart(void) {
+	HumNum dur = HumNum();
+	HTp resolvedToken = this->resolveNull();
+	HumdrumFile* infile = getLine()->getOwner();
+	int startLineIndex = resolvedToken->getLineIndex();
+	int thisLineIndex = getLineIndex();
+	for (int i = startLineIndex; i < thisLineIndex; i++) {
+		dur += infile->getLine(i)->getDuration();
+	}
+	// TODO handle tied notes
+	return dur;
+}
+
+
+HumNum HumdrumToken::getDurationFromNoteStart(HumNum scale) {
+	return this->getDurationFromNoteStart() * scale;
+}
+
+
+
+//////////////////////////////
+//
+// HumdrumToken::getDurationToNoteEnd -- Returns the duration from this token to
+//   the end of the resolved HumdrumToken duration. This is useful to get the
+//   remaining duration of a null token.
+//
+
+HumNum HumdrumToken::getDurationToNoteEnd(void) {
+	// TODO handle tied notes
+	return this->resolveNull()->getDuration() - getDurationFromNoteStart();
+}
+
+
+HumNum HumdrumToken::getDurationToNoteEnd(HumNum scale) {
+	return this->getDurationToNoteEnd() * scale;
 }
 
 
@@ -101899,6 +101945,7 @@ Tool_myank::Tool_myank(void) {
 	define("T|M|bar-number-text=b", "print barnum with LO text above system ");
 	define("d|double|dm|md|mdsep|mdseparator=b", "Put double barline between non-consecutive measure segments");
 	define("m|b|measures|bars|measure|bar=s", "Measures to yank");
+	define("l|lines|line-range=s", "Line numbers range to yank (e.g. 40-50)");
 	define("I|i|instrument=b", "Include instrument codes from start of data");
 	define("visible|not-invisible=b", "Do not make initial measure invisible");
 	define("B|noendbar=b", "Do not print barline at end of data");
@@ -102061,26 +102108,28 @@ void Tool_myank::initialize(HumdrumFile& infile) {
 		return;
 	}
 
-	debugQ        = getBoolean("debug");
-	inlistQ       = getBoolean("inlist");
-	outlistQ      = getBoolean("outlist");
-	verboseQ      = getBoolean("verbose");
-	maxQ          = getBoolean("max");
-	minQ          = getBoolean("min");
+	m_debugQ        = getBoolean("debug");
+	m_inlistQ       = getBoolean("inlist");
+	m_outlistQ      = getBoolean("outlist");
+	m_verboseQ      = getBoolean("verbose");
+	m_maxQ          = getBoolean("max");
+	m_minQ          = getBoolean("min");
 
-	invisibleQ    = !getBoolean("not-invisible");
-	instrumentQ   =  getBoolean("instrument");
-	nolastbarQ    =  getBoolean("noendbar");
-	markQ         =  getBoolean("mark");
-	doubleQ       =  getBoolean("mdsep");
-	barnumtextQ   =  getBoolean("bar-number-text");
-	sectionCountQ =  getBoolean("section-count");
-	Section       =  getInteger("section");
+	m_invisibleQ    = !getBoolean("not-invisible");
+	m_instrumentQ   =  getBoolean("instrument");
+	m_nolastbarQ    =  getBoolean("noendbar");
+	m_markQ         =  getBoolean("mark");
+	m_doubleQ       =  getBoolean("mdsep");
+	m_barnumtextQ   =  getBoolean("bar-number-text");
+	m_sectionCountQ =  getBoolean("section-count");
+	m_section       =  getInteger("section");
 
-	if (!Section) {
-		if (!(getBoolean("measures") || markQ)) {
+	m_lineRange     = getString("lines");
+
+	if (!m_section) {
+		if (!(getBoolean("measures") || m_markQ) && !getBoolean("lines")) {
 			// if -m option is not given, then --mark option presumed
-			markQ = 1;
+			m_markQ = 1;
 			// cerr << "Error: the -m option is required" << endl;
 			// exit(1);
 		}
@@ -102096,62 +102145,136 @@ void Tool_myank::initialize(HumdrumFile& infile) {
 //
 
 void Tool_myank::processFile(HumdrumFile& infile) {
-	if (sectionCountQ) {
+	if (m_sectionCountQ) {
 		int sections = getSectionCount(infile);
 		m_humdrum_text << sections << endl;
 		return;
 	}
 
-	getMetStates(metstates, infile);
-	getMeasureStartStop(MeasureInList, infile);
+	getMetStates(m_metstates, infile);
+	getMeasureStartStop(m_measureInList, infile);
 
 	string measurestring = getString("measures");
+
+	if (getBoolean("lines")) {
+		m_barNumbersPerLine = analyzeBarNumbers(infile);
+		int startBarNumber = getBarNumberForLineNumber(getStartLineNumber());
+		int endBarNumber = getBarNumberForLineNumber(getEndLineNumber());
+		measurestring = to_string(startBarNumber) + "-" + to_string(endBarNumber);
+	}
+
 	measurestring = expandMultipliers(measurestring);
-	if (markQ) {
+	if (m_markQ) {
 		stringstream mstring;
 		getMarkString(mstring, infile);
 		measurestring = mstring.str();
-		if (debugQ) {
+		if (m_debugQ) {
 			m_free_text << "MARK STRING: " << mstring.str() << endl;
 		}
-	} else if (Section) {
+	} else if (m_section) {
 		string sstring;
-		getSectionString(sstring, infile, Section);
+		getSectionString(sstring, infile, m_section);
 		measurestring = sstring;
 	}
-	if (debugQ) {
+	if (m_debugQ) {
 		m_free_text << "MARK MEASURES: " << measurestring << endl;
 	}
 
 	// expand to multiple measures later.
-	expandMeasureOutList(MeasureOutList, MeasureInList, infile,
+	expandMeasureOutList(m_measureOutList, m_measureInList, infile,
 			measurestring);
 
-	if (inlistQ) {
+	if (m_inlistQ) {
 		m_free_text << "INPUT MEASURE MAP: " << endl;
-		for (int i=0; i<(int)MeasureInList.size(); i++) {
-			m_free_text << MeasureInList[i];
+		for (int i=0; i<(int)m_measureInList.size(); i++) {
+			m_free_text << m_measureInList[i];
 		}
 	}
-	if (outlistQ) {
+	if (m_outlistQ) {
 		m_free_text << "OUTPUT MEASURE MAP: " << endl;
-		for (int i=0; i<(int)MeasureOutList.size(); i++) {
-			m_free_text << MeasureOutList[i];
+		for (int i=0; i<(int)m_measureOutList.size(); i++) {
+			m_free_text << m_measureOutList[i];
 		}
 	}
 
-	if (MeasureOutList.size() == 0) {
+	if (m_measureOutList.size() == 0) {
 		// disallow processing files with no barlines
 		return;
 	}
 
 	// move stopStyle to startStyle of next measure group.
-	for (int i=(int)MeasureOutList.size()-1; i>0; i--) {
-		MeasureOutList[i].startStyle = MeasureOutList[i-1].stopStyle;
-		MeasureOutList[i-1].stopStyle = "";
+	for (int i=(int)m_measureOutList.size()-1; i>0; i--) {
+		m_measureOutList[i].startStyle = m_measureOutList[i-1].stopStyle;
+		m_measureOutList[i-1].stopStyle = "";
 	}
 
-	myank(infile, MeasureOutList);
+	myank(infile, m_measureOutList);
+}
+
+
+
+////////////////////////
+//
+// Tool_myank::analyzeBarNumbers -- Stores the bar number of each line in a vector
+//
+
+vector<int> Tool_myank::analyzeBarNumbers(HumdrumFile& infile) {
+	vector<int> m_barnum;
+	m_barnum.resize(infile.getLineCount());
+	int current = -1;
+	HumRegex hre;
+	for (int i=0; i<infile.getLineCount(); i++) {
+		if (!infile[i].isBarline()) {
+			m_barnum.at(i) = current;
+			continue;
+		}
+		if (hre.search(infile[i].token(0), "=(\\d+)")) {
+			current = hre.getMatchInt(1);
+		}
+		m_barnum.at(i) = current;
+	}
+	return m_barnum;
+}
+
+
+
+////////////////////////
+//
+// Tool_myank::getBarNumberForLineNumber --
+//
+
+int Tool_myank::getBarNumberForLineNumber(int lineNumber) {
+	return m_barNumbersPerLine[lineNumber-1];
+}
+
+
+
+////////////////////////
+//
+// Tool_myank::getStartLineNumber -- Get start line number from --lines
+//
+
+int Tool_myank::getStartLineNumber(void) {
+	HumRegex hre;
+	if (hre.search(m_lineRange, "^(\\d+)\\-(\\d+)$")) {
+        return hre.getMatchInt(1);
+    }
+	return -1;
+}
+
+
+
+////////////////////////
+//
+// Tool_myank::getEndLineNumber -- Get end line number from --lines
+//
+
+int Tool_myank::getEndLineNumber(void) {
+	HumRegex hre;
+	if (hre.search(m_lineRange, "^(\\d+)\\-(\\d+)$")) {
+        return hre.getMatchInt(2);
+    }
+	return -1;
 }
 
 
@@ -102224,7 +102347,7 @@ void Tool_myank::getMetStates(vector<vector<MyCoord> >& metstates,
 		}
 	}
 
-	if (debugQ) {
+	if (m_debugQ) {
 		for (int i=0; i<infile.getLineCount(); i++) {
 			for (int j=1; j<(int)metstates[i].size(); j++) {
 				if (metstates[i][j].x < 0) {
@@ -102332,7 +102455,7 @@ void Tool_myank::getMarkString(ostream& out, HumdrumFile& infile)  {
 		}
 	}
 
-	if (debugQ) {
+	if (m_debugQ) {
 		for (int i=0; i<(int)mchar.size(); i++) {
 			m_free_text << "\tMARK CHARCTER: " << mchar[i] << endl;
 		}
@@ -102409,12 +102532,39 @@ void Tool_myank::myank(HumdrumFile& infile, vector<MeasureInfo>& outmeasures) {
 	int barnum = -1;
 	int datastart = 0;
 	int bartextcount = 0;
+	bool startLineHandled = false;
+
+	int lastLineIndex = getBoolean("lines") ? getEndLineNumber() - 1 : outmeasures[outmeasures.size() - 1].stop;
+
+	// Find the actual last line of the selected section that is a line with
+	// data tokens
+	while (infile.getLine(lastLineIndex)->isData() == false) {
+		lastLineIndex--;
+	}
+
+	// Mapping with with the start token for each spine 
+	vector<int> lastLineResolvedTokenLineIndex;
+	// Mapping with the later needed durations of the note that fits within the
+	// selected section
+	vector<HumNum> lastLineDurationsFromNoteStart;
+
+	lastLineResolvedTokenLineIndex.resize(infile.getLine(lastLineIndex)->getTokenCount());
+	lastLineDurationsFromNoteStart.resize(infile.getLine(lastLineIndex)->getTokenCount());
+
+	for (int a = 0; a < infile.getLine(lastLineIndex)->getTokenCount(); a++) {
+		HTp token = infile.token(lastLineIndex, a);
+		// Get lineIndex for last data token with an attack
+		lastLineResolvedTokenLineIndex[a] = infile.token(lastLineIndex, a)->resolveNull()->getLineIndex();
+		// Get needed duration for this token until section end
+		lastLineDurationsFromNoteStart[a] = token->getDurationFromNoteStart() + token->getLine()->getDuration();
+	}
+
 	for (h=0; h<(int)outmeasures.size(); h++) {
 		barnum = outmeasures[h].num;
 		measurestart = 1;
 		printed = 0;
 		counter = 0;
-		if (debugQ) {
+		if (m_debugQ) {
 			m_humdrum_text << "!! =====================================\n";
 			m_humdrum_text << "!! processing " << outmeasures[h].num << endl;
 		}
@@ -102424,7 +102574,9 @@ void Tool_myank::myank(HumdrumFile& infile, vector<MeasureInfo>& outmeasures) {
 		} else {
 			reconcileStartingPosition(infile, outmeasures[0].start);
 		}
-		for (i=outmeasures[h].start; i<outmeasures[h].stop; i++) {
+		int startLine = getBoolean("lines") ? std::max(getStartLineNumber()-1, outmeasures[h].start): outmeasures[h].start;
+		int endLine = getBoolean("lines") ? std::min(getEndLineNumber(), outmeasures[h].stop): outmeasures[h].stop;
+		for (i=startLine; i<endLine; i++) {
 			counter++;
 			if ((!printed) && ((mcount == 0) || (counter == 2))) {
 				if ((datastart == 0) && outmeasures[h].num == 0) {
@@ -102441,25 +102593,25 @@ void Tool_myank::myank(HumdrumFile& infile, vector<MeasureInfo>& outmeasures) {
 			if (infile[i].isBarline()) {
 				mcount++;
 			}
-			if ((mcount == 1) && invisibleQ && infile[i].isBarline()) {
+			if ((mcount == 1) && m_invisibleQ && infile[i].isBarline()) {
 				printInvisibleMeasure(infile, i);
 				measurestart = 0;
 				if ((bartextcount++ == 0) && infile[i].isBarline()) {
 					int barline = 0;
 					sscanf(infile.token(i, 0)->c_str(), "=%d", &barline);
-					if (barnumtextQ && (barline > 0)) {
+					if (m_barnumtextQ && (barline > 0)) {
 						m_humdrum_text << "!!LO:TX:Z=20:X=-90:t=" << barline << endl;
 					}
 				}
-			} else if (doubleQ && (lastbarnum > -1) && (abs(barnum - lastbarnum) > 1)) {
+			} else if (m_doubleQ && (lastbarnum > -1) && (abs(barnum - lastbarnum) > 1)) {
 				printDoubleBarline(infile, i);
 				measurestart = 0;
 			} else if (measurestart && infile[i].isBarline()) {
 				printMeasureStart(infile, i, outmeasures[h].startStyle);
 				measurestart = 0;
 			} else {
-				m_humdrum_text << infile[i] << "\n";
-				if (barnumtextQ && (bartextcount++ == 0) && infile[i].isBarline()) {
+				printDataLine(infile.getLine(i), startLineHandled, lastLineResolvedTokenLineIndex, lastLineDurationsFromNoteStart);
+				if (m_barnumtextQ && (bartextcount++ == 0) && infile[i].isBarline()) {
 					int barline = 0;
 					sscanf(infile.token(i, 0)->c_str(), "=%d", &barline);
 					if (barline > 0) {
@@ -102480,13 +102632,13 @@ void Tool_myank::myank(HumdrumFile& infile, vector<MeasureInfo>& outmeasures) {
 	} else {
 		lasti = -1;
 	}
-	if ((!nolastbarQ) &&  (lasti >= 0) && infile[lasti].isBarline()) {
+	if ((!m_nolastbarQ) &&  (lasti >= 0) && infile[lasti].isBarline()) {
 		for (j=0; j<infile[lasti].getFieldCount(); j++) {
 			token = *infile.token(lasti, j);
 			hre.replaceDestructive(token, outmeasures.back().stopStyle, "\\d+.*");
 			// collapse final barlines
 			hre.replaceDestructive(token, "==", "===+");
-			if (doubleQ) {
+			if (m_doubleQ) {
 				if (hre.search(token, "=(.+)")) {
 					// don't add double barline, there is already
 					// some style on the barline
@@ -102505,7 +102657,7 @@ void Tool_myank::myank(HumdrumFile& infile, vector<MeasureInfo>& outmeasures) {
 
 	collapseSpines(infile, lasti);
 
-	if (debugQ) {
+	if (m_debugQ) {
 		m_free_text << "PROCESSING ENDING" << endl;
 	}
 
@@ -103016,6 +103168,77 @@ void Tool_myank::adjustGlobalInterpretationsStart(HumdrumFile& infile, int ii,
 }
 
 
+
+//////////////////////////////
+//
+// Tool_myank::printDataLine -- Print line with data tokens of selected section
+//
+
+void Tool_myank::printDataLine(HLp line, bool& startLineHandled, const vector<int>& lastLineResolvedTokenLineIndex, const vector<HumNum>& lastLineDurationsFromNoteStart) {
+	bool lineChange = false;
+	// Handle cutting the previeous token of a note that hangs into the selected
+	// section
+	if (startLineHandled == false) {
+		if (line->isData()) {
+			vector<HTp> tokens;
+			line->getTokens(tokens);
+			for (HTp token : tokens) {
+				if (token->isKern() && token->isNull()) {
+					HTp resolvedToken = token->resolveNull();
+					if (resolvedToken->isNull()) {
+						continue;
+					}
+					string recip = Convert::durationToRecip(token->getDurationToNoteEnd());
+					string pitch;
+					HumRegex hre;
+					if (hre.search(resolvedToken, "([rRA-Ga-gxyXYn#-]+)")) {
+						pitch = hre.getMatch(1);
+					}
+					string tokenText = recip + pitch + "]";
+					token->setText(tokenText);
+					lineChange = true;
+				}
+			}
+			startLineHandled = true;
+		}
+	// Handle cutting the last attacked note of the selected section
+	} else {
+		// Check if line has a note that needs to be handled
+		if (std::find(lastLineResolvedTokenLineIndex.begin(), lastLineResolvedTokenLineIndex.end(), line->getLineIndex()) != lastLineResolvedTokenLineIndex.end()) {
+			for (int i = 0; i < line->getTokenCount(); i++) {
+				HTp token = line->token(i);
+				// Check if token need the be handled and is of type **kern
+				if (token->isKern() && (lastLineResolvedTokenLineIndex[i] == line->getLineIndex())) {
+					HTp resolvedToken = token->resolveNull();
+					if (resolvedToken->isNull()) {
+						continue;
+					}
+					HumNum dur = lastLineDurationsFromNoteStart[i];
+					string recip = Convert::durationToRecip(dur);
+					string pitch;
+					HumRegex hre;
+					if (hre.search(resolvedToken, "([rRA-Ga-gxyXYn#-]+)")) {
+						pitch = hre.getMatch(1);
+					}
+					string tokenText;
+					if (resolvedToken->getDuration() > dur) {
+						tokenText += "[";
+					}
+					tokenText += recip + pitch;
+					token->setText(tokenText);
+					lineChange = true;
+				}
+			}
+		}
+	}
+	if (lineChange) {
+		line->getOwner()->createLinesFromTokens();
+	}
+	m_humdrum_text << line << "\n";
+}
+
+
+
 //////////////////////////////
 //
 // Tool_myank::printMeasureStart -- print a starting measure of a segment.
@@ -103052,7 +103275,7 @@ void Tool_myank::printMeasureStart(HumdrumFile& infile, int line, const string& 
 	}
 	m_humdrum_text << "\n";
 
-	if (barnumtextQ) {
+	if (m_barnumtextQ) {
 		int barline = 0;
 		sscanf(infile.token(line, 0)->c_str(), "=%d", &barline);
 		if (barline > 0) {
@@ -103089,7 +103312,7 @@ void Tool_myank::printDoubleBarline(HumdrumFile& infile, int line) {
 	}
 	m_humdrum_text << "\n";
 
-	if (barnumtextQ) {
+	if (m_barnumtextQ) {
 		int barline = 0;
 		sscanf(infile.token(line, 0)->c_str(), "=%d", &barline);
 		if (barline > 0) {
@@ -103147,7 +103370,7 @@ void Tool_myank::printInvisibleMeasure(HumdrumFile& infile, int line) {
 
 void Tool_myank::reconcileSpineBoundary(HumdrumFile& infile, int index1, int index2) {
 
-	if (debugQ) {
+	if (m_debugQ) {
 		m_humdrum_text << "RECONCILING LINES " << index1+1 << " and " << index2+1 << endl;
 		m_humdrum_text << "FIELD COUNT OF " << index1+1 << " is "
 			  << infile[index1].getFieldCount() << endl;
@@ -103314,7 +103537,7 @@ void Tool_myank::printStarting(HumdrumFile& infile) {
 
 	int hasI = 0;
 
-	if (instrumentQ) {
+	if (m_instrumentQ) {
 		// print any tandem interpretations which start with *I found
 		// at the start of the data before measures, notes, or any
 		// spine manipulator lines
@@ -103365,7 +103588,7 @@ void Tool_myank::printStarting(HumdrumFile& infile) {
 //
 
 void Tool_myank::printEnding(HumdrumFile& infile, int lastline, int adjlin) {
-	if (debugQ) {
+	if (m_debugQ) {
 		m_humdrum_text << "IN printEnding" << endl;
 	}
 	int ending = -1;
@@ -103688,14 +103911,14 @@ void Tool_myank::expandMeasureOutList(vector<MeasureInfo>& measureout,
 		cerr << "Error: ridiculusly large measure number: " << maxmeasure << endl;
 		exit(1);
 	}
-	if (maxQ) {
+	if (m_maxQ) {
 		if (measurein.size() == 0) {
 			m_humdrum_text << 0 << endl;
 		} else {
 			m_humdrum_text << maxmeasure << endl;
 		}
 		exit(0);
-	} else if (minQ) {
+	} else if (m_minQ) {
 		for (int ii=0; ii<infile.getLineCount(); ii++) {
 			if (infile[ii].isBarline()) {
 				if (hre.search(infile.token(ii, 0), "=\\d", "")) {
@@ -103729,7 +103952,7 @@ void Tool_myank::expandMeasureOutList(vector<MeasureInfo>& measureout,
 	string ostring = optionstring;
 	removeDollarsFromString(ostring, maxmeasure);
 
-	if (debugQ) {
+	if (m_debugQ) {
 		m_free_text << "Option string expanded: " << ostring << endl;
 	}
 
@@ -104260,7 +104483,7 @@ void Tool_myank::removeDollarsFromString(string& buffer, int maxx) {
 	int outval;
 	int value;
 
-	if (debugQ) {
+	if (m_debugQ) {
 		m_free_text << "MEASURE STRING BEFORE DOLLAR REMOVAL: " << buffer << endl;
 	}
 
@@ -104282,7 +104505,7 @@ void Tool_myank::removeDollarsFromString(string& buffer, int maxx) {
 		obuf += hre.getMatch(1);
 		hre.replaceDestructive(buffer, tbuf, obuf);
 	}
-	if (debugQ) {
+	if (m_debugQ) {
 		m_free_text << "DOLLAR EXPAND: " << buffer << endl;
 	}
 }

--- a/src/humlib.cpp
+++ b/src/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mi 25 Jan 2023 16:23:25 CET
+// Last Modified: Mi 25 Jan 2023 23:37:27 CET
 // Filename:      /include/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/src/humlib.cpp
 // Syntax:        C++11
@@ -102614,7 +102614,17 @@ void Tool_myank::myank(HumdrumFile& infile, vector<MeasureInfo>& outmeasures) {
 					// not ideal setup...
 					datastart = 1;
 				} else{
-					adjustGlobalInterpretations(infile, i, outmeasures, h);
+					// Fix adjustGlobalInterpretations when line is a global comment
+					int nextLineIndexWithSpines = i;
+					if (infile.getLine(i)->isCommentGlobal()) {
+						for (int d = i; d <= endLineNumber - 1; d++) {
+							if (!infile.getLine(d)->isCommentGlobal()) {
+								nextLineIndexWithSpines = d;
+								break;
+							}
+						}
+					}
+					adjustGlobalInterpretations(infile, nextLineIndexWithSpines, outmeasures, h);
 					printed = 1;
 				}
 			}

--- a/src/tool-myank.cpp
+++ b/src/tool-myank.cpp
@@ -329,20 +329,18 @@ int Tool_myank::getBarNumberForLine(int lineNumber) {
 }
 
 int Tool_myank::getStartLine(void) {
-	regex re("^(\\d+)\\-(\\d+)$");
-	std::smatch match;
-	if (regex_search(m_lineRange, match, re) && match.size() > 1) {
-		return stoi(match.str(1));
-	}
+	HumRegex hre;
+	if (hre.search(m_lineRange, "^(\\d+)\\-(\\d+)$")) {
+        return hre.getMatchInt(1);
+    }
 	return -1;
 }
 
 int Tool_myank::getEndLine(void) {
-	regex re("^(\\d+)\\-(\\d+)$");
-	std::smatch match;
-	if (regex_search(m_lineRange, match, re) && match.size() > 1) {
-		return stoi(match.str(2));
-	}
+	HumRegex hre;
+	if (hre.search(m_lineRange, "^(\\d+)\\-(\\d+)$")) {
+        return hre.getMatchInt(2);
+    }
 	return -1;
 }
 

--- a/src/tool-myank.cpp
+++ b/src/tool-myank.cpp
@@ -723,7 +723,7 @@ void Tool_myank::myank(HumdrumFile& infile, vector<MeasureInfo>& outmeasures) {
 				}
 			}
 			lastline = i;
-			if (infile.getLine(i)->token(0)->isKern()) {
+			if (infile.getLine(i)->isData()) {
 				lastDataLine = i;
 			}
 		}

--- a/src/tool-myank.cpp
+++ b/src/tool-myank.cpp
@@ -252,8 +252,8 @@ void Tool_myank::processFile(HumdrumFile& infile) {
 
 	if (getBoolean("lines")) {
 		m_barNumbersPerLine = analyzeBarNumbers(infile);
-		int startBarNumber = getBarNumberForLine(getStartLine());
-		int endBarNumber = getBarNumberForLine(getEndLine());
+		int startBarNumber = getBarNumberForLineNumber(getStartLineNumber());
+		int endBarNumber = getBarNumberForLineNumber(getEndLineNumber());
 		measurestring = to_string(startBarNumber) + "-" + to_string(endBarNumber);
 	}
 
@@ -306,6 +306,12 @@ void Tool_myank::processFile(HumdrumFile& infile) {
 }
 
 
+
+////////////////////////
+//
+// Tool_myank::analyzeBarNumbers -- Stores the bar number of each line in a vector
+//
+
 vector<int> Tool_myank::analyzeBarNumbers(HumdrumFile& infile) {
 	vector<int> m_barnum;
 	m_barnum.resize(infile.getLineCount());
@@ -324,11 +330,25 @@ vector<int> Tool_myank::analyzeBarNumbers(HumdrumFile& infile) {
 	return m_barnum;
 }
 
-int Tool_myank::getBarNumberForLine(int lineNumber) {
+
+
+////////////////////////
+//
+// Tool_myank::getBarNumberForLineNumber --
+//
+
+int Tool_myank::getBarNumberForLineNumber(int lineNumber) {
 	return m_barNumbersPerLine[lineNumber-1];
 }
 
-int Tool_myank::getStartLine(void) {
+
+
+////////////////////////
+//
+// Tool_myank::getStartLineNumber -- Get start line number from --lines
+//
+
+int Tool_myank::getStartLineNumber(void) {
 	HumRegex hre;
 	if (hre.search(m_lineRange, "^(\\d+)\\-(\\d+)$")) {
         return hre.getMatchInt(1);
@@ -336,13 +356,21 @@ int Tool_myank::getStartLine(void) {
 	return -1;
 }
 
-int Tool_myank::getEndLine(void) {
+
+
+////////////////////////
+//
+// Tool_myank::getEndLineNumber -- Get end line number from --lines
+//
+
+int Tool_myank::getEndLineNumber(void) {
 	HumRegex hre;
 	if (hre.search(m_lineRange, "^(\\d+)\\-(\\d+)$")) {
         return hre.getMatchInt(2);
     }
 	return -1;
 }
+
 
 
 //////////////////////////////
@@ -613,8 +641,8 @@ void Tool_myank::myank(HumdrumFile& infile, vector<MeasureInfo>& outmeasures) {
 		} else {
 			reconcileStartingPosition(infile, outmeasures[0].start);
 		}
-		int startLine = getBoolean("lines") ? std::max(getStartLine()-1, outmeasures[h].start): outmeasures[h].start;
-		int endLine = getBoolean("lines") ? std::min(getEndLine(), outmeasures[h].stop): outmeasures[h].stop;
+		int startLine = getBoolean("lines") ? std::max(getStartLineNumber()-1, outmeasures[h].start): outmeasures[h].start;
+		int endLine = getBoolean("lines") ? std::min(getEndLineNumber(), outmeasures[h].stop): outmeasures[h].stop;
 		for (i=startLine; i<endLine; i++) {
 			counter++;
 			if ((!printed) && ((mcount == 0) || (counter == 2))) {

--- a/src/tool-myank.cpp
+++ b/src/tool-myank.cpp
@@ -1682,6 +1682,10 @@ void Tool_myank::printStarting(HumdrumFile& infile) {
 		}
 		if (!m_hideStarting) {
 			m_humdrum_text << infile[i] << "\n";
+		} else {
+			if (infile[i].rfind("!!!RDF", 0) == 0) {
+				m_humdrum_text << infile[i] << "\n";
+			}
 		}
 	}
 
@@ -1774,9 +1778,12 @@ void Tool_myank::printEnding(HumdrumFile& infile, int lastline, int adjlin) {
 
 	if (startline >= 0) {
 		for (i=startline; i<infile.getLineCount(); i++) {
-			m_humdrum_text << infile[i] << "\n";
 			if (m_hideEnding && (i >= ending)) {
-				break;
+				if (infile[i].rfind("!!!RDF", 0) == 0) {
+					m_humdrum_text << infile[i] << "\n";
+				}
+			} else {
+				m_humdrum_text << infile[i] << "\n";
 			}
 		}
 	}

--- a/src/tool-myank.cpp
+++ b/src/tool-myank.cpp
@@ -1380,7 +1380,7 @@ void Tool_myank::printDataLine(HLp line, bool& startLineHandled, const vector<in
 		}
 	}
 	if (lineChange) {
-		line->getOwner()->createLinesFromTokens();
+		line->createLineFromTokens();
 	}
 	m_humdrum_text << line << "\n";
 }

--- a/src/tool-myank.cpp
+++ b/src/tool-myank.cpp
@@ -52,6 +52,8 @@ Tool_myank::Tool_myank(void) {
 	define("version=b",       "Program version");
 	define("example=b",       "Program examples");
 	define("h|help=b",        "Short description");
+	define("hide-starting=b", "Prevent printStarting");
+	define("hide-ending=b",   "Prevent printEnding");
 }
 
 
@@ -220,6 +222,9 @@ void Tool_myank::initialize(HumdrumFile& infile) {
 	m_section       =  getInteger("section");
 
 	m_lineRange     = getString("lines");
+	m_hideStarting  = getBoolean("hide-starting");
+	m_hideEnding    = getBoolean("hide-ending");
+
 
 	if (!m_section) {
 		if (!(getBoolean("measures") || m_markQ) && !getBoolean("lines")) {
@@ -1675,7 +1680,9 @@ void Tool_myank::printStarting(HumdrumFile& infile) {
 			exi = i;
 			break;
 		}
-		m_humdrum_text << infile[i] << "\n";
+		if (!m_hideStarting) {
+			m_humdrum_text << infile[i] << "\n";
+		}
 	}
 
 	int hasI = 0;
@@ -1768,6 +1775,9 @@ void Tool_myank::printEnding(HumdrumFile& infile, int lastline, int adjlin) {
 	if (startline >= 0) {
 		for (i=startline; i<infile.getLineCount(); i++) {
 			m_humdrum_text << infile[i] << "\n";
+			if (m_hideEnding && (i >= ending)) {
+				break;
+			}
 		}
 	}
 

--- a/src/tool-myank.cpp
+++ b/src/tool-myank.cpp
@@ -768,7 +768,8 @@ void Tool_myank::myank(HumdrumFile& infile, vector<MeasureInfo>& outmeasures) {
 		lastbarnum = barnum;
 	}
 
-	if (getBoolean("lines") && (lastDataLine >= 0) && (infile.getLine(lastDataLine)->getDurationToBarline() > infile.getLine(lastDataLine)->getDuration())) {
+	if (getBoolean("lines") && (lastDataLine >= 0) &&
+			(infile.getLine(lastDataLine)->getDurationToBarline() > infile.getLine(lastDataLine)->getDuration())) {
 		m_nolastbarQ = true;
 	}
 
@@ -1322,7 +1323,10 @@ void Tool_myank::adjustGlobalInterpretationsStart(HumdrumFile& infile, int ii,
 // Tool_myank::printDataLine -- Print line with data tokens of selected section
 //
 
-void Tool_myank::printDataLine(HLp line, bool& startLineHandled, const vector<int>& lastLineResolvedTokenLineIndex, const vector<HumNum>& lastLineDurationsFromNoteStart) {
+void Tool_myank::printDataLine(HLp line,
+		bool& startLineHandled,
+		const vector<int>& lastLineResolvedTokenLineIndex,
+		const vector<HumNum>& lastLineDurationsFromNoteStart) {
 	bool lineChange = false;
 	// Handle cutting the previeous token of a note that hangs into the selected
 	// section
@@ -1352,7 +1356,8 @@ void Tool_myank::printDataLine(HLp line, bool& startLineHandled, const vector<in
 	// Handle cutting the last attacked note of the selected section
 	} else {
 		// Check if line has a note that needs to be handled
-		if (std::find(lastLineResolvedTokenLineIndex.begin(), lastLineResolvedTokenLineIndex.end(), line->getLineIndex()) != lastLineResolvedTokenLineIndex.end()) {
+		if (std::find(lastLineResolvedTokenLineIndex.begin(), lastLineResolvedTokenLineIndex.end(), line->getLineIndex()) !=
+				lastLineResolvedTokenLineIndex.end()) {
 			for (int i = 0; i < line->getTokenCount(); i++) {
 				HTp token = line->token(i);
 				// Check if token need the be handled and is of type **kern

--- a/src/tool-myank.cpp
+++ b/src/tool-myank.cpp
@@ -625,6 +625,7 @@ void Tool_myank::myank(HumdrumFile& infile, vector<MeasureInfo>& outmeasures) {
 	}
 
 	int lastline = -1;
+	int lastDataLine = -1;
 	int h, i, j;
 	int counter;
 	int printed = 0;
@@ -722,8 +723,15 @@ void Tool_myank::myank(HumdrumFile& infile, vector<MeasureInfo>& outmeasures) {
 				}
 			}
 			lastline = i;
+			if (infile.getLine(i)->token(0)->isKern()) {
+				lastDataLine = i;
+			}
 		}
 		lastbarnum = barnum;
+	}
+
+	if (getBoolean("lines") && (lastDataLine >= 0) && (infile.getLine(lastDataLine)->getDurationToBarline() > infile.getLine(lastDataLine)->getDuration())) {
+		m_nolastbarQ = true;
 	}
 
 	HumRegex hre;

--- a/src/tool-myank.cpp
+++ b/src/tool-myank.cpp
@@ -709,7 +709,17 @@ void Tool_myank::myank(HumdrumFile& infile, vector<MeasureInfo>& outmeasures) {
 					// not ideal setup...
 					datastart = 1;
 				} else{
-					adjustGlobalInterpretations(infile, i, outmeasures, h);
+					// Fix adjustGlobalInterpretations when line is a global comment
+					int nextLineIndexWithSpines = i;
+					if (infile.getLine(i)->isCommentGlobal()) {
+						for (int d = i; d <= endLineNumber - 1; d++) {
+							if (!infile.getLine(d)->isCommentGlobal()) {
+								nextLineIndexWithSpines = d;
+								break;
+							}
+						}
+					}
+					adjustGlobalInterpretations(infile, nextLineIndexWithSpines, outmeasures, h);
 					printed = 1;
 				}
 			}

--- a/src/tool-myank.cpp
+++ b/src/tool-myank.cpp
@@ -250,7 +250,7 @@ void Tool_myank::processFile(HumdrumFile& infile) {
 
 	string measurestring = getString("measures");
 
-	if(getBoolean("lines")) {
+	if (getBoolean("lines")) {
 		BarNumbers = analyzeBarNumbers(infile);
 		int startBarNumber = getBarNumberForLine(getStartLine());
 		int endBarNumber = getBarNumberForLine(getEndLine());

--- a/src/tool-myank.cpp
+++ b/src/tool-myank.cpp
@@ -39,7 +39,7 @@ Tool_myank::Tool_myank(void) {
 	define("T|M|bar-number-text=b", "print barnum with LO text above system ");
 	define("d|double|dm|md|mdsep|mdseparator=b", "Put double barline between non-consecutive measure segments");
 	define("m|b|measures|bars|measure|bar=s", "Measures to yank");
-	define("l|lines=s", "Lines to yank");
+	define("l|lines|line-range=s", "Line numbers range to yank (e.g. 40-50)");
 	define("I|i|instrument=b", "Include instrument codes from start of data");
 	define("visible|not-invisible=b", "Do not make initial measure invisible");
 	define("B|noendbar=b", "Do not print barline at end of data");

--- a/src/tool-myank.cpp
+++ b/src/tool-myank.cpp
@@ -252,9 +252,16 @@ void Tool_myank::processFile(HumdrumFile& infile) {
 	string measurestring = getString("measures");
 
 	if (getBoolean("lines")) {
+		int startLineNumber = getStartLineNumber();
+		int endLineNumber = getEndLineNumber();
+		if ((startLineNumber > endLineNumber) || (endLineNumber > infile.getLineCount())) {
+			// Disallow when end line number is bigger then line count or when
+			// start line number greather than end line number
+			return;
+		}
 		m_barNumbersPerLine = analyzeBarNumbers(infile);
-		int startBarNumber = getBarNumberForLineNumber(getStartLineNumber());
-		int endBarNumber = getBarNumberForLineNumber(getEndLineNumber());
+		int startBarNumber = getBarNumberForLineNumber(startLineNumber);
+		int endBarNumber = getBarNumberForLineNumber(endLineNumber);
 		measurestring = to_string(startBarNumber) + "-" + to_string(endBarNumber);
 	}
 

--- a/src/tool-myank.cpp
+++ b/src/tool-myank.cpp
@@ -662,6 +662,29 @@ void Tool_myank::myank(HumdrumFile& infile, vector<MeasureInfo>& outmeasures) {
 		lastLineDurationsFromNoteStart[a] = token->getDurationFromNoteStart() + token->getLine()->getDuration();
 	}
 
+	int startLineNumber = getStartLineNumber();
+	int endLineNumber = getEndLineNumber();
+
+	if (getBoolean("lines")) {
+		int firstDataLineIndex = -1;
+		for (int b = startLineNumber - 1; b <= endLineNumber - 1; b++) {
+			if (infile.getLine(b)->isData()) {
+				firstDataLineIndex = b;
+				break;
+			}
+		}
+		if (firstDataLineIndex >= 0) {
+			if (infile.getLine(firstDataLineIndex)->getDurationFromBarline() == 0) {
+				for (int c = startLineNumber - 1; c >=  0; c--) {
+					if (infile.getLine(c)->isBarline()) {
+						startLineNumber = c + 1;
+						break;
+					}
+				}
+			}
+		}
+	}
+
 	for (h=0; h<(int)outmeasures.size(); h++) {
 		barnum = outmeasures[h].num;
 		measurestart = 1;
@@ -677,8 +700,8 @@ void Tool_myank::myank(HumdrumFile& infile, vector<MeasureInfo>& outmeasures) {
 		} else {
 			reconcileStartingPosition(infile, outmeasures[0].start);
 		}
-		int startLine = getBoolean("lines") ? std::max(getStartLineNumber()-1, outmeasures[h].start): outmeasures[h].start;
-		int endLine = getBoolean("lines") ? std::min(getEndLineNumber(), outmeasures[h].stop): outmeasures[h].stop;
+		int startLine = getBoolean("lines") ? std::max(startLineNumber-1, outmeasures[h].start): outmeasures[h].start;
+		int endLine = getBoolean("lines") ? std::min(endLineNumber, outmeasures[h].stop): outmeasures[h].stop;
 		for (i=startLine; i<endLine; i++) {
 			counter++;
 			if ((!printed) && ((mcount == 0) || (counter == 2))) {

--- a/src/tool-myank.cpp
+++ b/src/tool-myank.cpp
@@ -330,7 +330,7 @@ int Tool_myank::getBarNumberForLine(int line) {
 
 int Tool_myank::getStartLine() {
 	regex re("^(\\d+)\\-(\\d+)$");
-    std::smatch match;
+	std::smatch match;
 	if (regex_search(linesQ, match, re) && match.size() > 1) {
 		return stoi(match.str(1));
 	}
@@ -339,7 +339,7 @@ int Tool_myank::getStartLine() {
 
 int Tool_myank::getEndLine() {
 	regex re("^(\\d+)\\-(\\d+)$");
-    std::smatch match;
+	std::smatch match;
 	if (regex_search(linesQ, match, re) && match.size() > 1) {
 		return stoi(match.str(2));
 	}


### PR DESCRIPTION
This PR enables to pass a line range to `myank` to filter a specific segment of the score and adds improved support for sustained notes that are not tied. See this exmaple:

<img width="638" alt="Bildschirm­foto 2023-01-24 um 21 41 44" src="https://user-images.githubusercontent.com/865594/214406041-5fbb8f9f-d5ed-420d-b041-f91122322682.png">


[VHV](https://verovio.humdrum.org/?file=https://raw.githubusercontent.com/WolfgangDrescher/lassus-geistliche-psalmen/master/kern/05-verba-mea-auribus.krn#mh4)

Probably this is not the best approach because in combination with `myank` this feature needs bar numbers to be present in the source kern file, but filtering by a line range should not depend on bar numbers.

Maybe it's better to add a new `lyank` method to the `myank` tool? Or would it be better to create a separate command for this? Since `myank` and `lyank` need similar features, like the one described in https://github.com/humdrum-tools/verovio-humdrum-viewer/issues/780 and https://github.com/humdrum-tools/verovio-humdrum-viewer/issues/781, I suggest to keep it within `myank`.