### PR TITLE
[myank] Improve data token handling at start end end of `myank`ed section

### DIFF
--- a/include/humlib.h
+++ b/include/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Di 14 Mär 2023 19:56:17 CET
+// Last Modified: Di 14 Mär 2023 21:42:31 CET
 // Filename:      humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/include/humlib.h
 // Syntax:        C++11

--- a/include/humlib.h
+++ b/include/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Di 14 Mär 2023 21:42:31 CET
+// Last Modified: Di 14 Mär 2023 22:41:15 CET
 // Filename:      humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/include/humlib.h
 // Syntax:        C++11

--- a/src/humlib.cpp
+++ b/src/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Di 14 Mär 2023 19:56:17 CET
+// Last Modified: Di 14 Mär 2023 21:42:31 CET
 // Filename:      /include/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/src/humlib.cpp
 // Syntax:        C++11
@@ -103509,6 +103509,7 @@ void Tool_myank::printDataLine(HLp line,
 		const vector<int>& lastLineResolvedTokenLineIndex,
 		const vector<HumNum>& lastLineDurationsFromNoteStart) {
 	bool lineChange = false;
+	string recipRegex = R"re(([\d%.]+))re";
 	// Handle cutting the previeous token of a note that hangs into the selected
 	// section
 	if (startLineHandled == false) {
@@ -103521,13 +103522,28 @@ void Tool_myank::printDataLine(HLp line,
 					if (resolvedToken->isNull()) {
 						continue;
 					}
-					string recip = Convert::durationToRecip(token->getDurationToNoteEnd());
-					string pitch;
 					HumRegex hre;
-					if (hre.search(resolvedToken, "([rRA-Ga-gxyXYn#-]+)")) {
-						pitch = hre.getMatch(1);
+					string recip = Convert::durationToRecip(token->getDurationToNoteEnd());
+					vector<string> subtokens = resolvedToken->getSubtokens();
+					string tokenText;
+					for (int i=0; i<(int)subtokens.size(); i++) {
+						if (hre.search(subtokens[i], recipRegex)) {
+							string before = hre.getPrefix();
+							string after = hre.getSuffix();
+							hre.replaceDestructive(after, "", recipRegex, "g");
+							string subtokenText;
+							// Replace the old duration with the clipped one
+							subtokenText += before + recip + after;
+							// Add a tie end if not already in a tie group
+							if (!hre.search(subtokens[i], "[_\\]]")) {
+									subtokenText += "]";
+							}
+							tokenText += subtokenText;
+							if (i < (int)subtokens.size() - 1) {
+								tokenText += " ";
+							}
+						}
 					}
-					string tokenText = recip + pitch + "]";
 					token->setText(tokenText);
 					lineChange = true;
 				}
@@ -103548,19 +103564,27 @@ void Tool_myank::printDataLine(HLp line,
 						continue;
 					}
 					HumNum dur = lastLineDurationsFromNoteStart[i];
-					string recip = Convert::durationToRecip(dur);
-					string pitch;
-					HumRegex hre;
-					if (hre.search(resolvedToken, "([rRA-Ga-gxyXYn#-]+)")) {
-						pitch = hre.getMatch(1);
-					}
-					string tokenText;
 					if (resolvedToken->getDuration() > dur) {
-						tokenText += "[";
+						HumRegex hre;
+						string recip = Convert::durationToRecip(dur);
+						vector<string> subtokens = resolvedToken->getSubtokens();
+						for (int i=0; i<(int)subtokens.size(); i++) {
+							if (hre.search(subtokens[i], recipRegex)) {
+								string before = hre.getPrefix();
+								string after = hre.getSuffix();
+								hre.replaceDestructive(after, "", recipRegex, "g");
+								string subtokenText;
+								// Add a tie start if not already in a tie group
+								if (!hre.search(subtokens[i], "[_\\[]")) {
+										subtokenText += "[";
+								}
+								// Replace the old duration with the clipped one
+								subtokenText += before + recip + after;
+								token->replaceSubtoken(i, subtokenText);
+								lineChange = true;
+							}
+						}
 					}
-					tokenText += recip + pitch;
-					token->setText(tokenText);
-					lineChange = true;
 				}
 			}
 		}

--- a/src/humlib.cpp
+++ b/src/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Di 14 Mär 2023 21:42:31 CET
+// Last Modified: Di 14 Mär 2023 22:41:15 CET
 // Filename:      /include/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/src/humlib.cpp
 // Syntax:        C++11
@@ -103564,25 +103564,25 @@ void Tool_myank::printDataLine(HLp line,
 						continue;
 					}
 					HumNum dur = lastLineDurationsFromNoteStart[i];
-					if (resolvedToken->getDuration() > dur) {
-						HumRegex hre;
-						string recip = Convert::durationToRecip(dur);
-						vector<string> subtokens = resolvedToken->getSubtokens();
-						for (int i=0; i<(int)subtokens.size(); i++) {
-							if (hre.search(subtokens[i], recipRegex)) {
-								string before = hre.getPrefix();
-								string after = hre.getSuffix();
-								hre.replaceDestructive(after, "", recipRegex, "g");
-								string subtokenText;
+					HumRegex hre;
+					string recip = Convert::durationToRecip(dur);
+					vector<string> subtokens = resolvedToken->getSubtokens();
+					for (int i=0; i<(int)subtokens.size(); i++) {
+						if (hre.search(subtokens[i], recipRegex)) {
+							string before = hre.getPrefix();
+							string after = hre.getSuffix();
+							hre.replaceDestructive(after, "", recipRegex, "g");
+							string subtokenText;
+							if (resolvedToken->getDuration() > dur) {
 								// Add a tie start if not already in a tie group
 								if (!hre.search(subtokens[i], "[_\\[]")) {
 										subtokenText += "[";
 								}
-								// Replace the old duration with the clipped one
-								subtokenText += before + recip + after;
-								token->replaceSubtoken(i, subtokenText);
-								lineChange = true;
 							}
+							// Replace the old duration with the clipped one
+							subtokenText += before + recip + after;
+							token->replaceSubtoken(i, subtokenText);
+							lineChange = true;
 						}
 					}
 				}

--- a/src/tool-myank.cpp
+++ b/src/tool-myank.cpp
@@ -1383,25 +1383,25 @@ void Tool_myank::printDataLine(HLp line,
 						continue;
 					}
 					HumNum dur = lastLineDurationsFromNoteStart[i];
-					if (resolvedToken->getDuration() > dur) {
-						HumRegex hre;
-						string recip = Convert::durationToRecip(dur);
-						vector<string> subtokens = resolvedToken->getSubtokens();
-						for (int i=0; i<(int)subtokens.size(); i++) {
-							if (hre.search(subtokens[i], recipRegex)) {
-								string before = hre.getPrefix();
-								string after = hre.getSuffix();
-								hre.replaceDestructive(after, "", recipRegex, "g");
-								string subtokenText;
+					HumRegex hre;
+					string recip = Convert::durationToRecip(dur);
+					vector<string> subtokens = resolvedToken->getSubtokens();
+					for (int i=0; i<(int)subtokens.size(); i++) {
+						if (hre.search(subtokens[i], recipRegex)) {
+							string before = hre.getPrefix();
+							string after = hre.getSuffix();
+							hre.replaceDestructive(after, "", recipRegex, "g");
+							string subtokenText;
+							if (resolvedToken->getDuration() > dur) {
 								// Add a tie start if not already in a tie group
 								if (!hre.search(subtokens[i], "[_\\[]")) {
 										subtokenText += "[";
 								}
-								// Replace the old duration with the clipped one
-								subtokenText += before + recip + after;
-								token->replaceSubtoken(i, subtokenText);
-								lineChange = true;
 							}
+							// Replace the old duration with the clipped one
+							subtokenText += before + recip + after;
+							token->replaceSubtoken(i, subtokenText);
+							lineChange = true;
 						}
 					}
 				}

--- a/src/tool-myank.cpp
+++ b/src/tool-myank.cpp
@@ -1328,6 +1328,7 @@ void Tool_myank::printDataLine(HLp line,
 		const vector<int>& lastLineResolvedTokenLineIndex,
 		const vector<HumNum>& lastLineDurationsFromNoteStart) {
 	bool lineChange = false;
+	string recipRegex = R"re(([\d%.]+))re";
 	// Handle cutting the previeous token of a note that hangs into the selected
 	// section
 	if (startLineHandled == false) {
@@ -1340,13 +1341,28 @@ void Tool_myank::printDataLine(HLp line,
 					if (resolvedToken->isNull()) {
 						continue;
 					}
-					string recip = Convert::durationToRecip(token->getDurationToNoteEnd());
-					string pitch;
 					HumRegex hre;
-					if (hre.search(resolvedToken, "([rRA-Ga-gxyXYn#-]+)")) {
-						pitch = hre.getMatch(1);
+					string recip = Convert::durationToRecip(token->getDurationToNoteEnd());
+					vector<string> subtokens = resolvedToken->getSubtokens();
+					string tokenText;
+					for (int i=0; i<(int)subtokens.size(); i++) {
+						if (hre.search(subtokens[i], recipRegex)) {
+							string before = hre.getPrefix();
+							string after = hre.getSuffix();
+							hre.replaceDestructive(after, "", recipRegex, "g");
+							string subtokenText;
+							// Replace the old duration with the clipped one
+							subtokenText += before + recip + after;
+							// Add a tie end if not already in a tie group
+							if (!hre.search(subtokens[i], "[_\\]]")) {
+									subtokenText += "]";
+							}
+							tokenText += subtokenText;
+							if (i < (int)subtokens.size() - 1) {
+								tokenText += " ";
+							}
+						}
 					}
-					string tokenText = recip + pitch + "]";
 					token->setText(tokenText);
 					lineChange = true;
 				}
@@ -1367,19 +1383,27 @@ void Tool_myank::printDataLine(HLp line,
 						continue;
 					}
 					HumNum dur = lastLineDurationsFromNoteStart[i];
-					string recip = Convert::durationToRecip(dur);
-					string pitch;
-					HumRegex hre;
-					if (hre.search(resolvedToken, "([rRA-Ga-gxyXYn#-]+)")) {
-						pitch = hre.getMatch(1);
-					}
-					string tokenText;
 					if (resolvedToken->getDuration() > dur) {
-						tokenText += "[";
+						HumRegex hre;
+						string recip = Convert::durationToRecip(dur);
+						vector<string> subtokens = resolvedToken->getSubtokens();
+						for (int i=0; i<(int)subtokens.size(); i++) {
+							if (hre.search(subtokens[i], recipRegex)) {
+								string before = hre.getPrefix();
+								string after = hre.getSuffix();
+								hre.replaceDestructive(after, "", recipRegex, "g");
+								string subtokenText;
+								// Add a tie start if not already in a tie group
+								if (!hre.search(subtokens[i], "[_\\[]")) {
+										subtokenText += "[";
+								}
+								// Replace the old duration with the clipped one
+								subtokenText += before + recip + after;
+								token->replaceSubtoken(i, subtokenText);
+								lineChange = true;
+							}
+						}
 					}
-					tokenText += recip + pitch;
-					token->setText(tokenText);
-					lineChange = true;
 				}
 			}
 		}


### PR DESCRIPTION
Closes https://github.com/craigsapp/humlib/issues/71

Adds support for chords at start and end of a score filtered with `myank` and now keep all signifiers (e.g. `ll` for terminal long notes were removed).

### Chord example

Source:

```
**kern
*M4/4
=1
1c 1e 1g
=2
1d 1f 1a
=3
1e 1g 1b
=4
1f 1a 1cc
=5
1g 1b 1dd
==
*-
```

=> `myank -m 2-3`

```
**kern
*M4/4
=2
1d 1f 1a
=3
1e 1g 1b
=
*-
```

### Signifier example

Source:

```
**kern
*M4/4
=1
1c
=2
1d
=3
1e
=4
1f
=5
1gll
==
*-
```

=> `myank -l 12-12`

```
**kern
*M4/4
=5
1gll
==
*-
```

---

0a07e11 handles some special cases such as:

Before:

<img width="1100" alt="Bildschirm­foto 2023-03-21 um 12 16 12" src="https://user-images.githubusercontent.com/865594/226590332-4b119e13-1cc2-4b13-b945-c32359759a47.png">

After:

<img width="1098" alt="Bildschirm­foto 2023-03-21 um 12 16 32" src="https://user-images.githubusercontent.com/865594/226590419-8f857aec-e2da-48f6-afc8-9953ac8ebafa.png">
