### PR TITLE
Improve option names

### DIFF
--- a/include/humlib.h
+++ b/include/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Sa 21 Jan 2023 09:48:51 CET
+// Last Modified: Mo 23 Jan 2023 16:28:28 CET
 // Filename:      humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/include/humlib.h
 // Syntax:        C++11
@@ -7302,13 +7302,13 @@ class Tool_fb : public HumTool {
 		bool   m_sortQ          = false;
 		bool   m_lowestQ        = false;
 		bool   m_normalizeQ     = false;
-		bool   m_abbrQ          = false;
+		bool   m_abbreviateQ    = false;
 		bool   m_attackQ        = false;
 		bool   m_figuredbassQ   = false;
 		bool   m_hideThreeQ     = false;
 		bool   m_showNegativeQ  = false;
 		bool   m_aboveQ         = false;
-		string m_recipQ         = "";
+		string m_rateQ          = "";
 
 		string m_spineTracks    = ""; // used with -s option
 		string m_kernTracks     = ""; // used with -k option

--- a/include/humlib.h
+++ b/include/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mo 23 Jan 2023 16:28:28 CET
+// Last Modified: Mo 23 Jan 2023 17:20:50 CET
 // Filename:      humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/include/humlib.h
 // Syntax:        C++11

--- a/include/tool-fb.h
+++ b/include/tool-fb.h
@@ -91,7 +91,7 @@ class Tool_fb : public HumTool {
 		bool   m_sortQ          = false;
 		bool   m_lowestQ        = false;
 		bool   m_normalizeQ     = false;
-		bool   m_abbrQ          = false;
+		bool   m_abbreviateQ    = false;
 		bool   m_attackQ        = false;
 		bool   m_figuredbassQ   = false;
 		bool   m_hideThreeQ     = false;

--- a/include/tool-fb.h
+++ b/include/tool-fb.h
@@ -97,7 +97,7 @@ class Tool_fb : public HumTool {
 		bool   m_hideThreeQ     = false;
 		bool   m_showNegativeQ  = false;
 		bool   m_aboveQ         = false;
-		string m_recipQ         = "";
+		string m_rateQ          = "";
 
 		string m_spineTracks    = ""; // used with -s option
 		string m_kernTracks     = ""; // used with -k option

--- a/src/humlib.cpp
+++ b/src/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mo 23 Jan 2023 16:28:28 CET
+// Last Modified: Mo 23 Jan 2023 17:20:50 CET
 // Filename:      /include/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/src/humlib.cpp
 // Syntax:        C++11
@@ -78044,7 +78044,7 @@ Tool_fb::Tool_fb(void) {
 	define("3|hide-three=b",        "hide number 3 if it has an accidental (e.g.: #3 => #)");
 	define("m|negative=b",          "show negative numbers");
 	define("above=b",               "place figured bass numbers above staff (**fba)");
-	define("rate|recip=s:",         "rate to display the numbers (set a **recip value, e.g. 2, 4, 8, 4.)");
+	define("rate=s:",               "rate to display the numbers (set a **recip value, e.g. 2, 4, 8, 4.)");
 	define("k|kern-tracks=s",       "Process only the specified kern spines");
 	define("s|spine-tracks|spine|spines|track|tracks=s", "Process only the specified spines");
 }

--- a/src/tool-fb.cpp
+++ b/src/tool-fb.cpp
@@ -34,7 +34,7 @@ Tool_fb::Tool_fb(void) {
 	define("o|sort|order=b",        "sort figured bass numbers by interval size and not by voice index");
 	define("l|lowest=b",            "use lowest note as base note; -b flag will be ignored");
 	define("n|normalize=b",         "remove octave and doubled intervals; adds: --compound --sort");
-	define("r|abbr=b",              "use abbreviated figures; adds: --normalize --compound --sort");
+	define("r|abbreviate=b",        "use abbreviated figures; adds: --normalize --compound --sort");
 	define("t|ties=b",              "hide repeated numbers for sustained notes when base does not change");
 	define("f|figuredbass=b",       "shortcut for -c -a -o -n -r -3");
 	define("3|hide-three=b",        "hide number 3 if it has an accidental (e.g.: #3 => #)");
@@ -102,7 +102,7 @@ void Tool_fb::initialize(void) {
 	m_sortQ          = getBoolean("sort");
 	m_lowestQ        = getBoolean("lowest");
 	m_normalizeQ     = getBoolean("normalize");
-	m_abbrQ          = getBoolean("abbr");
+	m_abbreviateQ    = getBoolean("abbreviate");
 	m_attackQ        = getBoolean("ties");
 	m_figuredbassQ   = getBoolean("figuredbass");
 	m_hideThreeQ     = getBoolean("hide-three");
@@ -121,14 +121,14 @@ void Tool_fb::initialize(void) {
 		m_sortQ = true;
 	}
 
-	if (m_abbrQ) {
+	if (m_abbreviateQ) {
 		m_normalizeQ = true;
 		m_compoundQ = true;
 		m_sortQ = true;
 	}
 
 	if (m_figuredbassQ) {
-		m_abbrQ = true;
+		m_abbreviateQ = true;
 		m_normalizeQ = true;
 		m_compoundQ = true;
 		m_sortQ = true;
@@ -630,7 +630,7 @@ string Tool_fb::formatFiguredBassNumbers(const vector<FiguredBassNumber*>& numbe
 		});
 	}
 
-	if (m_abbrQ) {
+	if (m_abbreviateQ) {
 		// Overwrite formattedNumbers with abbreviated numbers
 		formattedNumbers = getAbbreviatedNumbers(formattedNumbers);
 	}

--- a/src/tool-fb.cpp
+++ b/src/tool-fb.cpp
@@ -40,7 +40,7 @@ Tool_fb::Tool_fb(void) {
 	define("3|hide-three=b",        "hide number 3 if it has an accidental (e.g.: #3 => #)");
 	define("m|negative=b",          "show negative numbers");
 	define("above=b",               "place figured bass numbers above staff (**fba)");
-	define("rate|recip=s:",         "rate to display the numbers (set a **recip value, e.g. 2, 4, 8, 4.)");
+	define("rate=s:",               "rate to display the numbers (set a **recip value, e.g. 2, 4, 8, 4.)");
 	define("k|kern-tracks=s",       "Process only the specified kern spines");
 	define("s|spine-tracks|spine|spines|track|tracks=s", "Process only the specified spines");
 }

--- a/src/tool-fb.cpp
+++ b/src/tool-fb.cpp
@@ -40,7 +40,7 @@ Tool_fb::Tool_fb(void) {
 	define("3|hide-three=b",        "hide number 3 if it has an accidental (e.g.: #3 => #)");
 	define("m|negative=b",          "show negative numbers");
 	define("above=b",               "place figured bass numbers above staff (**fba)");
-	define("frequency|recip=s:",    "frequency to display the numbers (set a **recip value, e.g. 2, 4, 8, 4.)");
+	define("rate|recip=s:",         "rate to display the numbers (set a **recip value, e.g. 2, 4, 8, 4.)");
 	define("k|kern-tracks=s",       "Process only the specified kern spines");
 	define("s|spine-tracks|spine|spines|track|tracks=s", "Process only the specified spines");
 }
@@ -108,7 +108,7 @@ void Tool_fb::initialize(void) {
 	m_hideThreeQ     = getBoolean("hide-three");
 	m_showNegativeQ  = getBoolean("negative");
 	m_aboveQ         = getBoolean("above");
-	m_recipQ         = getString("frequency");
+	m_rateQ          = getString("rate");
 
 	if (getBoolean("spine-tracks")) {
 		m_spineTracks = getString("spine-tracks");
@@ -232,8 +232,8 @@ void Tool_fb::processFile(HumdrumFile& infile) {
 
 		string keySignature = getKeySignature(infile, baseCell->getLineIndex());
 
-		// Hide numbers if they do not match rhythmic position of --recip
-		if (!m_recipQ.empty()) {
+		// Hide numbers if they do not match rhythmic position of --rate
+		if (!m_rateQ.empty()) {
 			// Get time signatures
 			vector<pair<int, HumNum>> timeSigs;
 			infile.getTimeSigs(timeSigs, baseCell->getToken()->getTrack());
@@ -376,9 +376,9 @@ void Tool_fb::processFile(HumdrumFile& infile) {
 //
 
 bool Tool_fb::hideNumbersForTokenLine(HTp token, pair<int, HumNum> timeSig) {
-	// Get note duration from --recip option
-	HumNum recip = Convert::recipToDuration(m_recipQ);
-	if (recip.toFloat() != 0) {
+	// Get note duration from --rate option
+	HumNum rateDuration = Convert::recipToDuration(m_rateQ);
+	if (rateDuration.toFloat() != 0) {
 		float timeSigBarDuration = timeSig.first * Convert::recipToDuration(to_string(timeSig.second.getInteger())).toFloat();
 		float durationFromBarline = token->getDurationFromBarline().toFloat();
 		// Handle upbeats
@@ -387,8 +387,8 @@ bool Tool_fb::hideNumbersForTokenLine(HTp token, pair<int, HumNum> timeSig) {
 			// the bar duration of the time signature
 			durationFromBarline = timeSigBarDuration - token->getDurationToBarline().toFloat();
 		}
-		// Checks if rhythmic position is divisible by recip duration 
-		return fmod(durationFromBarline, recip.toFloat()) != 0;
+		// Checks if rhythmic position is divisible by rateDuration
+		return fmod(durationFromBarline, rateDuration.toFloat()) != 0;
 	}
 	return false;
 }


### PR DESCRIPTION
Reference: https://github.com/humdrum-tools/vhv-documentation/issues/20

> Should I keep --recip as an alternative? It could be confusing since it's something different than e.g. in the deg filter. So maybe not.

> Note that verovio on the fb documentation page will crash because of this change (at least it did on localhost). I will wait with merging this PR until humlib is updated in the verovio repo.