### PR TITLE
Fix missing spine terminators in myank

### DIFF
--- a/include/humlib.h
+++ b/include/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Fri  3 Mar 11:37:45 GMT 2023
+// Last Modified: Sa 11 Mär 2023 00:20:06 CET
 // Filename:      humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/include/humlib.h
 // Syntax:        C++11

--- a/src/humlib.cpp
+++ b/src/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Fri  3 Mar 11:37:45 GMT 2023
+// Last Modified: Sa 11 Mär 2023 00:20:06 CET
 // Filename:      /include/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/src/humlib.cpp
 // Syntax:        C++11
@@ -103695,7 +103695,7 @@ void Tool_myank::printEnding(HumdrumFile& infile, int lastline, int adjlin) {
 
 	if (startline >= 0) {
 		for (i=startline; i<infile.getLineCount(); i++) {
-			if (m_hideEnding && (i >= ending)) {
+			if (m_hideEnding && (i > ending)) {
 				if (infile[i].rfind("!!!RDF", 0) == 0) {
 					m_humdrum_text << infile[i] << "\n";
 				}

--- a/src/tool-myank.cpp
+++ b/src/tool-myank.cpp
@@ -1783,7 +1783,7 @@ void Tool_myank::printEnding(HumdrumFile& infile, int lastline, int adjlin) {
 
 	if (startline >= 0) {
 		for (i=startline; i<infile.getLineCount(); i++) {
-			if (m_hideEnding && (i >= ending)) {
+			if (m_hideEnding && (i > ending)) {
 				if (infile[i].rfind("!!!RDF", 0) == 0) {
 					m_humdrum_text << infile[i] << "\n";
 				}


### PR DESCRIPTION
There was a bug in `myank` where spine terminators were not display in combination with the `--hide-ending` option.