### PR TITLE
[myank] Keep *part and *staff interpretations

### DIFF
--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Tue Dec 12 11:01:04 PST 2023
+// Last Modified: Di 19 Dez 2023 10:29:03 CET
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -105906,6 +105906,31 @@ void Tool_myank::printStarting(HumdrumFile& infile) {
 			if (infile[i].rfind("!!!RDF", 0) == 0) {
 				m_humdrum_text << infile[i] << "\n";
 			}
+		}
+	}
+
+	// keep *part interpretations
+	bool hasPart = false;
+	for (i=exi+1; i<infile.getLineCount(); i++) {
+		hasPart = false;
+		for (j=0; j<infile[i].getFieldCount(); j++) {
+			if (infile.token(i, j)->compare(0, 5, "*part") == 0) {
+				hasPart = true;
+				break;
+			}
+		}
+		if (hasPart) {
+			for (j=0; j<infile[i].getFieldCount(); j++) {
+				if (infile.token(i, j)->compare(0, 5, "*part") == 0) {
+					m_humdrum_text << infile.token(i, j);
+				} else {
+					m_humdrum_text << "*";
+				}
+				if (j < infile[i].getFieldCount() - 1) {
+					m_humdrum_text << "\t";
+				}
+			}
+			m_humdrum_text << "\n";
 		}
 	}
 

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Di 19 Dez 2023 10:29:03 CET
+// Last Modified: Di 19 Dez 2023 10:30:08 CET
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -105922,6 +105922,31 @@ void Tool_myank::printStarting(HumdrumFile& infile) {
 		if (hasPart) {
 			for (j=0; j<infile[i].getFieldCount(); j++) {
 				if (infile.token(i, j)->compare(0, 5, "*part") == 0) {
+					m_humdrum_text << infile.token(i, j);
+				} else {
+					m_humdrum_text << "*";
+				}
+				if (j < infile[i].getFieldCount() - 1) {
+					m_humdrum_text << "\t";
+				}
+			}
+			m_humdrum_text << "\n";
+		}
+	}
+
+	// keep *staff interpretations
+	bool hasStaff = false;
+	for (i=exi+1; i<infile.getLineCount(); i++) {
+		hasStaff = false;
+		for (j=0; j<infile[i].getFieldCount(); j++) {
+			if (infile.token(i, j)->compare(0, 6, "*staff") == 0) {
+				hasStaff = true;
+				break;
+			}
+		}
+		if (hasStaff) {
+			for (j=0; j<infile[i].getFieldCount(); j++) {
+				if (infile.token(i, j)->compare(0, 6, "*staff") == 0) {
 					m_humdrum_text << infile.token(i, j);
 				} else {
 					m_humdrum_text << "*";

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Di 19 Dez 2023 10:30:08 CET
+// Last Modified: Di 19 Dez 2023 10:33:13 CET
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -105903,7 +105903,7 @@ void Tool_myank::printStarting(HumdrumFile& infile) {
 		if (!m_hideStarting) {
 			m_humdrum_text << infile[i] << "\n";
 		} else {
-			if (infile[i].rfind("!!!RDF", 0) == 0) {
+			if (infile[i].rfind("!!!RDF", 0) == 0 || infile[i].rfind("!!!system-decoration", 0) == 0) {
 				m_humdrum_text << infile[i] << "\n";
 			}
 		}
@@ -106049,7 +106049,7 @@ void Tool_myank::printEnding(HumdrumFile& infile, int lastline, int adjlin) {
 	if (startline >= 0) {
 		for (i=startline; i<infile.getLineCount(); i++) {
 			if (m_hideEnding && (i > ending)) {
-				if (infile[i].rfind("!!!RDF", 0) == 0) {
+				if (infile[i].rfind("!!!RDF", 0) == 0 || infile[i].rfind("!!!system-decoration", 0) == 0) {
 					m_humdrum_text << infile[i] << "\n";
 				}
 			} else {

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Di 19 Dez 2023 10:30:08 CET
+// Last Modified: Di 19 Dez 2023 10:33:13 CET
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Di 19 Dez 2023 10:29:03 CET
+// Last Modified: Di 19 Dez 2023 10:30:08 CET
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Tue Dec 12 11:01:04 PST 2023
+// Last Modified: Di 19 Dez 2023 10:29:03 CET
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11

--- a/src/tool-myank.cpp
+++ b/src/tool-myank.cpp
@@ -1743,6 +1743,31 @@ void Tool_myank::printStarting(HumdrumFile& infile) {
 		}
 	}
 
+	// keep *staff interpretations
+	bool hasStaff = false;
+	for (i=exi+1; i<infile.getLineCount(); i++) {
+		hasStaff = false;
+		for (j=0; j<infile[i].getFieldCount(); j++) {
+			if (infile.token(i, j)->compare(0, 6, "*staff") == 0) {
+				hasStaff = true;
+				break;
+			}
+		}
+		if (hasStaff) {
+			for (j=0; j<infile[i].getFieldCount(); j++) {
+				if (infile.token(i, j)->compare(0, 6, "*staff") == 0) {
+					m_humdrum_text << infile.token(i, j);
+				} else {
+					m_humdrum_text << "*";
+				}
+				if (j < infile[i].getFieldCount() - 1) {
+					m_humdrum_text << "\t";
+				}
+			}
+			m_humdrum_text << "\n";
+		}
+	}
+
 	int hasI = 0;
 
 	if (m_instrumentQ) {

--- a/src/tool-myank.cpp
+++ b/src/tool-myank.cpp
@@ -1718,6 +1718,31 @@ void Tool_myank::printStarting(HumdrumFile& infile) {
 		}
 	}
 
+	// keep *part interpretations
+	bool hasPart = false;
+	for (i=exi+1; i<infile.getLineCount(); i++) {
+		hasPart = false;
+		for (j=0; j<infile[i].getFieldCount(); j++) {
+			if (infile.token(i, j)->compare(0, 5, "*part") == 0) {
+				hasPart = true;
+				break;
+			}
+		}
+		if (hasPart) {
+			for (j=0; j<infile[i].getFieldCount(); j++) {
+				if (infile.token(i, j)->compare(0, 5, "*part") == 0) {
+					m_humdrum_text << infile.token(i, j);
+				} else {
+					m_humdrum_text << "*";
+				}
+				if (j < infile[i].getFieldCount() - 1) {
+					m_humdrum_text << "\t";
+				}
+			}
+			m_humdrum_text << "\n";
+		}
+	}
+
 	int hasI = 0;
 
 	if (m_instrumentQ) {

--- a/src/tool-myank.cpp
+++ b/src/tool-myank.cpp
@@ -1712,7 +1712,7 @@ void Tool_myank::printStarting(HumdrumFile& infile) {
 		if (!m_hideStarting) {
 			m_humdrum_text << infile[i] << "\n";
 		} else {
-			if (infile[i].rfind("!!!RDF", 0) == 0) {
+			if (infile[i].rfind("!!!RDF", 0) == 0 || infile[i].rfind("!!!system-decoration", 0) == 0) {
 				m_humdrum_text << infile[i] << "\n";
 			}
 		}
@@ -1858,7 +1858,7 @@ void Tool_myank::printEnding(HumdrumFile& infile, int lastline, int adjlin) {
 	if (startline >= 0) {
 		for (i=startline; i<infile.getLineCount(); i++) {
 			if (m_hideEnding && (i > ending)) {
-				if (infile[i].rfind("!!!RDF", 0) == 0) {
+				if (infile[i].rfind("!!!RDF", 0) == 0 || infile[i].rfind("!!!system-decoration", 0) == 0) {
 					m_humdrum_text << infile[i] << "\n";
 				}
 			} else {


### PR DESCRIPTION
The `*part` and `*staff` interpretations were always removed with `myank`. In this PR, these interpretations are now always preserved in the output.

Additionally, the `!!!system-decoration` line is kept when `--hide-ending` or `--hide-starting` is used.

It would be nice to merge this into Verovio. Should I open a PR for the merge?