### PR TITLE
Add lyricsformatter tool to enable melismatic underlines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ set(SRCS
 	src/tool-filter.cpp
 	src/tool-hproof.cpp
 	src/tool-imitation.cpp
+    src/tool-lyricsformatter.cpp
 	src/tool-mei2hum.cpp
 	src/tool-metlev.cpp
 	src/tool-msearch.cpp
@@ -154,6 +155,7 @@ set(HDRS
 	include/tool-fb.h
 	include/tool-hproof.h
 	include/tool-imitation.h
+    include/tool-lyricsformatter.h
 	include/tool-mei2hum.h
 	include/tool-metlev.h
 	include/tool-msearch.h

--- a/Makefile
+++ b/Makefile
@@ -644,7 +644,7 @@ tool-filter.o: tool-filter.cpp tool-filter.h \
   tool-composite.h tool-dissonant.h \
   tool-extract.h tool-fb.h tool-homorhythm.h \
   tool-homorhythm2.h tool-hproof.h \
-  tool-humdiff.h tool-shed.h tool-imitation.h \
+  tool-humdiff.h tool-shed.h tool-imitation.h tool-lyricsformatter.h \
   tool-kern2mens.h tool-melisma.h tool-metlev.h \
   tool-msearch.h tool-myank.h tool-phrase.h \
   tool-recip.h tool-restfill.h tool-satb2gs.h \
@@ -706,6 +706,15 @@ tool-imitation.o: tool-imitation.cpp tool-imitation.h \
   HumdrumToken.h HumNum.h HumAddress.h \
   HumHash.h HumParamSet.h HumdrumFileStream.h \
   NoteGrid.h NoteCell.h Convert.h \
+  HumRegex.h
+
+tool-lyricsformatter.o: tool-lyricsformatter.cpp tool-lyricsformatter.h \
+  HumTool.h Options.h HumdrumFileSet.h \
+  HumdrumFile.h HumdrumFileContent.h \
+  HumdrumFileStructure.h HumdrumFileBase.h \
+  HumSignifiers.h HumSignifier.h HumdrumLine.h \
+  HumdrumToken.h HumNum.h HumAddress.h \
+  HumHash.h HumParamSet.h HumdrumFileStream.h \
   HumRegex.h
 
 tool-kern2mens.o: tool-kern2mens.cpp tool-kern2mens.h \

--- a/cli/lyricsformatter.cpp
+++ b/cli/lyricsformatter.cpp
@@ -1,0 +1,17 @@
+//
+// Programmer:    Wolfgang Drescher <drescher.wolfgang@gmail.com>
+// Creation Date: Sa  4 Feb 2023 16:27:58 CET
+// Filename:      lyricsformatter.cpp
+// URL:           https://github.com/craigsapp/humlib/blob/master/cli/lyricsformatter.cpp
+// Syntax:        C++11
+// vim:           ts=3 noexpandtab nowrap
+//
+// Description:   Lyrics formatter program.
+//
+
+#include "humlib.h"
+
+STREAM_INTERFACE(Tool_lyricsformatter)
+
+
+

--- a/include/humlib.h
+++ b/include/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Thu Jan 26 22:41:11 PST 2023
+// Last Modified: Sa  4 Feb 2023 16:27:58 CET
 // Filename:      humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/include/humlib.h
 // Syntax:        C++11
@@ -7891,6 +7891,31 @@ class Tool_kernview : public HumTool {
 	private:
 		std::string m_view_string;
 		std::string m_hide_string;
+
+};
+
+
+class Tool_lyricsformatter : public HumTool {
+
+	public:
+		     Tool_lyricsformatter (void);
+		     ~Tool_lyricsformatter() {};
+
+		bool run(HumdrumFileSet& infiles);
+		bool run(HumdrumFile& infile);
+		bool run(const string& indata, ostream& out);
+		bool run(HumdrumFile& infile, ostream& out);
+
+	protected:
+		void initialize      (void);
+        void processFile     (HumdrumFile& infile);
+		void addUnderlines   (vector<HTp> spineStartList);
+		void removeUnderlines(vector<HTp> spineStartList);
+
+
+	private:
+		bool m_addUnderlineQ;
+		bool m_removeUnderlineQ;
 
 };
 

--- a/include/tool-lyricsformatter.h
+++ b/include/tool-lyricsformatter.h
@@ -1,0 +1,50 @@
+//
+// Programmer:    Wolfgang Drescher <drescher.wolfgang@gmail.com>
+// Creation Date: Sa  4 Feb 2023 16:27:58 CET
+// Filename:      tool-lyricsformatter.h
+// URL:           https://github.com/craigsapp/humlib/blob/master/include/tool-lyricsformatter.h
+// Syntax:        C++11; humlib
+// vim:           syntax=cpp ts=3 noexpandtab nowrap
+//
+// Description:   Interface for lyricsformatter tool, which formats lyrics of **text spines.
+//
+
+#ifndef _TOOL_LYRICSFORMATTER_H
+#define _TOOL_LYRICSFORMATTER_H
+
+#include "HumTool.h"
+#include "HumdrumFile.h"
+
+namespace hum {
+
+// START_MERGE
+
+class Tool_lyricsformatter : public HumTool {
+
+	public:
+		     Tool_lyricsformatter (void);
+		     ~Tool_lyricsformatter() {};
+
+		bool run(HumdrumFileSet& infiles);
+		bool run(HumdrumFile& infile);
+		bool run(const string& indata, ostream& out);
+		bool run(HumdrumFile& infile, ostream& out);
+
+	protected:
+		void initialize      (void);
+        void processFile     (HumdrumFile& infile);
+		void addUnderlines   (vector<HTp> spineStartList);
+		void removeUnderlines(vector<HTp> spineStartList);
+
+
+	private:
+		bool m_addUnderlineQ;
+		bool m_removeUnderlineQ;
+
+};
+
+// END_MERGE
+
+} // end namespace hum
+
+#endif /* _TOOL_LYRICSFORMATTER_H */

--- a/src/humlib.cpp
+++ b/src/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Thu Jan 26 22:41:11 PST 2023
+// Last Modified: Sa  4 Feb 2023 16:27:58 CET
 // Filename:      /include/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/src/humlib.cpp
 // Syntax:        C++11
@@ -79073,6 +79073,8 @@ bool Tool_filter::run(HumdrumFileSet& infiles) {
 			RUNTOOL(humtr, infile, commands[i].second, status);
 		} else if (commands[i].first == "imitation") {
 			RUNTOOL(imitation, infile, commands[i].second, status);
+		} else if (commands[i].first == "lyricsformatter") {
+			RUNTOOL(lyricsformatter, infile, commands[i].second, status);
 		} else if (commands[i].first == "kern2mens") {
 			RUNTOOL(kern2mens, infile, commands[i].second, status);
 		} else if (commands[i].first == "kernview") {
@@ -86108,6 +86110,155 @@ void Tool_kernview::processFile(HumdrumFile& infile) {
 }
 
 
+
+
+//////////////////////////////
+//
+// Tool_lyricsformatter::Tool_lyricsformatter -- Set the recognized options for the tool.
+//
+
+Tool_lyricsformatter::Tool_lyricsformatter(void) {
+	define("ul|aul|add-ul|add-underline|underline=b", "Add melismatic underlines at ending syllables of words");
+	define("xul|rul|remove-ul|remove-underline=b", "Remove melismatic underlines at ending syllables of words");
+}
+
+
+
+//////////////////////////////
+//
+// Tool_lyricsformatter::run -- Do the main work of the tool.
+//
+
+bool Tool_lyricsformatter::run(HumdrumFileSet &infiles) {
+	bool status = true;
+	for (int i = 0; i < infiles.getCount(); i++) {
+		status &= run(infiles[i]);
+	}
+	return status;
+}
+
+bool Tool_lyricsformatter::run(const string &indata, ostream &out) {
+	HumdrumFile infile(indata);
+	bool status = run(infile);
+	if (hasAnyText()) {
+		getAllText(out);
+	} else {
+		out << infile;
+	}
+	return status;
+}
+
+bool Tool_lyricsformatter::run(HumdrumFile &infile, ostream &out) {
+	bool status = run(infile);
+	if (hasAnyText()) {
+		getAllText(out);
+	} else {
+		out << infile;
+	}
+	return status;
+}
+
+bool Tool_lyricsformatter::run(HumdrumFile &infile) {
+	initialize();
+	processFile(infile);
+	return true;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_lyricsformatter::initialize -- 
+//
+
+void Tool_lyricsformatter::initialize(void) {
+	m_addUnderlineQ = getBoolean("add-underline");
+	m_removeUnderlineQ = getBoolean("remove-underline");
+}
+
+
+
+//////////////////////////////
+//
+// Tool_lyricsformatter::processFile -- 
+//
+
+void Tool_lyricsformatter::processFile(HumdrumFile& infile) {
+
+	vector<HTp> textSpinesStartList;
+	infile.getSpineStartList(textSpinesStartList, "**text");	
+
+	if (m_addUnderlineQ) {
+		addUnderlines(textSpinesStartList);
+	} else if (m_removeUnderlineQ) {
+		removeUnderlines(textSpinesStartList);
+	}
+
+	infile.createLinesFromTokens();
+
+	m_humdrum_text << infile;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_lyricsformatter::addUnderlines -- 
+//
+
+void Tool_lyricsformatter::addUnderlines(vector<HTp> spineStartList) {
+	for (HTp token : spineStartList) {
+		if (!token->isDataType("**text")) {
+			continue;
+		}
+		HTp currentToken = token;
+		while (currentToken) {
+			HTp nextToken = currentToken->getNextToken();
+			while (nextToken != NULL && !nextToken->isData()) {
+				nextToken = nextToken->getNextToken();
+			}
+			if (nextToken == NULL) {
+				break;
+			}
+			string syllableExtender = "-";
+			bool isWordEnd = equal(syllableExtender.rbegin(), syllableExtender.rend(), currentToken->getText().rbegin()) == false;
+			string wordEndExtender = "_";
+			bool endsWithUnderscore = equal(wordEndExtender.rbegin(), wordEndExtender.rend(), currentToken->getText().rbegin()) == true;
+			if (nextToken->isNull() && currentToken->isNonNullData() && isWordEnd && !endsWithUnderscore) {
+				currentToken->setText(currentToken->getText() + "_");
+			}
+			currentToken = nextToken;
+		}
+	}
+}
+
+
+
+//////////////////////////////
+//
+// Tool_lyricsformatter::removeUnderlines -- 
+//
+
+void Tool_lyricsformatter::removeUnderlines(vector<HTp> spineStartList) {
+	for (HTp token : spineStartList) {
+		if (!token->isDataType("**text")) {
+			continue;
+		}
+		HTp currentToken = token;
+		while (currentToken) {
+			if (currentToken->isNonNullData()) {
+				string wordEndExtender = "_";
+				bool endsWithUnderscore = equal(wordEndExtender.rbegin(), wordEndExtender.rend(), currentToken->getText().rbegin()) == true;
+				if (endsWithUnderscore) {
+					string text = currentToken->getText();
+					text.pop_back();
+					currentToken->setText(text);
+				}
+			}
+			currentToken = currentToken->getNextToken();
+		}
+	}
+}
 
 
 

--- a/src/tool-filter.cpp
+++ b/src/tool-filter.cpp
@@ -40,6 +40,7 @@
 #include "tool-humsheet.h"
 #include "tool-humtr.h"
 #include "tool-imitation.h"
+#include "tool-lyricsformatter.h"
 #include "tool-kern2mens.h"
 #include "tool-kernview.h"
 #include "tool-mei2hum.h"
@@ -258,6 +259,8 @@ bool Tool_filter::run(HumdrumFileSet& infiles) {
 			RUNTOOL(humtr, infile, commands[i].second, status);
 		} else if (commands[i].first == "imitation") {
 			RUNTOOL(imitation, infile, commands[i].second, status);
+		} else if (commands[i].first == "lyricsformatter") {
+			RUNTOOL(lyricsformatter, infile, commands[i].second, status);
 		} else if (commands[i].first == "kern2mens") {
 			RUNTOOL(kern2mens, infile, commands[i].second, status);
 		} else if (commands[i].first == "kernview") {

--- a/src/tool-lyricsformatter.cpp
+++ b/src/tool-lyricsformatter.cpp
@@ -1,0 +1,174 @@
+//
+// Programmer:    Wolfgang Drescher <drescher.wolfgang@gmail.com>
+// Creation Date: Sa  4 Feb 2023 16:27:58 CET
+// Filename:      tool-lyricsformatter.cpp
+// URL:           https://github.com/craigsapp/humlib/blob/master/src/tool-lyricsformatter.cpp
+// Syntax:        C++11; humlib
+// vim:           syntax=cpp ts=3 noexpandtab nowrap
+//
+// Description:   Format the lyrics of **text spines
+//
+
+#include "tool-lyricsformatter.h"
+#include "Convert.h"
+#include "HumRegex.h"
+#include <regex>
+#include <cmath>
+
+using namespace std;
+
+namespace hum {
+
+// START_MERGE
+
+//////////////////////////////
+//
+// Tool_lyricsformatter::Tool_lyricsformatter -- Set the recognized options for the tool.
+//
+
+Tool_lyricsformatter::Tool_lyricsformatter(void) {
+	define("ul|aul|add-ul|add-underline|underline=b", "Add melismatic underlines at ending syllables of words");
+	define("xul|rul|remove-ul|remove-underline=b", "Remove melismatic underlines at ending syllables of words");
+}
+
+
+
+//////////////////////////////
+//
+// Tool_lyricsformatter::run -- Do the main work of the tool.
+//
+
+bool Tool_lyricsformatter::run(HumdrumFileSet &infiles) {
+	bool status = true;
+	for (int i = 0; i < infiles.getCount(); i++) {
+		status &= run(infiles[i]);
+	}
+	return status;
+}
+
+bool Tool_lyricsformatter::run(const string &indata, ostream &out) {
+	HumdrumFile infile(indata);
+	bool status = run(infile);
+	if (hasAnyText()) {
+		getAllText(out);
+	} else {
+		out << infile;
+	}
+	return status;
+}
+
+bool Tool_lyricsformatter::run(HumdrumFile &infile, ostream &out) {
+	bool status = run(infile);
+	if (hasAnyText()) {
+		getAllText(out);
+	} else {
+		out << infile;
+	}
+	return status;
+}
+
+bool Tool_lyricsformatter::run(HumdrumFile &infile) {
+	initialize();
+	processFile(infile);
+	return true;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_lyricsformatter::initialize -- 
+//
+
+void Tool_lyricsformatter::initialize(void) {
+	m_addUnderlineQ = getBoolean("add-underline");
+	m_removeUnderlineQ = getBoolean("remove-underline");
+}
+
+
+
+//////////////////////////////
+//
+// Tool_lyricsformatter::processFile -- 
+//
+
+void Tool_lyricsformatter::processFile(HumdrumFile& infile) {
+
+	vector<HTp> textSpinesStartList;
+	infile.getSpineStartList(textSpinesStartList, "**text");	
+
+	if (m_addUnderlineQ) {
+		addUnderlines(textSpinesStartList);
+	} else if (m_removeUnderlineQ) {
+		removeUnderlines(textSpinesStartList);
+	}
+
+	infile.createLinesFromTokens();
+
+	m_humdrum_text << infile;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_lyricsformatter::addUnderlines -- 
+//
+
+void Tool_lyricsformatter::addUnderlines(vector<HTp> spineStartList) {
+	for (HTp token : spineStartList) {
+		if (!token->isDataType("**text")) {
+			continue;
+		}
+		HTp currentToken = token;
+		while (currentToken) {
+			HTp nextToken = currentToken->getNextToken();
+			while (nextToken != NULL && !nextToken->isData()) {
+				nextToken = nextToken->getNextToken();
+			}
+			if (nextToken == NULL) {
+				break;
+			}
+			string syllableExtender = "-";
+			bool isWordEnd = equal(syllableExtender.rbegin(), syllableExtender.rend(), currentToken->getText().rbegin()) == false;
+			string wordEndExtender = "_";
+			bool endsWithUnderscore = equal(wordEndExtender.rbegin(), wordEndExtender.rend(), currentToken->getText().rbegin()) == true;
+			if (nextToken->isNull() && currentToken->isNonNullData() && isWordEnd && !endsWithUnderscore) {
+				currentToken->setText(currentToken->getText() + "_");
+			}
+			currentToken = nextToken;
+		}
+	}
+}
+
+
+
+//////////////////////////////
+//
+// Tool_lyricsformatter::removeUnderlines -- 
+//
+
+void Tool_lyricsformatter::removeUnderlines(vector<HTp> spineStartList) {
+	for (HTp token : spineStartList) {
+		if (!token->isDataType("**text")) {
+			continue;
+		}
+		HTp currentToken = token;
+		while (currentToken) {
+			if (currentToken->isNonNullData()) {
+				string wordEndExtender = "_";
+				bool endsWithUnderscore = equal(wordEndExtender.rbegin(), wordEndExtender.rend(), currentToken->getText().rbegin()) == true;
+				if (endsWithUnderscore) {
+					string text = currentToken->getText();
+					text.pop_back();
+					currentToken->setText(text);
+				}
+			}
+			currentToken = currentToken->getNextToken();
+		}
+	}
+}
+
+// END_MERGE
+
+} // end namespace hum


### PR DESCRIPTION
This PR adds the functionality discussed in https://github.com/humdrum-tools/verovio-humdrum-viewer/issues/657#issuecomment-1083685445 to enable melismatic underlines at ending syllables of words with a dedicated filter for this. I used a generic name `lyricsformatter` so we can potentially add more features into this tool.

The name `lyricsformatter` is a bit verbose. Do you have a better suggestion? Maybe `lf`, `fmtlyrics` or something else?

Current usage do add melismatic underlines is

```sh
cat test.krn | lyricsformatter --ul
cat test.krn | lyricsformatter --underline
cat test.krn | lyricsformatter --add-underline
```

And to remove them:

```sh
cat test.krn | lyricsformatter --xul
cat test.krn | lyricsformatter --remove-underline
```

Do we need a pluralized alias for these options?

You mentioned a possible new `*ul` interpretation. I have not implemented this.

`Tool_lyricsformatter::addUnderlines`  and `Tool_lyricsformatter::removeUnderlines` only need to get passed a list with start tokens. So I hope this makes it usable in verovio `iohumdrum.cpp`, if needed. Should I make these methods static?