### PR TITLE
[musicxml2hum] Improve missing exclusive interpretations

### DIFF
--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mon Nov 13 08:17:24 JST 2023
+// Last Modified: Di 28 Nov 2023 10:52:29 CET
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -9604,8 +9604,8 @@ int HumGrid::getStaffCount(int partindex) {
 		return 0;
 	}
 
-	return (int)this->at(0)->front()->at(partindex)->size();
-	// return (int)this->at(0)->back()->at(partindex)->size();
+	// return (int)this->at(0)->front()->at(partindex)->size();
+	return (int)this->at(0)->back()->at(partindex)->size();
 }
 
 

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mon Nov 13 08:17:24 JST 2023
+// Last Modified: Di 28 Nov 2023 10:52:29 CET
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11

--- a/src/HumGrid.cpp
+++ b/src/HumGrid.cpp
@@ -130,8 +130,8 @@ int HumGrid::getStaffCount(int partindex) {
 		return 0;
 	}
 
-	return (int)this->at(0)->front()->at(partindex)->size();
-	// return (int)this->at(0)->back()->at(partindex)->size();
+	// return (int)this->at(0)->front()->at(partindex)->size();
+	return (int)this->at(0)->back()->at(partindex)->size();
 }
 
 


### PR DESCRIPTION
I reverted the change in `HumGrid::getStaffCount` that caused the problem introduced in 24db1559b8ab50f05ea767488091e1476f2f3026. Please see #85 for reference.

I will try to debug the other problem with the wrong order if the spine split and the missing note in the right hand in this PR, and keep this PR as a draft for now.

Closes #85.