### PR TITLE
Implement --solfege option for deg tool

### DIFF
--- a/include/humlib.h
+++ b/include/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Do 19 Jan 2023 23:52:54 CET
+// Last Modified: Do 19 Jan 2023 23:53:41 CET
 // Filename:      humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/include/humlib.h
 // Syntax:        C++11

--- a/include/humlib.h
+++ b/include/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Tue Jan 17 21:33:56 PST 2023
+// Last Modified: Do 19 Jan 2023 23:35:00 CET
 // Filename:      humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/include/humlib.h
 // Syntax:        C++11
@@ -6736,6 +6736,7 @@ class Tool_deg : public HumTool {
 		bool            isDegCircleLine          (HumdrumFile& infile, int lineIndex);
 		bool            isDegColorLine           (HumdrumFile& infile, int lineIndex);
 		bool            isDegHatLine             (HumdrumFile& infile, int lineIndex);
+		bool            isDegSolfegeLine         (HumdrumFile& infile, int lineIndex);
 		bool            isKeyDesignationLine     (HumdrumFile& infile, int lineIndex);
 
 		void            checkAboveStatus         (string& value, bool arrowStatus);
@@ -6743,6 +6744,7 @@ class Tool_deg : public HumTool {
 		void            checkCircleStatus        (string& value, bool arrowStatus);
 		void            checkColorStatus         (string& value, bool arrowStatus);
 		void            checkHatStatus           (string& value, bool arrowStatus);
+		void            checkSolfegeStatus       (string& value, bool arrowStatus);
 
 		void            checkKeyDesignationStatus(string& value, int keyDesignationStatus);
 
@@ -6783,6 +6785,7 @@ class Tool_deg : public HumTool {
 		bool m_hatQ            = false;   // used with --hat option
 		bool m_colorQ          = false;   // used with --color option
 		std::string  m_color;             // used with --color option
+		bool m_solfegeQ        = false;   // used with --solfege option
 
 		bool m_degOnlyQ        = false;   // used with -I option
 		bool m_recipQ          = false;   // used with -r option
@@ -6808,6 +6811,7 @@ class Tool_deg : public HumTool {
 				bool foundColorLine;
 				bool foundHatLine;
 				bool foundKeyDesignationLine;
+				bool foundSolfegeLine;
 
 				InterleavedPrintVariables(void) { clear(); }
 				void clear(void) {
@@ -6819,6 +6823,7 @@ class Tool_deg : public HumTool {
 					foundColorLine  = false;
 					foundHatLine    = false;
 					foundKeyDesignationLine = false;
+					foundSolfegeLine = false;
 				}
 		};
 		InterleavedPrintVariables m_ipv;

--- a/include/humlib.h
+++ b/include/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Do 19 Jan 2023 23:35:00 CET
+// Last Modified: Do 19 Jan 2023 23:52:54 CET
 // Filename:      humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/include/humlib.h
 // Syntax:        C++11

--- a/include/humlib.h
+++ b/include/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Do 19 Jan 2023 23:59:48 CET
+// Last Modified: Fr 20 Jan 2023 00:01:35 CET
 // Filename:      humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/include/humlib.h
 // Syntax:        C++11

--- a/include/humlib.h
+++ b/include/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Do 19 Jan 2023 23:53:41 CET
+// Last Modified: Do 19 Jan 2023 23:59:48 CET
 // Filename:      humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/include/humlib.h
 // Syntax:        C++11

--- a/include/tool-deg.h
+++ b/include/tool-deg.h
@@ -188,6 +188,7 @@ class Tool_deg : public HumTool {
 		bool            isDegCircleLine          (HumdrumFile& infile, int lineIndex);
 		bool            isDegColorLine           (HumdrumFile& infile, int lineIndex);
 		bool            isDegHatLine             (HumdrumFile& infile, int lineIndex);
+		bool            isDegSolfegeLine         (HumdrumFile& infile, int lineIndex);
 		bool            isKeyDesignationLine     (HumdrumFile& infile, int lineIndex);
 
 		void            checkAboveStatus         (string& value, bool arrowStatus);
@@ -195,6 +196,7 @@ class Tool_deg : public HumTool {
 		void            checkCircleStatus        (string& value, bool arrowStatus);
 		void            checkColorStatus         (string& value, bool arrowStatus);
 		void            checkHatStatus           (string& value, bool arrowStatus);
+		void            checkSolfegeStatus       (string& value, bool arrowStatus);
 
 		void            checkKeyDesignationStatus(string& value, int keyDesignationStatus);
 
@@ -235,6 +237,7 @@ class Tool_deg : public HumTool {
 		bool m_hatQ            = false;   // used with --hat option
 		bool m_colorQ          = false;   // used with --color option
 		std::string  m_color;             // used with --color option
+		bool m_solfegeQ        = false;   // used with --solfege option
 
 		bool m_degOnlyQ        = false;   // used with -I option
 		bool m_recipQ          = false;   // used with -r option
@@ -260,6 +263,7 @@ class Tool_deg : public HumTool {
 				bool foundColorLine;
 				bool foundHatLine;
 				bool foundKeyDesignationLine;
+				bool foundSolfegeLine;
 
 				InterleavedPrintVariables(void) { clear(); }
 				void clear(void) {
@@ -271,6 +275,7 @@ class Tool_deg : public HumTool {
 					foundColorLine  = false;
 					foundHatLine    = false;
 					foundKeyDesignationLine = false;
+					foundSolfegeLine = false;
 				}
 		};
 		InterleavedPrintVariables m_ipv;

--- a/src/humlib.cpp
+++ b/src/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Do 19 Jan 2023 23:35:00 CET
+// Last Modified: Do 19 Jan 2023 23:52:54 CET
 // Filename:      /include/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/src/humlib.cpp
 // Syntax:        C++11
@@ -68937,7 +68937,7 @@ Tool_deg::Tool_deg(void) {
 	define("color=s", "Display color for scale degrees");
 	define("c|circ|circles|circle=b", "Display scale degrees in circles");
 	define("hat|caret|circumflex=b", "Display hats on scale degrees");
-	define("solf|solfege=b", "Display solfege syllable instead of scale degree numbers");
+	define("solf|solfege=b", "Display (relative) solfege syllables instead of scale degree numbers");
 	define("I|no-input=b", "Do not interleave **deg data with input score in output");
 	define("kern=b", "Prefix composite rhythm **kern spine with -I option");
 	define("k|kern-tracks=s", "Process only the specified kern spines");

--- a/src/humlib.cpp
+++ b/src/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Do 19 Jan 2023 23:59:48 CET
+// Last Modified: Fr 20 Jan 2023 00:01:35 CET
 // Filename:      /include/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/src/humlib.cpp
 // Syntax:        C++11
@@ -70102,7 +70102,7 @@ void Tool_deg::printDegScore(HumdrumFile& infile) {
 			}
 
 			if (!printHat) {
-				string line = createDegInterpretation("*arr", i, m_recipQ);
+				string line = createDegInterpretation("*hat", i, m_recipQ);
 				m_humdrum_text << line << endl;
 				printHat = true;
 			}

--- a/src/humlib.cpp
+++ b/src/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Do 19 Jan 2023 23:53:41 CET
+// Last Modified: Do 19 Jan 2023 23:59:48 CET
 // Filename:      /include/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/src/humlib.cpp
 // Syntax:        C++11
@@ -69488,7 +69488,7 @@ void Tool_deg::checkKeyDesignationStatus(string& value, int keyDesignationStatus
 
 //////////////////////////////
 //
-// Tool_deg::checkAboveStatus -- Add *arr interpretation to spine if needed.
+// Tool_deg::checkAboveStatus -- Add *above interpretation to spine if needed.
 //
 
 void Tool_deg::checkAboveStatus(string& value, bool aboveStatus) {
@@ -69532,7 +69532,7 @@ void Tool_deg::checkCircleStatus(string& value, bool circleStatus) {
 
 //////////////////////////////
 //
-// Tool_deg::checkColorStatus -- Add *arr interpretation to spine if needed.
+// Tool_deg::checkColorStatus -- Add *color interpretation to spine if needed.
 //
 
 void Tool_deg::checkColorStatus(string& value, bool colorStatus) {
@@ -69602,8 +69602,7 @@ bool Tool_deg::isKeyDesignationLine(HumdrumFile& infile, int lineIndex) {
 //////////////////////////////
 //
 // Tool_deg::isDegAboveLine -- Return true if **deg spines only
-//     include *arr, *Xarr, *acc, *Xacc interpretations
-//     and "*" (but not all "*").
+//     include *above, *below, interpretations and "*" (but not all "*").
 //
 
 bool Tool_deg::isDegAboveLine(HumdrumFile& infile, int lineIndex) {
@@ -69975,7 +69974,7 @@ string Tool_deg::prepareMergerLine(vector<vector<string>>& merge) {
 
 //////////////////////////////
 //
-// Tool_deg::calculateManipulatorOutput -- Deal with *^ *v *- *+ manipulators
+// Tool_deg::calculateManipulatorOutputForSpine -- Deal with *^ *v *- *+ manipulators
 //
 
 void Tool_deg::calculateManipulatorOutputForSpine(vector<string>& lineout,
@@ -70757,7 +70756,7 @@ string Tool_deg::ScaleDegree::generateDegDataToken(void) const {
 
 //////////////////////////////
 //
-// Tool_deg::ScaleDegree::createDegDataSubToken -- Convert the ScaleDegree
+// Tool_deg::ScaleDegree::generateDegDataSubtoken -- Convert the ScaleDegree
 //		subtoken (chord note) into **deg data.
 //
 

--- a/src/humlib.cpp
+++ b/src/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Do 19 Jan 2023 23:52:54 CET
+// Last Modified: Do 19 Jan 2023 23:53:41 CET
 // Filename:      /include/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/src/humlib.cpp
 // Syntax:        C++11
@@ -69714,8 +69714,7 @@ bool Tool_deg::isDegCircleLine(HumdrumFile& infile, int lineIndex) {
 //////////////////////////////
 //
 // Tool_deg::isDegColorLine -- Return true if **deg spines only
-//     include *arr, *Xarr, *acc, *Xacc interpretations
-//     and "*" (but not all "*").
+//     include *color interpretations and "*" (but not all "*").
 //
 
 bool Tool_deg::isDegColorLine(HumdrumFile& infile, int lineIndex) {

--- a/src/tool-deg.cpp
+++ b/src/tool-deg.cpp
@@ -596,7 +596,7 @@ void Tool_deg::checkKeyDesignationStatus(string& value, int keyDesignationStatus
 
 //////////////////////////////
 //
-// Tool_deg::checkAboveStatus -- Add *arr interpretation to spine if needed.
+// Tool_deg::checkAboveStatus -- Add *above interpretation to spine if needed.
 //
 
 void Tool_deg::checkAboveStatus(string& value, bool aboveStatus) {
@@ -640,7 +640,7 @@ void Tool_deg::checkCircleStatus(string& value, bool circleStatus) {
 
 //////////////////////////////
 //
-// Tool_deg::checkColorStatus -- Add *arr interpretation to spine if needed.
+// Tool_deg::checkColorStatus -- Add *color interpretation to spine if needed.
 //
 
 void Tool_deg::checkColorStatus(string& value, bool colorStatus) {
@@ -710,8 +710,7 @@ bool Tool_deg::isKeyDesignationLine(HumdrumFile& infile, int lineIndex) {
 //////////////////////////////
 //
 // Tool_deg::isDegAboveLine -- Return true if **deg spines only
-//     include *arr, *Xarr, *acc, *Xacc interpretations
-//     and "*" (but not all "*").
+//     include *above, *below, interpretations and "*" (but not all "*").
 //
 
 bool Tool_deg::isDegAboveLine(HumdrumFile& infile, int lineIndex) {
@@ -1083,7 +1082,7 @@ string Tool_deg::prepareMergerLine(vector<vector<string>>& merge) {
 
 //////////////////////////////
 //
-// Tool_deg::calculateManipulatorOutput -- Deal with *^ *v *- *+ manipulators
+// Tool_deg::calculateManipulatorOutputForSpine -- Deal with *^ *v *- *+ manipulators
 //
 
 void Tool_deg::calculateManipulatorOutputForSpine(vector<string>& lineout,
@@ -1865,7 +1864,7 @@ string Tool_deg::ScaleDegree::generateDegDataToken(void) const {
 
 //////////////////////////////
 //
-// Tool_deg::ScaleDegree::createDegDataSubToken -- Convert the ScaleDegree
+// Tool_deg::ScaleDegree::generateDegDataSubtoken -- Convert the ScaleDegree
 //		subtoken (chord note) into **deg data.
 //
 

--- a/src/tool-deg.cpp
+++ b/src/tool-deg.cpp
@@ -1210,7 +1210,7 @@ void Tool_deg::printDegScore(HumdrumFile& infile) {
 			}
 
 			if (!printHat) {
-				string line = createDegInterpretation("*arr", i, m_recipQ);
+				string line = createDegInterpretation("*hat", i, m_recipQ);
 				m_humdrum_text << line << endl;
 				printHat = true;
 			}

--- a/src/tool-deg.cpp
+++ b/src/tool-deg.cpp
@@ -41,10 +41,11 @@ string Tool_deg::ScaleDegree::m_forcedKey = "";
 Tool_deg::Tool_deg(void) {
 	define("above=b", "Display scale degrees above analyzed staff");
 	define("arr|arrow|arrows=b", "Display scale degree alterations as arrows");
-   define("b|boxes|box=b", "Display scale degrees in boxes");
-   define("color=s", "Display color for scale degrees");
-   define("c|circ|circles|circle=b", "Display scale degrees in circles");
-   define("hat|caret|circumflex=b", "Display hats on scale degrees");
+	define("b|boxes|box=b", "Display scale degrees in boxes");
+	define("color=s", "Display color for scale degrees");
+	define("c|circ|circles|circle=b", "Display scale degrees in circles");
+	define("hat|caret|circumflex=b", "Display hats on scale degrees");
+	define("solf|solfege=b", "Display (relative) solfege syllables instead of scale degree numbers");
 	define("I|no-input=b", "Do not interleave **deg data with input score in output");
 	define("kern=b", "Prefix composite rhythm **kern spine with -I option");
 	define("k|kern-tracks=s", "Process only the specified kern spines");
@@ -116,6 +117,7 @@ void Tool_deg::initialize(void) {
 	m_circleQ  = getBoolean("circle");
 	m_colorQ   = getBoolean("color");
 	m_hatQ     = getBoolean("hat");
+	m_solfegeQ = getBoolean("solfege");
 
 	if (m_colorQ) {
 		m_color = getString("color");
@@ -325,6 +327,7 @@ string Tool_deg::createOutputHumdrumLine(HumdrumFile& infile, int lineIndex) {
 	bool colorStatus          = false;
 	bool hatStatus            = false;
 	bool keyDesignationStatus = false;
+	bool solfegeStatus        = false;
 
 	// Keep track of an existing styling line and if such a line is found,
 	// then insert a styling interpretation for the new **deg spines here
@@ -350,6 +353,9 @@ string Tool_deg::createOutputHumdrumLine(HumdrumFile& infile, int lineIndex) {
 		}
 		if (m_hatQ && !m_ipv.foundHatLine) {
 			hatStatus = isDegHatLine(infile, lineIndex);
+		}
+		if (m_solfegeQ && !m_ipv.foundSolfegeLine) {
+			solfegeStatus = isDegSolfegeLine(infile, lineIndex);
 		}
 	}
 
@@ -389,6 +395,7 @@ string Tool_deg::createOutputHumdrumLine(HumdrumFile& infile, int lineIndex) {
 				checkCircleStatus(value, circleStatus);
 				checkColorStatus(value, colorStatus);
 				checkHatStatus(value, hatStatus);
+				checkSolfegeStatus(value, hatStatus);
 				spineData.back().push_back(value);
 				if (value == "*v") {
 					hasDegMerger = true;
@@ -415,6 +422,7 @@ string Tool_deg::createOutputHumdrumLine(HumdrumFile& infile, int lineIndex) {
 			checkCircleStatus(value, circleStatus);
 			checkColorStatus(value, colorStatus);
 			checkHatStatus(value, hatStatus);
+			checkSolfegeStatus(value, hatStatus);
 			spineData.back().push_back(value);
 			if (value == "*v") {
 				hasDegMerger = true;
@@ -443,6 +451,9 @@ string Tool_deg::createOutputHumdrumLine(HumdrumFile& infile, int lineIndex) {
 	}
 	if (hatStatus) {
 		m_ipv.foundHatLine = true;
+	}
+	if (solfegeStatus) {
+		m_ipv.foundSolfegeLine = true;
 	}
 
 
@@ -495,6 +506,15 @@ string Tool_deg::createOutputHumdrumLine(HumdrumFile& infile, int lineIndex) {
 		if (!m_ipv.foundAboveLine) {
 			if (m_aboveQ && !m_ipv.foundAboveLine) {
 				string line = printDegInterpretation("*above", infile, lineIndex);
+				if (!line.empty()) {
+					extraLines.push_back(line);
+				}
+			}
+		}
+
+		if (!m_ipv.foundSolfegeLine) {
+			if (m_solfegeQ && !m_ipv.foundSolfegeLine) {
+				string line = printDegInterpretation("*solf", infile, lineIndex);
 				if (!line.empty()) {
 					extraLines.push_back(line);
 				}
@@ -642,6 +662,21 @@ void Tool_deg::checkHatStatus(string& value, bool hatStatus) {
 	if (hatStatus && m_hatQ && (!m_ipv.foundHatLine) && (!m_ipv.foundData)) {
 		if (value == "*") {
 			value = "*hat";
+		}
+	}
+}
+
+
+
+//////////////////////////////
+//
+// Tool_deg::checkSolfegeStatus -- Add *solfege interpretation to spine if needed.
+//
+
+void Tool_deg::checkSolfegeStatus(string& value, bool hatStatus) {
+	if (hatStatus && m_solfegeQ && (!m_ipv.foundSolfegeLine) && (!m_ipv.foundData)) {
+		if (value == "*") {
+			value = "*solf";
 		}
 	}
 }
@@ -846,6 +881,42 @@ bool Tool_deg::isDegHatLine(HumdrumFile& infile, int lineIndex) {
 		degCount++;
 		if (*token == "*hat")  { return true; }
 		if (*token == "*Xhat") { return true; }
+	}
+	if (degCount == 0) {
+		m_ipv.hasDegSpines = false;
+	}
+
+	return false;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_deg::isDegSolfegeLine -- Return true if **deg spines includes
+//     any *solf, or *Xsolf, interpretations and "*" (but not all "*").
+//
+
+bool Tool_deg::isDegSolfegeLine(HumdrumFile& infile, int lineIndex) {
+	// If there are no **deg spines, then don't bother searching for them.
+	if (!m_ipv.hasDegSpines) {
+		return false;
+	}
+	if (!infile[lineIndex].isInterpretation()) {
+		return false;
+	} if (infile[lineIndex].isManipulator()) {
+		return false;
+	}
+
+	int degCount = 0;
+	for (int i=0; i<infile[lineIndex].getFieldCount(); i++) {
+		HTp token = infile.token(lineIndex, i);
+		if (!token->isDataType("**deg")) {
+			continue;
+		}
+		degCount++;
+		if (*token == "*solf")  { return true; }
+		if (*token == "*Xsolf") { return true; }
 	}
 	if (degCount == 0) {
 		m_ipv.hasDegSpines = false;
@@ -1072,6 +1143,7 @@ void Tool_deg::printDegScore(HumdrumFile& infile) {
 	bool printCircle = !m_circleQ;
 	bool printColor  = !m_colorQ;
 	bool printHat    = !m_hatQ;
+	bool printSolfege = !m_solfegeQ;
 
 	int lineCount = (int)m_degSpines[0].size();
 	int spineCount = (int)m_degSpines.size();
@@ -1143,6 +1215,12 @@ void Tool_deg::printDegScore(HumdrumFile& infile) {
 				string line = createDegInterpretation("*arr", i, m_recipQ);
 				m_humdrum_text << line << endl;
 				printHat = true;
+			}
+
+			if (!printSolfege) {
+				string line = createDegInterpretation("*solf", i, m_recipQ);
+				m_humdrum_text << line << endl;
+				printSolfege = true;
 			}
 
 		}

--- a/src/tool-deg.cpp
+++ b/src/tool-deg.cpp
@@ -822,8 +822,7 @@ bool Tool_deg::isDegCircleLine(HumdrumFile& infile, int lineIndex) {
 //////////////////////////////
 //
 // Tool_deg::isDegColorLine -- Return true if **deg spines only
-//     include *arr, *Xarr, *acc, *Xacc interpretations
-//     and "*" (but not all "*").
+//     include *color interpretations and "*" (but not all "*").
 //
 
 bool Tool_deg::isDegColorLine(HumdrumFile& infile, int lineIndex) {


### PR DESCRIPTION
Note that absolute solfège syllables are possible with `deg --solf --force-key C`.

I also fixed some outdated method name and parameters in the comments, as well as a wrong tandem interpretation for `*hat`.