### PR TITLE
[musicxml2hum] Fix missing lines when nowevents includes nonzerodur elements

### DIFF
--- a/include/MxmlEvent.h
+++ b/include/MxmlEvent.h
@@ -100,6 +100,7 @@ class MxmlEvent {
 		void               setVoiceNumber     (int value);
 		int                getStaffNumber     (void) const;
 		int                getStaffIndex      (void) const;
+		int                getCrossStaffOffset(void) const;
 		int                getVoiceIndex      (int maxvoice = 4) const;
 		void               setStaffNumber     (int value);
 		measure_event_type getType            (void) const;

--- a/include/MxmlPart.h
+++ b/include/MxmlPart.h
@@ -72,6 +72,9 @@ class MxmlPart {
 		string        getPartAbbr          (void) const;
 		string        cleanSpaces          (const string& input);
 		bool          hasOrnaments         (void) const;
+		
+		vector<pair<int, int>> getVoiceMapping (void) { return m_voicemapping; };
+		vector<vector<int>> getStaffVoiceHist (void) { return m_staffvoicehist; };
 
 
 	private:

--- a/include/tool-musicxml2hum.h
+++ b/include/tool-musicxml2hum.h
@@ -236,7 +236,7 @@ class Tool_musicxml2hum : public HumTool {
 		int  m_maxstaff      = 0;
 		std::vector<std::vector<std::string>> m_last_ottava_direction;
 		std::vector<MusicXmlHarmonyInfo> offsetHarmony;
-		std::vector<MusicXmlFiguredBassInfo> offsetFiguredBass;
+		std::vector<MusicXmlFiguredBassInfo> m_offsetFiguredBass;
 		std::vector<string> m_stop_char;
 
 		// RDF indications in **kern data:

--- a/include/tool-musicxml2hum.h
+++ b/include/tool-musicxml2hum.h
@@ -249,7 +249,7 @@ class Tool_musicxml2hum : public HumTool {
 		std::vector<std::vector<pugi::xml_node>> m_current_brackets;
 		std::map<int, string> m_bracket_type_buffer;
 		std::vector<std::vector<pugi::xml_node>> m_used_hairpins;
-		std::vector<pugi::xml_node> m_current_figured_bass;
+		std::vector<std::vector<pugi::xml_node>> m_current_figured_bass;
 		std::vector<std::pair<int, pugi::xml_node>> m_current_text;
 		std::vector<std::pair<int, pugi::xml_node>> m_current_tempo;
 

--- a/include/tool-musicxml2hum.h
+++ b/include/tool-musicxml2hum.h
@@ -232,6 +232,8 @@ class Tool_musicxml2hum : public HumTool {
 		bool m_stemsQ        = false;
 		int  m_slurabove     = 0;
 		int  m_slurbelow     = 0;
+		int  m_staffabove    = 0;
+		int  m_staffbelow    = 0;
 		char m_hasEditorial  = '\0';
 		bool m_hasOrnamentsQ = false;
 		int  m_maxstaff      = 0;

--- a/include/tool-musicxml2hum.h
+++ b/include/tool-musicxml2hum.h
@@ -93,6 +93,7 @@ class Tool_musicxml2hum : public HumTool {
 		                             std::vector<SimultaneousEvents*>& nowevents,
 		                             HumNum nowtime,
 		                             std::vector<MxmlPart>& partdata);
+		void   handleFiguredBassWithoutNonZeroEvent (std::vector<SimultaneousEvents*>& nowevents, HumNum nowtime);
 		void   appendNonZeroEvents   (GridMeasure* outdata,
 		                              std::vector<SimultaneousEvents*>& nowevents,
 		                              HumNum nowtime,

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Di  5 Dez 2023 11:57:39 CET
+// Last Modified: Mi  6 Dez 2023 14:34:42 CET
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -98976,6 +98976,7 @@ bool Tool_musicxml2hum::convert(ostream& out, xml_document& doc) {
 
 	m_current_dynamic.resize(partids.size());
 	m_current_brackets.resize(partids.size());
+	m_current_figured_bass.resize(partids.size());
 	m_stop_char.resize(partids.size(), "[");
 
 	getPartContent(partcontent, partids, doc);
@@ -101859,13 +101860,13 @@ string Tool_musicxml2hum::getDynamicString(xml_node element) {
 //
 
 int Tool_musicxml2hum::addFiguredBass(GridPart* part, MxmlEvent* event, HumNum nowtime, int partindex) {
-	if (m_current_figured_bass.empty()) {
+	if (m_current_figured_bass[partindex].empty()) {
 		return 0;
 	}
 
 	int dursum = 0;
-	for (int i=0; i<(int)m_current_figured_bass.size(); i++) {
-		xml_node fnode = m_current_figured_bass.at(i);
+	for (int i=0; i<(int)m_current_figured_bass[partindex].size(); i++) {
+		xml_node fnode = m_current_figured_bass[partindex].at(i);
 		if (!fnode) {
 			// strange problem
 			continue;
@@ -101886,11 +101887,11 @@ int Tool_musicxml2hum::addFiguredBass(GridPart* part, MxmlEvent* event, HumNum n
 			finfo.token = ftok;
 			offsetFiguredBass.push_back(finfo);
 		}
-		if (i < (int)m_current_figured_bass.size() - 1) {
+		if (i < (int)m_current_figured_bass[partindex].size() - 1) {
 			dursum += getFiguredBassDuration(fnode);
 		}
 	}
-	m_current_figured_bass.clear();
+	m_current_figured_bass[partindex].clear();
 
 	return 1;
 
@@ -102535,7 +102536,7 @@ void Tool_musicxml2hum::appendZeroEvents(GridMeasure* outdata,
 					}
 				}
 			} else if (nodeType(element, "figured-bass")) {
-				m_current_figured_bass.push_back(element);
+				m_current_figured_bass[pindex].push_back(element);
 			} else if (nodeType(element, "note")) {
 				if (foundnongrace) {
 					addEventToList(graceafter, nowevents[i]->zerodur[j]);

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mo  4 Dez 2023 10:58:34 CET
+// Last Modified: Mo  4 Dez 2023 11:23:27 CET
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -100434,11 +100434,11 @@ bool Tool_musicxml2hum::convertNowEvents(GridMeasure* outdata,
 
 	bool hasNonZeroDurElements = false;
 	for (const SimultaneousEvents* event : nowevents) {
-        if (event->nonzerodur.size() != 0) {
-            hasNonZeroDurElements = true;
+		if (event->nonzerodur.size() != 0) {
+			hasNonZeroDurElements = true;
 			break;
-        }
-    }
+		}
+	}
 	if (!hasNonZeroDurElements) {
 		// no duration events (should be a terminal barline)
 		// ignore and deal with in calling function.

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mi  6 Dez 2023 14:34:42 CET
+// Last Modified: Mi  6 Dez 2023 18:35:46 CET
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -100179,7 +100179,7 @@ bool Tool_musicxml2hum::insertMeasure(HumGrid& outdata, int mnum,
 	if (offsetHarmony.size() > 0) {
 		insertOffsetHarmonyIntoMeasure(outdata.back());
 	}
-	if (offsetFiguredBass.size() > 0) {
+	if (m_offsetFiguredBass.size() > 0) {
 		insertOffsetFiguredBassIntoMeasure(outdata.back());
 	}
 	return status;
@@ -100193,7 +100193,7 @@ bool Tool_musicxml2hum::insertMeasure(HumGrid& outdata, int mnum,
 //
 
 void Tool_musicxml2hum::insertOffsetFiguredBassIntoMeasure(GridMeasure* gm) {
-	if (offsetFiguredBass.empty()) {
+	if (m_offsetFiguredBass.empty()) {
 		return;
 	}
 
@@ -100205,15 +100205,15 @@ void Tool_musicxml2hum::insertOffsetFiguredBassIntoMeasure(GridMeasure* gm) {
 			continue;
 		}
 		HumNum timestamp = gs->getTimestamp();
-		for (int i=0; i<(int)offsetFiguredBass.size(); i++) {
-			if (offsetFiguredBass[i].token == NULL) {
+		for (int i=0; i<(int)m_offsetFiguredBass.size(); i++) {
+			if (m_offsetFiguredBass[i].token == NULL) {
 				continue;
  			}
-			if (offsetFiguredBass[i].timestamp == timestamp) {
+			if (m_offsetFiguredBass[i].timestamp == timestamp) {
 				// this is the slice to insert the harmony
-				gs->at(offsetFiguredBass[i].partindex)->setFiguredBass(offsetFiguredBass[i].token);
-				offsetFiguredBass[i].token = NULL;
-			} else if (offsetFiguredBass[i].timestamp < timestamp) {
+				gs->at(m_offsetFiguredBass[i].partindex)->setFiguredBass(m_offsetFiguredBass[i].token);
+				m_offsetFiguredBass[i].token = NULL;
+			} else if (m_offsetFiguredBass[i].timestamp < timestamp) {
 				if (beginQ) {
 					cerr << "Error: Cannot insert harmony " << offsetFiguredBass[i].token
 					     << " at timestamp " << offsetFiguredBass[i].timestamp
@@ -100231,11 +100231,11 @@ void Tool_musicxml2hum::insertOffsetFiguredBassIntoMeasure(GridMeasure* gm) {
 						}
 						int partcount = (int)(*tempit)->size();
 						tempit++;
-						GridSlice* newgs = new GridSlice(gm, offsetFiguredBass[i].timestamp,
+						GridSlice* newgs = new GridSlice(gm, m_offsetFiguredBass[i].timestamp,
 								SliceType::Notes, partcount);
-						newgs->at(offsetFiguredBass[i].partindex)->setFiguredBass(offsetFiguredBass[i].token);
+						newgs->at(m_offsetFiguredBass[i].partindex)->setFiguredBass(m_offsetFiguredBass[i].token);
 						gm->insert(tempit, newgs);
-						offsetFiguredBass[i].token = NULL;
+						m_offsetFiguredBass[i].token = NULL;
 						break;
 					}
 				}
@@ -100245,19 +100245,19 @@ void Tool_musicxml2hum::insertOffsetFiguredBassIntoMeasure(GridMeasure* gm) {
 	}
 	// If there are still valid harmonies in the input list, apppend
 	// them to the end of the measure.
-	for (int i=0; i<(int)offsetFiguredBass.size(); i++) {
-		if (offsetFiguredBass[i].token == NULL) {
+	for (int i=0; i<(int)m_offsetFiguredBass.size(); i++) {
+		if (m_offsetFiguredBass[i].token == NULL) {
 			continue;
  		}
 		m_forceRecipQ = true;
 		int partcount = (int)gm->back()->size();
-		GridSlice* newgs = new GridSlice(gm, offsetFiguredBass[i].timestamp,
+		GridSlice* newgs = new GridSlice(gm, m_offsetFiguredBass[i].timestamp,
 				SliceType::Notes, partcount);
-		newgs->at(offsetFiguredBass[i].partindex)->setFiguredBass(offsetFiguredBass[i].token);
+		newgs->at(m_offsetFiguredBass[i].partindex)->setFiguredBass(m_offsetFiguredBass[i].token);
 		gm->insert(gm->end(), newgs);
-		offsetFiguredBass[i].token = NULL;
+		m_offsetFiguredBass[i].token = NULL;
 	}
-	offsetFiguredBass.clear();
+	m_offsetFiguredBass.clear();
 }
 
 
@@ -101885,7 +101885,7 @@ int Tool_musicxml2hum::addFiguredBass(GridPart* part, MxmlEvent* event, HumNum n
 			finfo.timestamp += nowtime;
 			finfo.partindex = partindex;
 			finfo.token = ftok;
-			offsetFiguredBass.push_back(finfo);
+			m_offsetFiguredBass.push_back(finfo);
 		}
 		if (i < (int)m_current_figured_bass[partindex].size() - 1) {
 			dursum += getFiguredBassDuration(fnode);

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Do  7 Dez 2023 12:23:44 CET
+// Last Modified: Do  7 Dez 2023 12:33:50 CET
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -101597,7 +101597,7 @@ string Tool_musicxml2hum::convertFiguredBassNumber(const xml_node& figure) {
 		accidental = "--";
 	} else if (prefix == "flat") {
 		accidental = "-";
-	} else if (prefix == "double-sharp") {
+	} else if (prefix == "double-sharp" || prefix == "sharp-sharp") {
 		accidental = "##";
 	} else if (prefix == "sharp") {
 		accidental = "#";
@@ -101607,7 +101607,7 @@ string Tool_musicxml2hum::convertFiguredBassNumber(const xml_node& figure) {
 		accidental = "--r";
 	} else if (suffix == "flat") {
 		accidental = "-r";
-	} else if (suffix == "double-sharp") {
+	} else if (suffix == "double-sharp" || suffix == "sharp-sharp") {
 		accidental = "##r";
 	} else if (suffix == "sharp") {
 		accidental = "#r";

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mi  6 Dez 2023 18:35:46 CET
+// Last Modified: Mi  6 Dez 2023 21:07:52 CET
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -99053,7 +99053,7 @@ bool Tool_musicxml2hum::convert(ostream& out, xml_document& doc) {
 		bool fbstate = partdata[p].hasFiguredBass();
 		if (fbstate) {
 			outdata.setFiguredBassPresent(p);
-			break;
+			// break;
 		}
 	}
 

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Di 28 Nov 2023 10:52:29 CET
+// Last Modified: Mo  4 Dez 2023 10:58:34 CET
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -100432,7 +100432,14 @@ bool Tool_musicxml2hum::convertNowEvents(GridMeasure* outdata,
 
 	appendZeroEvents(outdata, nowevents, nowtime, partdata);
 
-	if (nowevents[0]->nonzerodur.size() == 0) {
+	bool hasNonZeroDurElements = false;
+	for (const SimultaneousEvents* event : nowevents) {
+        if (event->nonzerodur.size() != 0) {
+            hasNonZeroDurElements = true;
+			break;
+        }
+    }
+	if (!hasNonZeroDurElements) {
 		// no duration events (should be a terminal barline)
 		// ignore and deal with in calling function.
 		return true;

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mo  4 Dez 2023 11:23:27 CET
+// Last Modified: Di  5 Dez 2023 11:57:39 CET
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -100634,7 +100634,7 @@ void Tool_musicxml2hum::addEvent(GridSlice* slice, GridMeasure* outdata, MxmlEve
 		cerr << "!!TOKEN: " << ss.str();
 		cerr << "\tTS: "    << event->getStartTime();
 		cerr << "\tDUR: "   << event->getDuration();
-		cerr << "\tSTi: "   << event->getStaffNumber();
+		cerr << "\tSTn: "   << event->getStaffNumber();
 		cerr << "\tVn: "    << event->getVoiceNumber();
 		cerr << "\tSTi: "   << event->getStaffIndex();
 		cerr << "\tVi: "    << event->getVoiceIndex();

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Fr  8 Dez 2023 21:34:43 CET
+// Last Modified: Di 12 Dez 2023 11:50:56 CET
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -45771,6 +45771,20 @@ int MxmlEvent::getVoiceIndex(int maxvoice) const {
 	if (m_owner) {
 		int voiceindex = m_owner->getVoiceIndex(m_voice);
 		if (voiceindex >= 0) {
+			vector<pair<int, int>> mapping = getOwner()->getOwner()->getVoiceMapping();
+			if (getVoiceNumber() < mapping.size()) {
+				// prevent overwriting existing notes in voiceindex layer, when
+				// the MxmlEvent are in another staff than in calculated in
+				// MxmlPart::m_voicemapping
+				vector<vector<int>> staffvoicehist = getOwner()->getOwner()->getStaffVoiceHist();
+				int totalVoicesInStaff = staffvoicehist[getStaffNumber()][getVoiceNumber()];
+				const auto& [mappingStaffIndex, mappingVoiceIndex] = mapping[getVoiceNumber()];
+				if (mappingStaffIndex != getStaffIndex()) {
+					// add total number of voices of the new staff to the
+					// voiceindex of the old staff
+					return totalVoicesInStaff + voiceindex;
+				}
+			}
 			return voiceindex;
 		}
 	}

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Fr  8 Dez 2023 00:13:22 CET
+// Last Modified: Fr  8 Dez 2023 12:36:58 CET
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -101947,6 +101947,17 @@ string Tool_musicxml2hum::getFiguredBassString(xml_node fnode) {
 		if (i < (int)children.size() - 1) {
 			output += " ";
 		}
+	}
+
+	output = std::regex_replace(output, std::regex("^ +| +$|( ) +"), "$1");
+
+	if (output.empty()) {
+		if (children.size()) {
+			cerr << "WARNING: figured bass string is empty but has "
+				<< children.size() << " figure elements as children. "
+				<< "The output has been replaced with \".\"" << endl;
+		}
+		output = ".";
 	}
 
 	return output;

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Fr  8 Dez 2023 12:36:58 CET
+// Last Modified: Fr  8 Dez 2023 12:39:54 CET
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -100455,7 +100455,41 @@ bool Tool_musicxml2hum::convertNowEvents(GridMeasure* outdata,
 
 	appendNonZeroEvents(outdata, nowevents, nowtime, partdata);
 
+	handleFiguredBassWithoutNonZeroEvent(nowevents, nowtime);
+
 	return true;
+}
+
+
+
+/////////////////////////////
+//
+// Tool_musicxml2hum::handleFiguredBassWithoutNonZeroEvent --
+//
+
+void Tool_musicxml2hum::handleFiguredBassWithoutNonZeroEvent(vector<SimultaneousEvents*>& nowevents, HumNum nowtime) {
+	vector<int> nonZeroParts;
+	vector<MxmlEvent> floatingFiguredBass;
+	for (const SimultaneousEvents* sevent : nowevents) {
+		for (MxmlEvent* mxmlEvent : sevent->nonzerodur) {
+			nonZeroParts.push_back(mxmlEvent->getPartIndex());
+		}
+		for (MxmlEvent* mxmlEvent : sevent->zerodur) {
+			if ("figured-bass" == mxmlEvent->getElementName()) {
+				if (std::find(nonZeroParts.begin(), nonZeroParts.end(), mxmlEvent->getPartIndex()) == nonZeroParts.end()) {
+					// cerr << mxmlEvent->getNode() << "\n";
+					string fstring = getFiguredBassString(mxmlEvent->getNode());
+					HTp ftok = new HumdrumToken(fstring);
+					MusicXmlFiguredBassInfo finfo;
+					finfo.timestamp = nowtime;
+					finfo.partindex = mxmlEvent->getPartIndex();
+					finfo.token = ftok;
+					m_offsetFiguredBass.push_back(finfo);
+					// cerr << "ADD FLOATING FB NUM " << fstring << " " << nowtime << "\n";
+				}
+			}
+		}
+	}
 }
 
 

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Fr  8 Dez 2023 20:35:27 CET
+// Last Modified: Fr  8 Dez 2023 21:34:43 CET
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -11454,7 +11454,7 @@ void HumGrid::checkForNullDataHoles(void) {
 							if (v >= (int)sp->size() - 1) {
 								// Found a data line with no data at given voice, so
 								// add slice duration to cumulative duration.
-								duration += slicep->getDuration();
+								// duration += slicep->getDuration();
 								continue;
 							}
 							vp = sp->at(v);

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Fr  8 Dez 2023 12:39:54 CET
+// Last Modified: Fr  8 Dez 2023 20:35:27 CET
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -101983,7 +101983,8 @@ string Tool_musicxml2hum::getFiguredBassString(xml_node fnode) {
 		}
 	}
 
-	output = std::regex_replace(output, std::regex("^ +| +$|( ) +"), "$1");
+	HumRegex hre;
+	hre.replaceDestructive(output, "", R"(^\s+|\s+$)");
 
 	if (output.empty()) {
 		if (children.size()) {

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mi  6 Dez 2023 21:07:52 CET
+// Last Modified: Mi  6 Dez 2023 21:12:42 CET
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -100215,8 +100215,8 @@ void Tool_musicxml2hum::insertOffsetFiguredBassIntoMeasure(GridMeasure* gm) {
 				m_offsetFiguredBass[i].token = NULL;
 			} else if (m_offsetFiguredBass[i].timestamp < timestamp) {
 				if (beginQ) {
-					cerr << "Error: Cannot insert harmony " << offsetFiguredBass[i].token
-					     << " at timestamp " << offsetFiguredBass[i].timestamp
+					cerr << "Error: Cannot insert harmony " << m_offsetFiguredBass[i].token
+					     << " at timestamp " << m_offsetFiguredBass[i].timestamp
 					     << " since first timestamp in measure is " << timestamp << endl;
 				} else {
 					m_forceRecipQ = true;

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mi  6 Dez 2023 21:12:42 CET
+// Last Modified: Do  7 Dez 2023 12:23:44 CET
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -101620,12 +101620,12 @@ string Tool_musicxml2hum::convertFiguredBassNumber(const xml_node& figure) {
 	// could be a flat).  At the moment do not assign the accidental, but
 	// in the future assign an accidental to the slashed figure, probably
 	// with a post-processing tool.
-	if (suffix == "cross" || prefix == "cross") {
+	if (suffix == "cross" || prefix == "cross" || suffix == "vertical" || prefix == "vertical") {
 		slash = "|";
 		if (accidental.empty()) {
 			accidental = "#";
 		}
-	} else if ((suffix == "backslash") || (prefix == "backslash")) {
+	} else if ((suffix == "backslash" || suffix == "back-slash") || (prefix == "backslash" || prefix == "back-slash")) {
 		slash = "\\";
 		if (accidental.empty()) {
 			accidental = "#";

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Do  7 Dez 2023 12:33:50 CET
+// Last Modified: Do  7 Dez 2023 22:29:45 CET
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -100447,6 +100447,10 @@ bool Tool_musicxml2hum::convertNowEvents(GridMeasure* outdata,
 	}
 
 	appendNonZeroEvents(outdata, nowevents, nowtime, partdata);
+
+	for (int i=0; i<(int)m_current_figured_bass.size(); i++) {
+		m_current_figured_bass[i].clear();
+	}
 
 	return true;
 }

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Do  7 Dez 2023 22:29:45 CET
+// Last Modified: Fr  8 Dez 2023 00:13:22 CET
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -100174,6 +100174,13 @@ bool Tool_musicxml2hum::insertMeasure(HumGrid& outdata, int mnum,
 		}
 		status &= convertNowEvents(outdata.back(),
 				nowevents, nowparts, processtime, partdata, partstaves);
+
+		// Remove all figured bass numbers for this nowtime so that they are not
+		// accidentally displayed in the next nowtime, which can currently
+		// happen if there are no nonzerodur events in the same part
+		for (int i=0; i<(int)m_current_figured_bass.size(); i++) {
+			m_current_figured_bass[i].clear();
+		}
 	}
 
 	if (offsetHarmony.size() > 0) {
@@ -100447,10 +100454,6 @@ bool Tool_musicxml2hum::convertNowEvents(GridMeasure* outdata,
 	}
 
 	appendNonZeroEvents(outdata, nowevents, nowtime, partdata);
-
-	for (int i=0; i<(int)m_current_figured_bass.size(); i++) {
-		m_current_figured_bass[i].clear();
-	}
 
 	return true;
 }

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Fr  8 Dez 2023 20:35:27 CET
+// Last Modified: Fr  8 Dez 2023 21:34:43 CET
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mi  6 Dez 2023 14:34:42 CET
+// Last Modified: Mi  6 Dez 2023 18:35:46 CET
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11
@@ -9178,7 +9178,7 @@ class Tool_musicxml2hum : public HumTool {
 		int  m_maxstaff      = 0;
 		std::vector<std::vector<std::string>> m_last_ottava_direction;
 		std::vector<MusicXmlHarmonyInfo> offsetHarmony;
-		std::vector<MusicXmlFiguredBassInfo> offsetFiguredBass;
+		std::vector<MusicXmlFiguredBassInfo> m_offsetFiguredBass;
 		std::vector<string> m_stop_char;
 
 		// RDF indications in **kern data:

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Di 28 Nov 2023 10:52:29 CET
+// Last Modified: Mo  4 Dez 2023 10:58:34 CET
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mo  4 Dez 2023 11:23:27 CET
+// Last Modified: Di  5 Dez 2023 11:57:39 CET
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Do  7 Dez 2023 22:29:45 CET
+// Last Modified: Fr  8 Dez 2023 00:13:22 CET
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Do  7 Dez 2023 12:33:50 CET
+// Last Modified: Do  7 Dez 2023 22:29:45 CET
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Fr  8 Dez 2023 12:39:54 CET
+// Last Modified: Fr  8 Dez 2023 20:35:27 CET
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mo  4 Dez 2023 10:58:34 CET
+// Last Modified: Mo  4 Dez 2023 11:23:27 CET
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Di  5 Dez 2023 11:57:39 CET
+// Last Modified: Mi  6 Dez 2023 14:34:42 CET
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11
@@ -9191,7 +9191,7 @@ class Tool_musicxml2hum : public HumTool {
 		std::vector<std::vector<pugi::xml_node>> m_current_brackets;
 		std::map<int, string> m_bracket_type_buffer;
 		std::vector<std::vector<pugi::xml_node>> m_used_hairpins;
-		std::vector<pugi::xml_node> m_current_figured_bass;
+		std::vector<std::vector<pugi::xml_node>> m_current_figured_bass;
 		std::vector<std::pair<int, pugi::xml_node>> m_current_text;
 		std::vector<std::pair<int, pugi::xml_node>> m_current_tempo;
 

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Do  7 Dez 2023 12:23:44 CET
+// Last Modified: Do  7 Dez 2023 12:33:50 CET
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Di 12 Dez 2023 11:50:56 CET
+// Last Modified: Di 12 Dez 2023 16:19:41 CET
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11
@@ -4850,6 +4850,7 @@ class MxmlEvent {
 		void               setVoiceNumber     (int value);
 		int                getStaffNumber     (void) const;
 		int                getStaffIndex      (void) const;
+		int                getCrossStaffOffset(void) const;
 		int                getVoiceIndex      (int maxvoice = 4) const;
 		void               setStaffNumber     (int value);
 		measure_event_type getType            (void) const;
@@ -9177,6 +9178,8 @@ class Tool_musicxml2hum : public HumTool {
 		bool m_stemsQ        = false;
 		int  m_slurabove     = 0;
 		int  m_slurbelow     = 0;
+		int  m_staffabove    = 0;
+		int  m_staffbelow    = 0;
 		char m_hasEditorial  = '\0';
 		bool m_hasOrnamentsQ = false;
 		int  m_maxstaff      = 0;

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Fr  8 Dez 2023 12:36:58 CET
+// Last Modified: Fr  8 Dez 2023 12:39:54 CET
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11
@@ -9035,6 +9035,7 @@ class Tool_musicxml2hum : public HumTool {
 		                             std::vector<SimultaneousEvents*>& nowevents,
 		                             HumNum nowtime,
 		                             std::vector<MxmlPart>& partdata);
+		void   handleFiguredBassWithoutNonZeroEvent (std::vector<SimultaneousEvents*>& nowevents, HumNum nowtime);
 		void   appendNonZeroEvents   (GridMeasure* outdata,
 		                              std::vector<SimultaneousEvents*>& nowevents,
 		                              HumNum nowtime,

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mi  6 Dez 2023 21:07:52 CET
+// Last Modified: Mi  6 Dez 2023 21:12:42 CET
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Fr  8 Dez 2023 00:13:22 CET
+// Last Modified: Fr  8 Dez 2023 12:36:58 CET
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Fr  8 Dez 2023 21:34:43 CET
+// Last Modified: Di 12 Dez 2023 11:50:56 CET
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11
@@ -4301,6 +4301,9 @@ class MxmlPart {
 		string        getPartAbbr          (void) const;
 		string        cleanSpaces          (const string& input);
 		bool          hasOrnaments         (void) const;
+		
+		vector<pair<int, int>> getVoiceMapping (void) { return m_voicemapping; };
+		vector<vector<int>> getStaffVoiceHist (void) { return m_staffvoicehist; };
 
 
 	private:

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mi  6 Dez 2023 18:35:46 CET
+// Last Modified: Mi  6 Dez 2023 21:07:52 CET
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mi  6 Dez 2023 21:12:42 CET
+// Last Modified: Do  7 Dez 2023 12:23:44 CET
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11

--- a/src/HumGrid.cpp
+++ b/src/HumGrid.cpp
@@ -1980,7 +1980,7 @@ void HumGrid::checkForNullDataHoles(void) {
 							if (v >= (int)sp->size() - 1) {
 								// Found a data line with no data at given voice, so
 								// add slice duration to cumulative duration.
-								duration += slicep->getDuration();
+								// duration += slicep->getDuration();
 								continue;
 							}
 							vp = sp->at(v);

--- a/src/tool-musicxml2hum.cpp
+++ b/src/tool-musicxml2hum.cpp
@@ -1587,7 +1587,41 @@ bool Tool_musicxml2hum::convertNowEvents(GridMeasure* outdata,
 
 	appendNonZeroEvents(outdata, nowevents, nowtime, partdata);
 
+	handleFiguredBassWithoutNonZeroEvent(nowevents, nowtime);
+
 	return true;
+}
+
+
+
+/////////////////////////////
+//
+// Tool_musicxml2hum::handleFiguredBassWithoutNonZeroEvent --
+//
+
+void Tool_musicxml2hum::handleFiguredBassWithoutNonZeroEvent(vector<SimultaneousEvents*>& nowevents, HumNum nowtime) {
+	vector<int> nonZeroParts;
+	vector<MxmlEvent> floatingFiguredBass;
+	for (const SimultaneousEvents* sevent : nowevents) {
+		for (MxmlEvent* mxmlEvent : sevent->nonzerodur) {
+			nonZeroParts.push_back(mxmlEvent->getPartIndex());
+		}
+		for (MxmlEvent* mxmlEvent : sevent->zerodur) {
+			if ("figured-bass" == mxmlEvent->getElementName()) {
+				if (std::find(nonZeroParts.begin(), nonZeroParts.end(), mxmlEvent->getPartIndex()) == nonZeroParts.end()) {
+					// cerr << mxmlEvent->getNode() << "\n";
+					string fstring = getFiguredBassString(mxmlEvent->getNode());
+					HTp ftok = new HumdrumToken(fstring);
+					MusicXmlFiguredBassInfo finfo;
+					finfo.timestamp = nowtime;
+					finfo.partindex = mxmlEvent->getPartIndex();
+					finfo.token = ftok;
+					m_offsetFiguredBass.push_back(finfo);
+					// cerr << "ADD FLOATING FB NUM " << fstring << " " << nowtime << "\n";
+				}
+			}
+		}
+	}
 }
 
 

--- a/src/tool-musicxml2hum.cpp
+++ b/src/tool-musicxml2hum.cpp
@@ -185,7 +185,7 @@ bool Tool_musicxml2hum::convert(ostream& out, xml_document& doc) {
 		bool fbstate = partdata[p].hasFiguredBass();
 		if (fbstate) {
 			outdata.setFiguredBassPresent(p);
-			break;
+			// break;
 		}
 	}
 

--- a/src/tool-musicxml2hum.cpp
+++ b/src/tool-musicxml2hum.cpp
@@ -1306,6 +1306,13 @@ bool Tool_musicxml2hum::insertMeasure(HumGrid& outdata, int mnum,
 		}
 		status &= convertNowEvents(outdata.back(),
 				nowevents, nowparts, processtime, partdata, partstaves);
+
+		// Remove all figured bass numbers for this nowtime so that they are not
+		// accidentally displayed in the next nowtime, which can currently
+		// happen if there are no nonzerodur events in the same part
+		for (int i=0; i<(int)m_current_figured_bass.size(); i++) {
+			m_current_figured_bass[i].clear();
+		}
 	}
 
 	if (offsetHarmony.size() > 0) {
@@ -1579,10 +1586,6 @@ bool Tool_musicxml2hum::convertNowEvents(GridMeasure* outdata,
 	}
 
 	appendNonZeroEvents(outdata, nowevents, nowtime, partdata);
-
-	for (int i=0; i<(int)m_current_figured_bass.size(); i++) {
-		m_current_figured_bass[i].clear();
-	}
 
 	return true;
 }

--- a/src/tool-musicxml2hum.cpp
+++ b/src/tool-musicxml2hum.cpp
@@ -268,10 +268,10 @@ bool Tool_musicxml2hum::convert(ostream& out, xml_document& doc) {
 	}
 
 	// add RDFs
-	if (m_slurabove) {
+	if (m_slurabove || m_staffabove) {
 		out << "!!!RDF**kern: > = above" << endl;
 	}
-	if (m_slurbelow) {
+	if (m_slurbelow || m_staffbelow) {
 		out << "!!!RDF**kern: < = below" << endl;
 	}
 
@@ -1776,6 +1776,12 @@ void Tool_musicxml2hum::addEvent(GridSlice* slice, GridMeasure* outdata, MxmlEve
 				recip += "q";
 			}
 		}
+	}
+	
+	if (event->getCrossStaffOffset() > 0) {
+		m_staffbelow = true;
+	} else if (event->getCrossStaffOffset() < 0) {
+		m_staffabove = true;
 	}
 
 	stringstream ss;

--- a/src/tool-musicxml2hum.cpp
+++ b/src/tool-musicxml2hum.cpp
@@ -1766,7 +1766,7 @@ void Tool_musicxml2hum::addEvent(GridSlice* slice, GridMeasure* outdata, MxmlEve
 		cerr << "!!TOKEN: " << ss.str();
 		cerr << "\tTS: "    << event->getStartTime();
 		cerr << "\tDUR: "   << event->getDuration();
-		cerr << "\tSTi: "   << event->getStaffNumber();
+		cerr << "\tSTn: "   << event->getStaffNumber();
 		cerr << "\tVn: "    << event->getVoiceNumber();
 		cerr << "\tSTi: "   << event->getStaffIndex();
 		cerr << "\tVi: "    << event->getVoiceIndex();

--- a/src/tool-musicxml2hum.cpp
+++ b/src/tool-musicxml2hum.cpp
@@ -3081,6 +3081,17 @@ string Tool_musicxml2hum::getFiguredBassString(xml_node fnode) {
 		}
 	}
 
+	output = std::regex_replace(output, std::regex("^ +| +$|( ) +"), "$1");
+
+	if (output.empty()) {
+		if (children.size()) {
+			cerr << "WARNING: figured bass string is empty but has "
+				<< children.size() << " figure elements as children. "
+				<< "The output has been replaced with \".\"" << endl;
+		}
+		output = ".";
+	}
+
 	return output;
 
 	// HTp fbtok = new HumdrumToken(fbstring);

--- a/src/tool-musicxml2hum.cpp
+++ b/src/tool-musicxml2hum.cpp
@@ -1564,7 +1564,14 @@ bool Tool_musicxml2hum::convertNowEvents(GridMeasure* outdata,
 
 	appendZeroEvents(outdata, nowevents, nowtime, partdata);
 
-	if (nowevents[0]->nonzerodur.size() == 0) {
+	bool hasNonZeroDurElements = false;
+	for (const SimultaneousEvents* event : nowevents) {
+        if (event->nonzerodur.size() != 0) {
+            hasNonZeroDurElements = true;
+			break;
+        }
+    }
+	if (!hasNonZeroDurElements) {
 		// no duration events (should be a terminal barline)
 		// ignore and deal with in calling function.
 		return true;

--- a/src/tool-musicxml2hum.cpp
+++ b/src/tool-musicxml2hum.cpp
@@ -108,6 +108,7 @@ bool Tool_musicxml2hum::convert(ostream& out, xml_document& doc) {
 
 	m_current_dynamic.resize(partids.size());
 	m_current_brackets.resize(partids.size());
+	m_current_figured_bass.resize(partids.size());
 	m_stop_char.resize(partids.size(), "[");
 
 	getPartContent(partcontent, partids, doc);
@@ -2991,13 +2992,13 @@ string Tool_musicxml2hum::getDynamicString(xml_node element) {
 //
 
 int Tool_musicxml2hum::addFiguredBass(GridPart* part, MxmlEvent* event, HumNum nowtime, int partindex) {
-	if (m_current_figured_bass.empty()) {
+	if (m_current_figured_bass[partindex].empty()) {
 		return 0;
 	}
 
 	int dursum = 0;
-	for (int i=0; i<(int)m_current_figured_bass.size(); i++) {
-		xml_node fnode = m_current_figured_bass.at(i);
+	for (int i=0; i<(int)m_current_figured_bass[partindex].size(); i++) {
+		xml_node fnode = m_current_figured_bass[partindex].at(i);
 		if (!fnode) {
 			// strange problem
 			continue;
@@ -3018,11 +3019,11 @@ int Tool_musicxml2hum::addFiguredBass(GridPart* part, MxmlEvent* event, HumNum n
 			finfo.token = ftok;
 			offsetFiguredBass.push_back(finfo);
 		}
-		if (i < (int)m_current_figured_bass.size() - 1) {
+		if (i < (int)m_current_figured_bass[partindex].size() - 1) {
 			dursum += getFiguredBassDuration(fnode);
 		}
 	}
-	m_current_figured_bass.clear();
+	m_current_figured_bass[partindex].clear();
 
 	return 1;
 
@@ -3667,7 +3668,7 @@ void Tool_musicxml2hum::appendZeroEvents(GridMeasure* outdata,
 					}
 				}
 			} else if (nodeType(element, "figured-bass")) {
-				m_current_figured_bass.push_back(element);
+				m_current_figured_bass[pindex].push_back(element);
 			} else if (nodeType(element, "note")) {
 				if (foundnongrace) {
 					addEventToList(graceafter, nowevents[i]->zerodur[j]);

--- a/src/tool-musicxml2hum.cpp
+++ b/src/tool-musicxml2hum.cpp
@@ -3115,7 +3115,8 @@ string Tool_musicxml2hum::getFiguredBassString(xml_node fnode) {
 		}
 	}
 
-	output = std::regex_replace(output, std::regex("^ +| +$|( ) +"), "$1");
+	HumRegex hre;
+	hre.replaceDestructive(output, "", R"(^\s+|\s+$)");
 
 	if (output.empty()) {
 		if (children.size()) {

--- a/src/tool-musicxml2hum.cpp
+++ b/src/tool-musicxml2hum.cpp
@@ -1347,8 +1347,8 @@ void Tool_musicxml2hum::insertOffsetFiguredBassIntoMeasure(GridMeasure* gm) {
 				m_offsetFiguredBass[i].token = NULL;
 			} else if (m_offsetFiguredBass[i].timestamp < timestamp) {
 				if (beginQ) {
-					cerr << "Error: Cannot insert harmony " << offsetFiguredBass[i].token
-					     << " at timestamp " << offsetFiguredBass[i].timestamp
+					cerr << "Error: Cannot insert harmony " << m_offsetFiguredBass[i].token
+					     << " at timestamp " << m_offsetFiguredBass[i].timestamp
 					     << " since first timestamp in measure is " << timestamp << endl;
 				} else {
 					m_forceRecipQ = true;

--- a/src/tool-musicxml2hum.cpp
+++ b/src/tool-musicxml2hum.cpp
@@ -1311,7 +1311,7 @@ bool Tool_musicxml2hum::insertMeasure(HumGrid& outdata, int mnum,
 	if (offsetHarmony.size() > 0) {
 		insertOffsetHarmonyIntoMeasure(outdata.back());
 	}
-	if (offsetFiguredBass.size() > 0) {
+	if (m_offsetFiguredBass.size() > 0) {
 		insertOffsetFiguredBassIntoMeasure(outdata.back());
 	}
 	return status;
@@ -1325,7 +1325,7 @@ bool Tool_musicxml2hum::insertMeasure(HumGrid& outdata, int mnum,
 //
 
 void Tool_musicxml2hum::insertOffsetFiguredBassIntoMeasure(GridMeasure* gm) {
-	if (offsetFiguredBass.empty()) {
+	if (m_offsetFiguredBass.empty()) {
 		return;
 	}
 
@@ -1337,15 +1337,15 @@ void Tool_musicxml2hum::insertOffsetFiguredBassIntoMeasure(GridMeasure* gm) {
 			continue;
 		}
 		HumNum timestamp = gs->getTimestamp();
-		for (int i=0; i<(int)offsetFiguredBass.size(); i++) {
-			if (offsetFiguredBass[i].token == NULL) {
+		for (int i=0; i<(int)m_offsetFiguredBass.size(); i++) {
+			if (m_offsetFiguredBass[i].token == NULL) {
 				continue;
  			}
-			if (offsetFiguredBass[i].timestamp == timestamp) {
+			if (m_offsetFiguredBass[i].timestamp == timestamp) {
 				// this is the slice to insert the harmony
-				gs->at(offsetFiguredBass[i].partindex)->setFiguredBass(offsetFiguredBass[i].token);
-				offsetFiguredBass[i].token = NULL;
-			} else if (offsetFiguredBass[i].timestamp < timestamp) {
+				gs->at(m_offsetFiguredBass[i].partindex)->setFiguredBass(m_offsetFiguredBass[i].token);
+				m_offsetFiguredBass[i].token = NULL;
+			} else if (m_offsetFiguredBass[i].timestamp < timestamp) {
 				if (beginQ) {
 					cerr << "Error: Cannot insert harmony " << offsetFiguredBass[i].token
 					     << " at timestamp " << offsetFiguredBass[i].timestamp
@@ -1363,11 +1363,11 @@ void Tool_musicxml2hum::insertOffsetFiguredBassIntoMeasure(GridMeasure* gm) {
 						}
 						int partcount = (int)(*tempit)->size();
 						tempit++;
-						GridSlice* newgs = new GridSlice(gm, offsetFiguredBass[i].timestamp,
+						GridSlice* newgs = new GridSlice(gm, m_offsetFiguredBass[i].timestamp,
 								SliceType::Notes, partcount);
-						newgs->at(offsetFiguredBass[i].partindex)->setFiguredBass(offsetFiguredBass[i].token);
+						newgs->at(m_offsetFiguredBass[i].partindex)->setFiguredBass(m_offsetFiguredBass[i].token);
 						gm->insert(tempit, newgs);
-						offsetFiguredBass[i].token = NULL;
+						m_offsetFiguredBass[i].token = NULL;
 						break;
 					}
 				}
@@ -1377,19 +1377,19 @@ void Tool_musicxml2hum::insertOffsetFiguredBassIntoMeasure(GridMeasure* gm) {
 	}
 	// If there are still valid harmonies in the input list, apppend
 	// them to the end of the measure.
-	for (int i=0; i<(int)offsetFiguredBass.size(); i++) {
-		if (offsetFiguredBass[i].token == NULL) {
+	for (int i=0; i<(int)m_offsetFiguredBass.size(); i++) {
+		if (m_offsetFiguredBass[i].token == NULL) {
 			continue;
  		}
 		m_forceRecipQ = true;
 		int partcount = (int)gm->back()->size();
-		GridSlice* newgs = new GridSlice(gm, offsetFiguredBass[i].timestamp,
+		GridSlice* newgs = new GridSlice(gm, m_offsetFiguredBass[i].timestamp,
 				SliceType::Notes, partcount);
-		newgs->at(offsetFiguredBass[i].partindex)->setFiguredBass(offsetFiguredBass[i].token);
+		newgs->at(m_offsetFiguredBass[i].partindex)->setFiguredBass(m_offsetFiguredBass[i].token);
 		gm->insert(gm->end(), newgs);
-		offsetFiguredBass[i].token = NULL;
+		m_offsetFiguredBass[i].token = NULL;
 	}
-	offsetFiguredBass.clear();
+	m_offsetFiguredBass.clear();
 }
 
 
@@ -3017,7 +3017,7 @@ int Tool_musicxml2hum::addFiguredBass(GridPart* part, MxmlEvent* event, HumNum n
 			finfo.timestamp += nowtime;
 			finfo.partindex = partindex;
 			finfo.token = ftok;
-			offsetFiguredBass.push_back(finfo);
+			m_offsetFiguredBass.push_back(finfo);
 		}
 		if (i < (int)m_current_figured_bass[partindex].size() - 1) {
 			dursum += getFiguredBassDuration(fnode);

--- a/src/tool-musicxml2hum.cpp
+++ b/src/tool-musicxml2hum.cpp
@@ -2752,12 +2752,12 @@ string Tool_musicxml2hum::convertFiguredBassNumber(const xml_node& figure) {
 	// could be a flat).  At the moment do not assign the accidental, but
 	// in the future assign an accidental to the slashed figure, probably
 	// with a post-processing tool.
-	if (suffix == "cross" || prefix == "cross") {
+	if (suffix == "cross" || prefix == "cross" || suffix == "vertical" || prefix == "vertical") {
 		slash = "|";
 		if (accidental.empty()) {
 			accidental = "#";
 		}
-	} else if ((suffix == "backslash") || (prefix == "backslash")) {
+	} else if ((suffix == "backslash" || suffix == "back-slash") || (prefix == "backslash" || prefix == "back-slash")) {
 		slash = "\\";
 		if (accidental.empty()) {
 			accidental = "#";

--- a/src/tool-musicxml2hum.cpp
+++ b/src/tool-musicxml2hum.cpp
@@ -2729,7 +2729,7 @@ string Tool_musicxml2hum::convertFiguredBassNumber(const xml_node& figure) {
 		accidental = "--";
 	} else if (prefix == "flat") {
 		accidental = "-";
-	} else if (prefix == "double-sharp") {
+	} else if (prefix == "double-sharp" || prefix == "sharp-sharp") {
 		accidental = "##";
 	} else if (prefix == "sharp") {
 		accidental = "#";
@@ -2739,7 +2739,7 @@ string Tool_musicxml2hum::convertFiguredBassNumber(const xml_node& figure) {
 		accidental = "--r";
 	} else if (suffix == "flat") {
 		accidental = "-r";
-	} else if (suffix == "double-sharp") {
+	} else if (suffix == "double-sharp" || suffix == "sharp-sharp") {
 		accidental = "##r";
 	} else if (suffix == "sharp") {
 		accidental = "#r";

--- a/src/tool-musicxml2hum.cpp
+++ b/src/tool-musicxml2hum.cpp
@@ -1580,6 +1580,10 @@ bool Tool_musicxml2hum::convertNowEvents(GridMeasure* outdata,
 
 	appendNonZeroEvents(outdata, nowevents, nowtime, partdata);
 
+	for (int i=0; i<(int)m_current_figured_bass.size(); i++) {
+		m_current_figured_bass[i].clear();
+	}
+
 	return true;
 }
 

--- a/src/tool-musicxml2hum.cpp
+++ b/src/tool-musicxml2hum.cpp
@@ -1566,11 +1566,11 @@ bool Tool_musicxml2hum::convertNowEvents(GridMeasure* outdata,
 
 	bool hasNonZeroDurElements = false;
 	for (const SimultaneousEvents* event : nowevents) {
-        if (event->nonzerodur.size() != 0) {
-            hasNonZeroDurElements = true;
+		if (event->nonzerodur.size() != 0) {
+			hasNonZeroDurElements = true;
 			break;
-        }
-    }
+		}
+	}
 	if (!hasNonZeroDurElements) {
 		// no duration events (should be a terminal barline)
 		// ignore and deal with in calling function.


### PR DESCRIPTION
This PR fixes the missing data lines problem explained in https://github.com/craigsapp/humlib/issues/87.

However, it introduces a new bug. The parts and staves are now in the wrong order:

```
**kern	**kern	**kern	**kern	**fb	**kern	**kern	**kern	**kern
*part6	*part5	*part6	*part5	*part5	*part4	*part3	*part2	*part1
*staff8	*staff6	*staff7	*staff5	*	*staff4	*staff3	*staff2	*staff1
```

Expected:

```
**kern	**fb	**kern	**kern	**kern	**kern	**kern	**kern	**kern
*part6	*part6	*part6	*part5	*part5	*part4	*part3	*part2	*part1
*staff8	*	*staff7	*staff6	*staff5	*staff4	*staff3	*staff2	*staff1
```

Also note that the `**fb` spine will be attached to the wrong part and staff now. Do you have any idea how to debug this further?

---

Sourcefile: [Schiorring - 04 Af dybeﬅe Nød raaber jeg til dig.mxl.zip](https://github.com/craigsapp/humlib/files/13518648/Schiorring.-.04.Af.dybe.e.Nod.raaber.jeg.til.dig.mxl.zip)

Screenshot of the output in VHV:

<img width="927" alt="Bildschirmfoto 2023-12-04 um 11 15 44" src="https://github.com/craigsapp/humlib/assets/865594/b0979669-13ca-4930-bb46-49f4cb4d446b">

<details>
 <summary>Click to see new output of musicxml2hum</summary>

```
!!!COM: Schiørring, Niels
!!!CDT: 1743-1798
!!!OPR@@DA: Choral-Bog
!!!ONM: 4
!!!OTL@@DA: Af dybeﬅe Nød raaber jeg til dig
**kern	**kern	**kern	**kern	**fb	**kern	**kern	**kern	**kern
*part6	*part5	*part6	*part5	*part5	*part4	*part3	*part2	*part1
*staff8	*staff6	*staff7	*staff5	*	*staff4	*staff3	*staff2	*staff1
*clefF4	*clefF4	*clefC1	*clefC1	*	*clefF4	*clefC4	*clefC3	*clefC1
*mclefF4	*	*mclefG2	*mclefF4	*mclefG2	*mclefF4	*mclefGv2	*mclefG2	*mclefG2
*k[]	*k[]	*k[]	*k[]	*	*k[]	*k[]	*k[]	*k[]
*M4/4	*M4/4	*M4/4	*M4/4	*	*M4/4	*M4/4	*M4/4	*M4/4
*met(c)	*met(c)	*met(c)	*met(c)	*	*met(c)	*met(c)	*met(c)	*met(c)
*MM180	*	*MM180	*MM180	*MM180	*MM180	*MM180	*MM180	*MM180
*	*^	*	*^	*	*	*	*	*
2E	2G	2E	2b	2b	2e	.	2E	2G	2e	2b
=1	=1	=1	=1	=1	=1	=1	=1	=1	=1	=1
2G	2B	2G	2e	2e	2e	.	2G	2B	2e	2e
2E	2G	2E	2b	2b	2e	.	2E	2G	2e	2b
=2	=2	=2	=2	=2	=2	=2	=2	=2	=2	=2
2AA	2A	2AA	2cc	2cc	2e	.	2AA	2A	2e	2cc
2BB	2F#X	2BB	4b	4b	2d#X	.	2BB	2F#X	2d#X	(4b
.	.	.	4a	4a	.	.	.	.	.	4a)
=3	=3	=3	=3	=3	=3	=3	=3	=3	=3	=3
1C	1E	1C	2g	2g	1e	.	2C	2E	2e	2g
.	.	.	2a	2a	.	.	2C	2A	2e	2a
=4	=4	=4	=4	=4	=4	=4	=4	=4	=4	=4
2BB	2F#X	2BB	2b	2b	2d#X	.	2BB	2F#X	2d#X	2b
2E	2G#X	2E	2b	2b	2e	.	2E	2G#X	2e	2b
=5	=5	=5	=5	=5	=5	=5	=5	=5	=5	=5
2A	[2A	2A	2cc	2cc	2e	.	2A	2A	2e	2cc
2D	4A]	2Dni	2dd	2ddni	2fni	.	2D	(4A	2f	2dd
.	4B	.	.	.	.	6	.	4B)	.	.
=6	=6	=6	=6	=6	=6	=6	=6	=6	=6	=6
2E	2.c	2E	2cc	2cc	2g	.	2E	2c	2g	2cc
2F	.	2F	2a	2a	2f	.	2F	(4c	2f	2a
.	4d	.	.	.	.	6	.	4d)	.	.
=7	=7	=7	=7	=7	=7	=7	=7	=7	=7	=7
2C#X	4ryy	2C#X	(2g	4e	2e	.	(2C#X	(4e	(2e	(2g
.	4A	.	.	4ryy	.	.	.	2A	.	.
2D	2A	2D	2f)	2f	4d	.	2D)	.	4d	2f)
.	.	.	.	.	4cni	.	.	4A)	4c)	.
=	=	=	=	=	=	=	=	=	=	=
2E	2G#X	2E	2e	2e	2B	.	2E	2G#X	2B	2e
=8:|!	=8:|!	=8:|!	=8:|!	=8:|!	=8:|!	=8:|!	=8:|!	=8:|!	=8:|!	=8:|!
[2F	2A	[2F	2a	2a	2d	.	[2F	2A	2d	2a
=9	=9	=9	=9	=9	=9	=9	=9	=9	=9	=9
2F]	2B	2F]	2g	2g	2d	.	2F]	2B	2d	2g
*	*	*	*	*	*^	*	*	*	*	*
4E	4c	4E	2cc	2cc	4g	4e\	.	(4E	(4c	(4g	2cc
4F#X	4A	4F#X	.	.	4a	4d\	.	4F#X)	4A)	4a)	.
=10	=10	=10	=10	=10	=10	=10	=10	=10	=10	=10	=10
1G	2d	2G	2b	2b	4g	2d\	.	2G	2d	(4g	2b
.	.	.	.	.	4fni	.	n7	.	.	4f)	.
.	2A	2G	2a	2a	2e	2c#X\	.	2G	2c#X	2e	2a
*	*	*	*	*	*v	*v	*	*	*	*	*
=11	=11	=11	=11	=11	=11	=11	=11	=11	=11	=11
4F	2.A	4F	4dd	4dd	4d	.	(4F	(4d	[2a	(4dd
4E	.	4E	4cc	4ccni	4e	.	4E)	4e)	.	4cc)
4D	.	4D	2b	2b	4f	.	(4D	(4f	(4a]	2b
4E	4G#X	4E	.	.	4e	.	4E)	4e)	4g#X)	.
=12	=12	=12	=12	=12	=12	=12	=12	=12	=12	=12
*	*	*	*	*	*^	*	*	*	*	*
2AA	2A	2AA	2a	2a	2c	2e/	.	2AA	2c	2a	2a
*	*	*	*	*	*v	*v	*	*	*	*	*
2F#X	2A	2F#X	2cc	2cc	2d	.	2F#X	2d	2a	2cc
=13	=13	=13	=13	=13	=13	=13	=13	=13	=13	=13
2G	2G	2G	2b	2b	2d	.	2G	2d	2g	2b
2C	2G	2C	2cc	2cc	2e	.	2C	2e	2g	2cc
=14	=14	=14	=14	=14	=14	=14	=14	=14	=14	=14
2BB	2G	2BB	2dd	2dd	2d	.	2BB	2d	2g	2dd
2E	2G	2E	2g	2g	2B	.	2E	2B	[2g	2g
=15	=15	=15	=15	=15	=15	=15	=15	=15	=15	=15
2AA	2.G	2AA	2cc	2cc	2e	.	2AA	2c	2g]	2cc
2D	.	2D	2a	2a	2d	.	2D	2d	(4g	2a
.	4F#X	.	.	.	.	#	.	.	4f#X)	.
=16	=16	=16	=16	=16	=16	=16	=16	=16	=16	=16
*	*	*	*	*	*^	*	*	*	*	*
2GG	2G	2GG	2g	2g	2B	2d/	.	2GG	2B	2g	2g
*	*	*	*	*	*v	*v	*	*	*	*	*
2F	2B	2Fni	2g	2g	2d	.	2F	2B	2d	2g
=17	=17	=17	=17	=17	=17	=17	=17	=17	=17	=17
2E	2c	2E	2cc	2cc	2g	.	2E	2c	2g	2cc
4D	4d	4D	2b	2b	4f	.	(4D	(4d	(4f	2b
4E	4G	4E	.	.	4g	.	4E)	4G)	4e)	.
=18	=18	=18	=18	=18	=18	=18	=18	=18	=18	=18
4F	2c	4F	2a	2a	2f	.	(4F	2A	2c	2a
4G	.	4G	.	.	.	.	4G)	.	.	.
2A	2A	2A	2e	2e	2c	.	2A	2A	2c	2e
=19	=19	=19	=19	=19	=19	=19	=19	=19	=19	=19
2C#X	1A	2C#X	(2g	2g	2e	.	(2C#X	1A	(2e	(2g
2D	.	2D	2f)	2f	4d	.	2D)	.	4d	2f)
.	.	.	.	.	4cni	7	.	.	4c)	.
=20	=20	=20	=20	=20	=20	=20	=20	=20	=20	=20
2E	2G#X	2E	2e	2e	2B	.	2E	2G#X	2B	2e
*	*v	*v	*	*	*	*	*	*	*	*
*	*	*	*v	*v	*	*	*	*	*
==	==	==	==	==	==	==	==	==
*-	*-	*-	*-	*-	*-	*-	*-	*-
!!!system-decoration: {(s1,s2,s3,s4)}{(s5,s6)}{(s7,s8)}
!!!RDF**kern: i = editorial accidental
!!!RDF**kern: > = above
!!!RDF**kern: < = below
!!!AGN: chorale
!!!EED: Derek Remeš
!!!EED2: Victor Phan
!!!END: 2023/11/28
!!!ENC: Wolfgang Drescher
!!!EEV: 2023/12/04
!!!title: @{ONM}. @{OTL}
```

</details>