### PR TITLE
[fb] Determine harmonic intervals with interval quality

### DIFF
--- a/include/tool-fb.h
+++ b/include/tool-fb.h
@@ -22,7 +22,7 @@ namespace hum {
 
 class FiguredBassNumber {
 	public:
-		            FiguredBassNumber(int num, string accid, bool showAccid, int voiceIndex, int lineIndex, bool isAttack, bool intervallsatz);
+		            FiguredBassNumber(int num, string accid, bool showAccid, int voiceIndex, int lineIndex, bool isAttack, bool intervallsatz, string intervalQuality, bool hint);
 		std::string toString(bool nonCompoundIntervalsQ, bool noAccidentalsQ, bool hideThreeQ);
 		int         getNumberWithinOctave(void);
 
@@ -35,6 +35,8 @@ class FiguredBassNumber {
 		bool        m_isAttack;
 		bool        m_convert2To9 = false;
 		bool        m_intervallsatz = false;
+		std::string m_intervalQuality;
+		bool        m_hint = false;
 
 };
 
@@ -81,6 +83,7 @@ class Tool_fb : public HumTool {
 		string                     getNumberString                        (vector<FiguredBassNumber*> numbers);
 		string                     getKeySignature                        (HumdrumFile& infile, int lineIndex);
 		int                        getLowestBase40Pitch                   (vector<int> base40Pitches);
+		string                     getIntervalQuality                     (int basePitchBase40, int targetPitchBase40);
 
 
 	private:
@@ -98,6 +101,7 @@ class Tool_fb : public HumTool {
 		bool   m_showNegativeQ  = false;
 		bool   m_aboveQ         = false;
 		string m_rateQ          = "";
+		bool   m_hintQ          = false;
 
 		string m_spineTracks    = ""; // used with -s option
 		string m_kernTracks     = ""; // used with -k option

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Tue Jun 13 04:58:02 PDT 2023
+// Last Modified: Mo 10 Jul 2023 15:49:26 CEST
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -78135,6 +78135,7 @@ Tool_fb::Tool_fb(void) {
 	define("rate=s:",                    "Rate to display the numbers (use a **recip value, e.g. 4, 4.)");
 	define("k|kern-tracks=s",            "Process only the specified kern spines");
 	define("s|spine-tracks|spine|spines|track|tracks=s", "Process only the specified spines");
+	define("hint=b",                     "Determine harmonic intervals with interval quality");
 }
 
 
@@ -78201,6 +78202,7 @@ void Tool_fb::initialize(void) {
 	m_showNegativeQ  = getBoolean("negative");
 	m_aboveQ         = getBoolean("above");
 	m_rateQ          = getString("rate");
+	m_hintQ          = getBoolean("hint");
 
 	if (getBoolean("spine-tracks")) {
 		m_spineTracks = getString("spine-tracks");
@@ -78226,6 +78228,11 @@ void Tool_fb::initialize(void) {
 		m_sortQ = true;
 		m_accidentalsQ = true;
 		m_hideThreeQ = true;
+	}
+
+	if (m_hintQ) {
+		m_showNegativeQ = true;
+		// m_lowestQ = true;
 	}
 }
 
@@ -78434,6 +78441,10 @@ void Tool_fb::processFile(HumdrumFile& infile) {
 
 	string exinterp = m_aboveQ ? "**fba" : "**fb";
 
+	if (m_hintQ) {
+		exinterp = "**hint";
+	}
+
 	if (m_intervallsatzQ) {
 		// Create **fb spine for each voice
 		for (int voiceIndex = 0; voiceIndex < grid.getVoiceCount(); voiceIndex++) {
@@ -78597,7 +78608,9 @@ FiguredBassNumber* Tool_fb::createFiguredBassNumber(int basePitchBase40, int tar
 		}
 	}
 
-	FiguredBassNumber* number = new FiguredBassNumber(num, accid, showAccid, voiceIndex, lineIndex, isAttack, m_intervallsatzQ);
+	string intervalQuality = getIntervalQuality(basePitchBase40, targetPitchBase40);
+
+	FiguredBassNumber* number = new FiguredBassNumber(num, accid, showAccid, voiceIndex, lineIndex, isAttack, m_intervallsatzQ, intervalQuality, m_hintQ);
 
 	return number;
 }
@@ -78873,12 +78886,95 @@ int Tool_fb::getLowestBase40Pitch(vector<int> base40Pitches) {
 }
 
 
+
+//////////////////////////////
+//
+// Tool_fb::getIntervalQuality -- Return interval quality prefix string
+//
+
+string Tool_fb::getIntervalQuality(int basePitchBase40, int targetPitchBase40) {
+
+	int diff = (targetPitchBase40 - basePitchBase40) % 40;
+
+	diff = diff < -2 ? abs(diff) : diff;
+
+	// See https://wiki.ccarh.org/wiki/Base_40
+	string quality;
+	switch (diff) {
+		// 1
+		case -2:
+		case 38:
+			quality = "dd"; break;
+		case -1:
+		case 39:
+			quality = "d"; break;
+		case 0: quality = "P"; break;
+		case 1: quality = "A"; break;
+		case 2: quality = "AA"; break;
+
+		// 2
+		case 3: quality = "dd"; break;
+		case 4: quality = "d"; break;
+		case 5: quality = "m"; break;
+		case 6: quality = "M"; break;
+		case 7: quality = "A"; break;
+		case 8: quality = "AA"; break;
+
+		// 3
+		case 9: quality = "dd"; break;
+		case 10: quality = "d"; break;
+		case 11: quality = "m"; break;
+		case 12: quality = "M"; break;
+		case 13: quality = "A"; break;
+		case 14: quality = "AA"; break;
+
+		// 4
+		case 15: quality = "dd"; break;
+		case 16: quality = "d"; break;
+		case 17: quality = "P"; break;
+		case 18: quality = "A"; break;
+		case 19: quality = "AA"; break;
+
+		case 20: quality = "<unused>"; break;
+
+		// 5
+		case 21: quality = "dd"; break;
+		case 22: quality = "d"; break;
+		case 23: quality = "P"; break;
+		case 24: quality = "A"; break;
+		case 25: quality = "AA"; break;
+
+		// 6
+		case 26: quality = "dd"; break;
+		case 27: quality = "d"; break;
+		case 28: quality = "m"; break;
+		case 29: quality = "M"; break;
+		case 30: quality = "A"; break;
+		case 31: quality = "AA"; break;
+
+		// 7
+		case 32: quality = "dd"; break;
+		case 33: quality = "d"; break;
+		case 34: quality = "m"; break;
+		case 35: quality = "M"; break;
+		case 36: quality = "A"; break;
+		case 37: quality = "AA"; break;
+
+		default: quality = "?"; break;
+	}
+
+	return quality;
+
+}
+
+
+
 //////////////////////////////
 //
 // FiguredBassNumber::FiguredBassNumber -- Constructor
 //
 
-FiguredBassNumber::FiguredBassNumber(int num, string accid, bool showAccid, int voiceIdx, int lineIdx, bool isAtk, bool intervallsatz) {
+FiguredBassNumber::FiguredBassNumber(int num, string accid, bool showAccid, int voiceIdx, int lineIdx, bool isAtk, bool intervallsatz, string intervalQuality, bool hint) {
 	m_number          = num;
 	m_accidentals     = accid;
 	m_voiceIndex      = voiceIdx;
@@ -78886,6 +78982,8 @@ FiguredBassNumber::FiguredBassNumber(int num, string accid, bool showAccid, int 
 	m_showAccidentals = showAccid;
 	m_isAttack        = isAtk;
 	m_intervallsatz   = intervallsatz;
+	m_intervalQuality = intervalQuality;
+	m_hint            = hint;
 }
 
 
@@ -78897,6 +78995,9 @@ FiguredBassNumber::FiguredBassNumber(int num, string accid, bool showAccid, int 
 
 string FiguredBassNumber::toString(bool compoundQ, bool accidentalsQ, bool hideThreeQ) {
 	int num = (compoundQ) ? getNumberWithinOctave() : m_number;
+	if (m_hint) {
+		return m_intervalQuality + to_string(abs(num));
+	}
 	string accid = (accidentalsQ && m_showAccidentals) ? m_accidentals : "";
 	if (((num == 3) || (num == -3)) && accidentalsQ && m_showAccidentals && hideThreeQ) {
 		return accid;
@@ -78931,7 +79032,7 @@ int FiguredBassNumber::getNumberWithinOctave(void) {
 	// Replace 1 with 8 and -8
 	if (abs(num) == 1) {
 		// Allow unisono in intervallsatz
-		if (m_intervallsatz) {
+		if (m_intervallsatz || m_hint) {
 			if (abs(m_number) == 1) {
 				return 1;
 			}

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Tue Jun 13 04:58:02 PDT 2023
+// Last Modified: Mo 10 Jul 2023 15:49:26 CEST
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11
@@ -7259,7 +7259,7 @@ class Tool_extract : public HumTool {
 
 class FiguredBassNumber {
 	public:
-		            FiguredBassNumber(int num, string accid, bool showAccid, int voiceIndex, int lineIndex, bool isAttack, bool intervallsatz);
+		            FiguredBassNumber(int num, string accid, bool showAccid, int voiceIndex, int lineIndex, bool isAttack, bool intervallsatz, string intervalQuality, bool hint);
 		std::string toString(bool nonCompoundIntervalsQ, bool noAccidentalsQ, bool hideThreeQ);
 		int         getNumberWithinOctave(void);
 
@@ -7272,6 +7272,8 @@ class FiguredBassNumber {
 		bool        m_isAttack;
 		bool        m_convert2To9 = false;
 		bool        m_intervallsatz = false;
+		std::string m_intervalQuality;
+		bool        m_hint = false;
 
 };
 
@@ -7318,6 +7320,7 @@ class Tool_fb : public HumTool {
 		string                     getNumberString                        (vector<FiguredBassNumber*> numbers);
 		string                     getKeySignature                        (HumdrumFile& infile, int lineIndex);
 		int                        getLowestBase40Pitch                   (vector<int> base40Pitches);
+		string                     getIntervalQuality                     (int basePitchBase40, int targetPitchBase40);
 
 
 	private:
@@ -7335,6 +7338,7 @@ class Tool_fb : public HumTool {
 		bool   m_showNegativeQ  = false;
 		bool   m_aboveQ         = false;
 		string m_rateQ          = "";
+		bool   m_hintQ          = false;
 
 		string m_spineTracks    = ""; // used with -s option
 		string m_kernTracks     = ""; // used with -k option


### PR DESCRIPTION
This PR implements the a new `--hint` option to display harmonic intervals with interval quality in a `**hint` spine instead of a `**fb` and figured bass intervals (without interval quality but accidentals).

The original `hint` humdrum tool is not able to handle intervals when a null token is involved, which is not ideal for analytical purposes.

Note that this new option can be combined with `-c` to always display non-compound intervals (compare with the original humdrum tool hint `-c` flag).

Also note that the difference between two pitches is calculated as an absolute number so always the lowest pitch will be the base note. Otherwise `augmented` and `diminished` interval qualities will be wrong.

<details>
<summary>Click to show examples</summary>

## Example 1

Input:

```
**kern	**kern
4c	4A--
4c	4A-
4c	4A
4c	4A#
4c	4A##
=	=
4c	4B--
4c	4B-
4c	4B
4c	4B#
4c	4B##
=	=
4c	4c--
4c	4c-
4c	4c
4c	4c#
4c	4c##
=	=
4c	4d--
4c	4d-
4c	4d
4c	4d#
4c	4d##
=	=
4c	4e--
4c	4e-
4c	4e
4c	4e#
4c	4e##
=	=
4c	4f--
4c	4f-
4c	4f
4c	4f#
4c	4f##
=	=
4c	4g--
4c	4g-
4c	4g
4c	4g#
4c	4g##
=	=
4c	4a--
4c	4a-
4c	4a
4c	4a#
4c	4a##
=	=
4c	4b--
4c	4b-
4c	4b
4c	4b#
4c	4b##
=	=
4c	4cc--
4c	4cc-
4c	4cc
4c	4cc#
4c	4cc##
=	=
4c	4dd--
4c	4dd-
4c	4dd
4c	4dd#
4c	4dd##
=	=
4c	4ee--
4c	4ee-
4c	4ee
4c	4ee#
4c	4ee##
=	=
*-	*-
```

[open in VHV](https://verovio.humdrum.org?t=KiprZXJuCSoqa2Vybgo0Ywk0QS0tCjRjCTRBLQo0Ywk0QQo0Ywk0QSMKNGMJNEEjIwo9CT0KNGMJNEItLQo0Ywk0Qi0KNGMJNEIKNGMJNEIjCjRjCTRCIyMKPQk9CjRjCTRjLS0KNGMJNGMtCjRjCTRjCjRjCTRjIwo0Ywk0YyMjCj0JPQo0Ywk0ZC0tCjRjCTRkLQo0Ywk0ZAo0Ywk0ZCMKNGMJNGQjIwo9CT0KNGMJNGUtLQo0Ywk0ZS0KNGMJNGUKNGMJNGUjCjRjCTRlIyMKPQk9CjRjCTRmLS0KNGMJNGYtCjRjCTRmCjRjCTRmIwo0Ywk0ZiMjCj0JPQo0Ywk0Zy0tCjRjCTRnLQo0Ywk0Zwo0Ywk0ZyMKNGMJNGcjIwo9CT0KNGMJNGEtLQo0Ywk0YS0KNGMJNGEKNGMJNGEjCjRjCTRhIyMKPQk9CjRjCTRiLS0KNGMJNGItCjRjCTRiCjRjCTRiIwo0Ywk0YiMjCj0JPQo0Ywk0Y2MtLQo0Ywk0Y2MtCjRjCTRjYwo0Ywk0Y2MjCjRjCTRjYyMjCj0JPQo0Ywk0ZGQtLQo0Ywk0ZGQtCjRjCTRkZAo0Ywk0ZGQjCjRjCTRkZCMjCj0JPQo0Ywk0ZWUtLQo0Ywk0ZWUtCjRjCTRlZQo0Ywk0ZWUjCjRjCTRlZSMjCj0JPQoqLQkqLQo=)

Output:

```
**kern	**hint	**kern
4c	A3	4A--
4c	M3	4A-
4c	m3	4A
4c	d3	4A#
4c	dd3	4A##
=	=	=
4c	A2	4B--
4c	M2	4B-
4c	m2	4B
4c	d2	4B#
4c	dd2	4B##
=	=	=
4c	dd1	4c--
4c	d1	4c-
4c	P1	4c
4c	A1	4c#
4c	AA1	4c##
=	=	=
4c	d2	4d--
4c	m2	4d-
4c	M2	4d
4c	A2	4d#
4c	AA2	4d##
=	=	=
4c	d3	4e--
4c	m3	4e-
4c	M3	4e
4c	A3	4e#
4c	AA3	4e##
=	=	=
4c	dd4	4f--
4c	d4	4f-
4c	P4	4f
4c	A4	4f#
4c	AA4	4f##
=	=	=
4c	dd5	4g--
4c	d5	4g-
4c	P5	4g
4c	A5	4g#
4c	AA5	4g##
=	=	=
4c	d6	4a--
4c	m6	4a-
4c	M6	4a
4c	A6	4a#
4c	AA6	4a##
=	=	=
4c	d7	4b--
4c	m7	4b-
4c	M7	4b
4c	A7	4b#
4c	AA7	4b##
=	=	=
4c	dd8	4cc--
4c	d8	4cc-
4c	P8	4cc
4c	A8	4cc#
4c	AA8	4cc##
=	=	=
4c	d9	4dd--
4c	m9	4dd-
4c	M9	4dd
4c	A9	4dd#
4c	AA9	4dd##
=	=	=
4c	d10	4ee--
4c	m10	4ee-
4c	M10	4ee
4c	A10	4ee#
4c	AA10	4ee##
=	=	=
*-	*-	*-
```

## Example 2

Chord are also supported.

Input: 

```
**kern	**kern	**kern
4c	4A--	4%5e
4c	4A-	.
4c	4A	.
4c	4A#	.
4c	4A##	.
=	=	=
4c	4B--	4%5f
4c	4B-	.
4c	4B	.
4c	4B#	.
4c	4B##	.
=	=	=
4c	4c--	4%5g
4c	4c-	.
4c	4c	.
4c	4c#	.
4c	4c##	.
=	=	=
4c	4d--	4%5a
4c	4d-	.
4c	4d	.
4c	4d#	.
4c	4d##	.
=	=	=
4c	4e--	4%5b
4c	4e-	.
4c	4e	.
4c	4e#	.
4c	4e##	.
=	=	=
4c	4f--	4%5cc
4c	4f-	.
4c	4f	.
4c	4f#	.
4c	4f##	.
=	=	=
4c	4g--	4%5dd
4c	4g-	.
4c	4g	.
4c	4g#	.
4c	4g##	.
=	=	=
4c	4a--	4%5ee
4c	4a-	.
4c	4a	.
4c	4a#	.
4c	4a##	.
=	=	=
4c	4b--	4%5ff
4c	4b-	.
4c	4b	.
4c	4b#	.
4c	4b##	.
=	=	=
4c	4cc--	4%5gg
4c	4cc-	.
4c	4cc	.
4c	4cc#	.
4c	4cc##	.
=	=	=
4c	4dd--	4%5gg
4c	4dd-	.
4c	4dd	.
4c	4dd#	.
4c	4dd##	.
=	=	=
4c	4ee--	4%5gg
4c	4ee-	.
4c	4ee	.
4c	4ee#	.
4c	4ee##	.
=	=	=
*-	*-	*-
```

[open in VHV](https://verovio.humdrum.org?t=KiprZXJuCSoqa2VybgkqKmtlcm4KNGMJNEEtLQk0JTVlCjRjCTRBLQkuCjRjCTRBCS4KNGMJNEEjCS4KNGMJNEEjIwkuCj0JPQk9CjRjCTRCLS0JNCU1Zgo0Ywk0Qi0JLgo0Ywk0QgkuCjRjCTRCIwkuCjRjCTRCIyMJLgo9CT0JPQo0Ywk0Yy0tCTQlNWcKNGMJNGMtCS4KNGMJNGMJLgo0Ywk0YyMJLgo0Ywk0YyMjCS4KPQk9CT0KNGMJNGQtLQk0JTVhCjRjCTRkLQkuCjRjCTRkCS4KNGMJNGQjCS4KNGMJNGQjIwkuCj0JPQk9CjRjCTRlLS0JNCU1Ygo0Ywk0ZS0JLgo0Ywk0ZQkuCjRjCTRlIwkuCjRjCTRlIyMJLgo9CT0JPQo0Ywk0Zi0tCTQlNWNjCjRjCTRmLQkuCjRjCTRmCS4KNGMJNGYjCS4KNGMJNGYjIwkuCj0JPQk9CjRjCTRnLS0JNCU1ZGQKNGMJNGctCS4KNGMJNGcJLgo0Ywk0ZyMJLgo0Ywk0ZyMjCS4KPQk9CT0KNGMJNGEtLQk0JTVlZQo0Ywk0YS0JLgo0Ywk0YQkuCjRjCTRhIwkuCjRjCTRhIyMJLgo9CT0JPQo0Ywk0Yi0tCTQlNWZmCjRjCTRiLQkuCjRjCTRiCS4KNGMJNGIjCS4KNGMJNGIjIwkuCj0JPQk9CjRjCTRjYy0tCTQlNWdnCjRjCTRjYy0JLgo0Ywk0Y2MJLgo0Ywk0Y2MjCS4KNGMJNGNjIyMJLgo9CT0JPQo0Ywk0ZGQtLQk0JTVnZwo0Ywk0ZGQtCS4KNGMJNGRkCS4KNGMJNGRkIwkuCjRjCTRkZCMjCS4KPQk9CT0KNGMJNGVlLS0JNCU1Z2cKNGMJNGVlLQkuCjRjCTRlZQkuCjRjCTRlZSMJLgo0Ywk0ZWUjIwkuCj0JPQk9CiotCSotCSotCg==)

Output:

```
**kern	**hint	**kern	**kern
4c	M3 A3	4A--	4%5e
4c	M3 M3	4A-	.
4c	M3 m3	4A	.
4c	M3 d3	4A#	.
4c	M3 dd3	4A##	.
=	=	=	=
4c	P4 A2	4B--	4%5f
4c	P4 M2	4B-	.
4c	P4 m2	4B	.
4c	P4 d2	4B#	.
4c	P4 dd2	4B##	.
=	=	=	=
4c	P5 dd1	4c--	4%5g
4c	P5 d1	4c-	.
4c	P5 P1	4c	.
4c	P5 A1	4c#	.
4c	P5 AA1	4c##	.
=	=	=	=
4c	M6 d2	4d--	4%5a
4c	M6 m2	4d-	.
4c	M6 M2	4d	.
4c	M6 A2	4d#	.
4c	M6 AA2	4d##	.
=	=	=	=
4c	M7 d3	4e--	4%5b
4c	M7 m3	4e-	.
4c	M7 M3	4e	.
4c	M7 A3	4e#	.
4c	M7 AA3	4e##	.
=	=	=	=
4c	P8 dd4	4f--	4%5cc
4c	P8 d4	4f-	.
4c	P8 P4	4f	.
4c	P8 A4	4f#	.
4c	P8 AA4	4f##	.
=	=	=	=
4c	M9 dd5	4g--	4%5dd
4c	M9 d5	4g-	.
4c	M9 P5	4g	.
4c	M9 A5	4g#	.
4c	M9 AA5	4g##	.
=	=	=	=
4c	M10 d6	4a--	4%5ee
4c	M10 m6	4a-	.
4c	M10 M6	4a	.
4c	M10 A6	4a#	.
4c	M10 AA6	4a##	.
=	=	=	=
4c	P11 d7	4b--	4%5ff
4c	P11 m7	4b-	.
4c	P11 M7	4b	.
4c	P11 A7	4b#	.
4c	P11 AA7	4b##	.
=	=	=	=
4c	P12 dd8	4cc--	4%5gg
4c	P12 d8	4cc-	.
4c	P12 P8	4cc	.
4c	P12 A8	4cc#	.
4c	P12 AA8	4cc##	.
=	=	=	=
4c	P12 d9	4dd--	4%5gg
4c	P12 m9	4dd-	.
4c	P12 M9	4dd	.
4c	P12 A9	4dd#	.
4c	P12 AA9	4dd##	.
=	=	=	=
4c	P12 d10	4ee--	4%5gg
4c	P12 m10	4ee-	.
4c	P12 M10	4ee	.
4c	P12 A10	4ee#	.
4c	P12 AA10	4ee##	.
=	=	=	=
*-	*-	*-	*-
```

</details>