### PR TITLE
More improvements for option names

### DIFF
--- a/include/humlib.h
+++ b/include/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mo 23 Jan 2023 17:20:50 CET
+// Last Modified: Mo 23 Jan 2023 17:27:53 CET
 // Filename:      humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/include/humlib.h
 // Syntax:        C++11

--- a/include/humlib.h
+++ b/include/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mo 23 Jan 2023 17:27:53 CET
+// Last Modified: Mo 23 Jan 2023 17:34:04 CET
 // Filename:      humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/include/humlib.h
 // Syntax:        C++11
@@ -7302,7 +7302,7 @@ class Tool_fb : public HumTool {
 		bool   m_sortQ          = false;
 		bool   m_lowestQ        = false;
 		bool   m_normalizeQ     = false;
-		bool   m_abbreviateQ    = false;
+		bool   m_reduceQ        = false;
 		bool   m_attackQ        = false;
 		bool   m_figuredbassQ   = false;
 		bool   m_hideThreeQ     = false;

--- a/include/humlib.h
+++ b/include/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mo 23 Jan 2023 17:45:05 CET
+// Last Modified: Mo 23 Jan 2023 17:46:24 CET
 // Filename:      humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/include/humlib.h
 // Syntax:        C++11

--- a/include/humlib.h
+++ b/include/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mo 23 Jan 2023 17:46:24 CET
+// Last Modified: Mo 23 Jan 2023 17:51:36 CET
 // Filename:      humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/include/humlib.h
 // Syntax:        C++11

--- a/include/humlib.h
+++ b/include/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mo 23 Jan 2023 17:34:04 CET
+// Last Modified: Mo 23 Jan 2023 17:45:05 CET
 // Filename:      humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/include/humlib.h
 // Syntax:        C++11

--- a/include/tool-fb.h
+++ b/include/tool-fb.h
@@ -91,7 +91,7 @@ class Tool_fb : public HumTool {
 		bool   m_sortQ          = false;
 		bool   m_lowestQ        = false;
 		bool   m_normalizeQ     = false;
-		bool   m_abbreviateQ    = false;
+		bool   m_reduceQ        = false;
 		bool   m_attackQ        = false;
 		bool   m_figuredbassQ   = false;
 		bool   m_hideThreeQ     = false;

--- a/src/humlib.cpp
+++ b/src/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mo 23 Jan 2023 17:46:24 CET
+// Last Modified: Mo 23 Jan 2023 17:51:36 CET
 // Filename:      /include/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/src/humlib.cpp
 // Syntax:        C++11
@@ -78032,7 +78032,7 @@ void Tool_extract::initialize(HumdrumFile& infile) {
 
 Tool_fb::Tool_fb(void) {
 	define("c|compound=b",               "Output reasonable figured bass numbers within octave");
-	define("a|accidentals=b",            "Display accidentals in front of the numbers");
+	define("a|accidentals|accid|acc=b",  "Display accidentals in front of the numbers");
 	define("b|base|base-track=i:1",      "Number of the base kern track (compare with -k)");
 	define("i|intervallsatz=b",          "Display numbers under their voice instead of under the base staff");
 	define("o|sort|order=b",             "Sort figured bass numbers by size");

--- a/src/humlib.cpp
+++ b/src/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mo 23 Jan 2023 17:45:05 CET
+// Last Modified: Mo 23 Jan 2023 17:46:24 CET
 // Filename:      /include/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/src/humlib.cpp
 // Syntax:        C++11

--- a/src/humlib.cpp
+++ b/src/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mo 23 Jan 2023 17:34:04 CET
+// Last Modified: Mo 23 Jan 2023 17:45:05 CET
 // Filename:      /include/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/src/humlib.cpp
 // Syntax:        C++11
@@ -78031,20 +78031,20 @@ void Tool_extract::initialize(HumdrumFile& infile) {
 //
 
 Tool_fb::Tool_fb(void) {
-	define("c|compound=b",               "output reasonable figured bass numbers within octave");
-	define("a|accidentals=b",            "display accidentals in figured bass output");
-	define("b|base|base-track=i:1",      "number of the base kern track (compare with -k)");
-	define("i|intervallsatz=b",          "display intervals under their voice and not under the lowest staff");
-	define("o|sort|order=b",             "sort figured bass numbers by interval size and not by voice index");
-	define("l|lowest=b",                 "use lowest note as base note; -b flag will be ignored");
-	define("n|normalize=b",              "remove octave and doubled intervals; adds: --compound --sort");
-	define("r|reduce|abbreviate|abbr=b", "use abbreviated figures; adds: --normalize --compound --sort");
-	define("t|ties=b",                   "hide repeated numbers for sustained notes when base does not change");
-	define("f|figuredbass=b",            "shortcut for -c -a -o -n -r -3");
-	define("3|hide-three=b",             "hide number 3 if it has an accidental (e.g.: #3 => #)");
-	define("m|negative=b",               "show negative numbers");
-	define("above=b",                    "place figured bass numbers above staff (**fba)");
-	define("rate=s:",                    "rate to display the numbers (set a **recip value, e.g. 2, 4, 8, 4.)");
+	define("c|compound=b",               "Output reasonable figured bass numbers within octave");
+	define("a|accidentals=b",            "Display accidentals in front of the numbers");
+	define("b|base|base-track=i:1",      "Number of the base kern track (compare with -k)");
+	define("i|intervallsatz=b",          "Display numbers under their voice instead of under the base staff");
+	define("o|sort|order=b",             "Sort figured bass numbers by size");
+	define("l|lowest=b",                 "Use lowest note as base note");
+	define("n|normalize=b",              "Remove number 8 and doubled numbers; adds -co");
+	define("r|reduce|abbreviate|abbr=b", "Use abbreviated figures; adds -nco");
+	define("t|ties=b",                   "Hide numbers without attack or changing base (needs -i)");
+	define("f|figuredbass=b",            "Shortcut for -acorn3");
+	define("3|hide-three=b",             "Hide number 3 if it has an accidental");
+	define("m|negative=b",               "Show negative numbers");
+	define("above=b",                    "Show numbers above the staff (**fba)");
+	define("rate=s:",                    "Rate to display the numbers (use a **recip value, e.g. 4, 4.)");
 	define("k|kern-tracks=s",            "Process only the specified kern spines");
 	define("s|spine-tracks|spine|spines|track|tracks=s", "Process only the specified spines");
 }

--- a/src/humlib.cpp
+++ b/src/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mo 23 Jan 2023 17:20:50 CET
+// Last Modified: Mo 23 Jan 2023 17:27:53 CET
 // Filename:      /include/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/src/humlib.cpp
 // Syntax:        C++11
@@ -78038,7 +78038,7 @@ Tool_fb::Tool_fb(void) {
 	define("o|sort|order=b",        "sort figured bass numbers by interval size and not by voice index");
 	define("l|lowest=b",            "use lowest note as base note; -b flag will be ignored");
 	define("n|normalize=b",         "remove octave and doubled intervals; adds: --compound --sort");
-	define("r|abbreviate=b",        "use abbreviated figures; adds: --normalize --compound --sort");
+	define("r|abbreviate|abbr=b",   "use abbreviated figures; adds: --normalize --compound --sort");
 	define("t|ties=b",              "hide repeated numbers for sustained notes when base does not change");
 	define("f|figuredbass=b",       "shortcut for -c -a -o -n -r -3");
 	define("3|hide-three=b",        "hide number 3 if it has an accidental (e.g.: #3 => #)");

--- a/src/humlib.cpp
+++ b/src/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mo 23 Jan 2023 17:27:53 CET
+// Last Modified: Mo 23 Jan 2023 17:34:04 CET
 // Filename:      /include/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/src/humlib.cpp
 // Syntax:        C++11
@@ -78031,21 +78031,21 @@ void Tool_extract::initialize(HumdrumFile& infile) {
 //
 
 Tool_fb::Tool_fb(void) {
-	define("c|compound=b",          "output reasonable figured bass numbers within octave");
-	define("a|accidentals=b",       "display accidentals in figured bass output");
-	define("b|base|base-track=i:1", "number of the base kern track (compare with -k)");
-	define("i|intervallsatz=b",     "display intervals under their voice and not under the lowest staff");
-	define("o|sort|order=b",        "sort figured bass numbers by interval size and not by voice index");
-	define("l|lowest=b",            "use lowest note as base note; -b flag will be ignored");
-	define("n|normalize=b",         "remove octave and doubled intervals; adds: --compound --sort");
-	define("r|abbreviate|abbr=b",   "use abbreviated figures; adds: --normalize --compound --sort");
-	define("t|ties=b",              "hide repeated numbers for sustained notes when base does not change");
-	define("f|figuredbass=b",       "shortcut for -c -a -o -n -r -3");
-	define("3|hide-three=b",        "hide number 3 if it has an accidental (e.g.: #3 => #)");
-	define("m|negative=b",          "show negative numbers");
-	define("above=b",               "place figured bass numbers above staff (**fba)");
-	define("rate=s:",               "rate to display the numbers (set a **recip value, e.g. 2, 4, 8, 4.)");
-	define("k|kern-tracks=s",       "Process only the specified kern spines");
+	define("c|compound=b",               "output reasonable figured bass numbers within octave");
+	define("a|accidentals=b",            "display accidentals in figured bass output");
+	define("b|base|base-track=i:1",      "number of the base kern track (compare with -k)");
+	define("i|intervallsatz=b",          "display intervals under their voice and not under the lowest staff");
+	define("o|sort|order=b",             "sort figured bass numbers by interval size and not by voice index");
+	define("l|lowest=b",                 "use lowest note as base note; -b flag will be ignored");
+	define("n|normalize=b",              "remove octave and doubled intervals; adds: --compound --sort");
+	define("r|reduce|abbreviate|abbr=b", "use abbreviated figures; adds: --normalize --compound --sort");
+	define("t|ties=b",                   "hide repeated numbers for sustained notes when base does not change");
+	define("f|figuredbass=b",            "shortcut for -c -a -o -n -r -3");
+	define("3|hide-three=b",             "hide number 3 if it has an accidental (e.g.: #3 => #)");
+	define("m|negative=b",               "show negative numbers");
+	define("above=b",                    "place figured bass numbers above staff (**fba)");
+	define("rate=s:",                    "rate to display the numbers (set a **recip value, e.g. 2, 4, 8, 4.)");
+	define("k|kern-tracks=s",            "Process only the specified kern spines");
 	define("s|spine-tracks|spine|spines|track|tracks=s", "Process only the specified spines");
 }
 
@@ -78106,7 +78106,7 @@ void Tool_fb::initialize(void) {
 	m_sortQ          = getBoolean("sort");
 	m_lowestQ        = getBoolean("lowest");
 	m_normalizeQ     = getBoolean("normalize");
-	m_abbreviateQ    = getBoolean("abbreviate");
+	m_reduceQ        = getBoolean("reduce");
 	m_attackQ        = getBoolean("ties");
 	m_figuredbassQ   = getBoolean("figuredbass");
 	m_hideThreeQ     = getBoolean("hide-three");
@@ -78125,14 +78125,14 @@ void Tool_fb::initialize(void) {
 		m_sortQ = true;
 	}
 
-	if (m_abbreviateQ) {
+	if (m_reduceQ) {
 		m_normalizeQ = true;
 		m_compoundQ = true;
 		m_sortQ = true;
 	}
 
 	if (m_figuredbassQ) {
-		m_abbreviateQ = true;
+		m_reduceQ = true;
 		m_normalizeQ = true;
 		m_compoundQ = true;
 		m_sortQ = true;
@@ -78634,7 +78634,7 @@ string Tool_fb::formatFiguredBassNumbers(const vector<FiguredBassNumber*>& numbe
 		});
 	}
 
-	if (m_abbreviateQ) {
+	if (m_reduceQ) {
 		// Overwrite formattedNumbers with abbreviated numbers
 		formattedNumbers = getAbbreviatedNumbers(formattedNumbers);
 	}

--- a/src/tool-fb.cpp
+++ b/src/tool-fb.cpp
@@ -34,7 +34,7 @@ Tool_fb::Tool_fb(void) {
 	define("o|sort|order=b",        "sort figured bass numbers by interval size and not by voice index");
 	define("l|lowest=b",            "use lowest note as base note; -b flag will be ignored");
 	define("n|normalize=b",         "remove octave and doubled intervals; adds: --compound --sort");
-	define("r|abbreviate=b",        "use abbreviated figures; adds: --normalize --compound --sort");
+	define("r|abbreviate|abbr=b",   "use abbreviated figures; adds: --normalize --compound --sort");
 	define("t|ties=b",              "hide repeated numbers for sustained notes when base does not change");
 	define("f|figuredbass=b",       "shortcut for -c -a -o -n -r -3");
 	define("3|hide-three=b",        "hide number 3 if it has an accidental (e.g.: #3 => #)");

--- a/src/tool-fb.cpp
+++ b/src/tool-fb.cpp
@@ -27,21 +27,21 @@ namespace hum {
 //
 
 Tool_fb::Tool_fb(void) {
-	define("c|compound=b",          "output reasonable figured bass numbers within octave");
-	define("a|accidentals=b",       "display accidentals in figured bass output");
-	define("b|base|base-track=i:1", "number of the base kern track (compare with -k)");
-	define("i|intervallsatz=b",     "display intervals under their voice and not under the lowest staff");
-	define("o|sort|order=b",        "sort figured bass numbers by interval size and not by voice index");
-	define("l|lowest=b",            "use lowest note as base note; -b flag will be ignored");
-	define("n|normalize=b",         "remove octave and doubled intervals; adds: --compound --sort");
-	define("r|abbreviate|abbr=b",   "use abbreviated figures; adds: --normalize --compound --sort");
-	define("t|ties=b",              "hide repeated numbers for sustained notes when base does not change");
-	define("f|figuredbass=b",       "shortcut for -c -a -o -n -r -3");
-	define("3|hide-three=b",        "hide number 3 if it has an accidental (e.g.: #3 => #)");
-	define("m|negative=b",          "show negative numbers");
-	define("above=b",               "place figured bass numbers above staff (**fba)");
-	define("rate=s:",               "rate to display the numbers (set a **recip value, e.g. 2, 4, 8, 4.)");
-	define("k|kern-tracks=s",       "Process only the specified kern spines");
+	define("c|compound=b",               "output reasonable figured bass numbers within octave");
+	define("a|accidentals=b",            "display accidentals in figured bass output");
+	define("b|base|base-track=i:1",      "number of the base kern track (compare with -k)");
+	define("i|intervallsatz=b",          "display intervals under their voice and not under the lowest staff");
+	define("o|sort|order=b",             "sort figured bass numbers by interval size and not by voice index");
+	define("l|lowest=b",                 "use lowest note as base note; -b flag will be ignored");
+	define("n|normalize=b",              "remove octave and doubled intervals; adds: --compound --sort");
+	define("r|reduce|abbreviate|abbr=b", "use abbreviated figures; adds: --normalize --compound --sort");
+	define("t|ties=b",                   "hide repeated numbers for sustained notes when base does not change");
+	define("f|figuredbass=b",            "shortcut for -c -a -o -n -r -3");
+	define("3|hide-three=b",             "hide number 3 if it has an accidental (e.g.: #3 => #)");
+	define("m|negative=b",               "show negative numbers");
+	define("above=b",                    "place figured bass numbers above staff (**fba)");
+	define("rate=s:",                    "rate to display the numbers (set a **recip value, e.g. 2, 4, 8, 4.)");
+	define("k|kern-tracks=s",            "Process only the specified kern spines");
 	define("s|spine-tracks|spine|spines|track|tracks=s", "Process only the specified spines");
 }
 
@@ -102,7 +102,7 @@ void Tool_fb::initialize(void) {
 	m_sortQ          = getBoolean("sort");
 	m_lowestQ        = getBoolean("lowest");
 	m_normalizeQ     = getBoolean("normalize");
-	m_abbreviateQ    = getBoolean("abbreviate");
+	m_reduceQ        = getBoolean("reduce");
 	m_attackQ        = getBoolean("ties");
 	m_figuredbassQ   = getBoolean("figuredbass");
 	m_hideThreeQ     = getBoolean("hide-three");
@@ -121,14 +121,14 @@ void Tool_fb::initialize(void) {
 		m_sortQ = true;
 	}
 
-	if (m_abbreviateQ) {
+	if (m_reduceQ) {
 		m_normalizeQ = true;
 		m_compoundQ = true;
 		m_sortQ = true;
 	}
 
 	if (m_figuredbassQ) {
-		m_abbreviateQ = true;
+		m_reduceQ = true;
 		m_normalizeQ = true;
 		m_compoundQ = true;
 		m_sortQ = true;
@@ -630,7 +630,7 @@ string Tool_fb::formatFiguredBassNumbers(const vector<FiguredBassNumber*>& numbe
 		});
 	}
 
-	if (m_abbreviateQ) {
+	if (m_reduceQ) {
 		// Overwrite formattedNumbers with abbreviated numbers
 		formattedNumbers = getAbbreviatedNumbers(formattedNumbers);
 	}

--- a/src/tool-fb.cpp
+++ b/src/tool-fb.cpp
@@ -27,20 +27,20 @@ namespace hum {
 //
 
 Tool_fb::Tool_fb(void) {
-	define("c|compound=b",               "output reasonable figured bass numbers within octave");
-	define("a|accidentals=b",            "display accidentals in figured bass output");
-	define("b|base|base-track=i:1",      "number of the base kern track (compare with -k)");
-	define("i|intervallsatz=b",          "display intervals under their voice and not under the lowest staff");
-	define("o|sort|order=b",             "sort figured bass numbers by interval size and not by voice index");
-	define("l|lowest=b",                 "use lowest note as base note; -b flag will be ignored");
-	define("n|normalize=b",              "remove octave and doubled intervals; adds: --compound --sort");
-	define("r|reduce|abbreviate|abbr=b", "use abbreviated figures; adds: --normalize --compound --sort");
-	define("t|ties=b",                   "hide repeated numbers for sustained notes when base does not change");
-	define("f|figuredbass=b",            "shortcut for -c -a -o -n -r -3");
-	define("3|hide-three=b",             "hide number 3 if it has an accidental (e.g.: #3 => #)");
-	define("m|negative=b",               "show negative numbers");
-	define("above=b",                    "place figured bass numbers above staff (**fba)");
-	define("rate=s:",                    "rate to display the numbers (set a **recip value, e.g. 2, 4, 8, 4.)");
+	define("c|compound=b",               "Output reasonable figured bass numbers within octave");
+	define("a|accidentals=b",            "Display accidentals in front of the numbers");
+	define("b|base|base-track=i:1",      "Number of the base kern track (compare with -k)");
+	define("i|intervallsatz=b",          "Display numbers under their voice instead of under the base staff");
+	define("o|sort|order=b",             "Sort figured bass numbers by size");
+	define("l|lowest=b",                 "Use lowest note as base note");
+	define("n|normalize=b",              "Remove number 8 and doubled numbers; adds -co");
+	define("r|reduce|abbreviate|abbr=b", "Use abbreviated figures; adds -nco");
+	define("t|ties=b",                   "Hide numbers without attack or changing base (needs -i)");
+	define("f|figuredbass=b",            "Shortcut for -acorn3");
+	define("3|hide-three=b",             "Hide number 3 if it has an accidental");
+	define("m|negative=b",               "Show negative numbers");
+	define("above=b",                    "Show numbers above the staff (**fba)");
+	define("rate=s:",                    "Rate to display the numbers (use a **recip value, e.g. 4, 4.)");
 	define("k|kern-tracks=s",            "Process only the specified kern spines");
 	define("s|spine-tracks|spine|spines|track|tracks=s", "Process only the specified spines");
 }

--- a/src/tool-fb.cpp
+++ b/src/tool-fb.cpp
@@ -29,7 +29,7 @@ namespace hum {
 
 Tool_fb::Tool_fb(void) {
 	define("c|compound=b",               "Output reasonable figured bass numbers within octave");
-	define("a|accidentals=b",            "Display accidentals in front of the numbers");
+	define("a|accidentals|accid|acc=b",  "Display accidentals in front of the numbers");
 	define("b|base|base-track=i:1",      "Number of the base kern track (compare with -k)");
 	define("i|intervallsatz=b",          "Display numbers under their voice instead of under the base staff");
 	define("o|sort|order=b",             "Sort figured bass numbers by size");

--- a/src/tool-fb.cpp
+++ b/src/tool-fb.cpp
@@ -7,6 +7,7 @@
 // vim:           syntax=cpp ts=3 noexpandtab nowrap
 //
 // Description:   Add figured bass numbers from **kern spines.
+// Documentation: https://doc.verovio.humdrum.org/filter/fb
 //
 
 #include "tool-fb.h"


### PR DESCRIPTION
* add aliases `accid` and `acc`
* add documentation link
* set reduce as long form of `r`
* improve option descriptions