### PR TITLE
[myank] Keep `*mclef`, `*oclef`, `*mmet` and `*omet` interpretations

### DIFF
--- a/include/tool-myank.h
+++ b/include/tool-myank.h
@@ -33,20 +33,26 @@ class MeasureInfo {
 	public:
 		MeasureInfo(void) { clear(); }
 		void clear(void)  { num = seg = start = stop = -1;
-			sclef.resize(0); skeysig.resize(0); skey.resize(0);
+			sclef.resize(0); smclef.resize(0); soclef.resize(0);
+			skeysig.resize(0); skey.resize(0);
 			stimesig.resize(0); smet.resize(0); stempo.resize(0);
-			eclef.resize(0); ekeysig.resize(0); ekey.resize(0);
+			eclef.resize(0); emclef.resize(0); eoclef.resize(0);
+			ekeysig.resize(0); ekey.resize(0);
 			etimesig.resize(0); emet.resize(0); etempo.resize(0);
 			file = NULL;
 		}
 		void setTrackCount(int tcount) {
 			sclef.resize(tcount+1);
+			smclef.resize(tcount+1);
+			soclef.resize(tcount+1);
 			skeysig.resize(tcount+1);
 			skey.resize(tcount+1);
 			stimesig.resize(tcount+1);
 			smet.resize(tcount+1);
 			stempo.resize(tcount+1);
 			eclef.resize(tcount+1);
+			emclef.resize(tcount+1);
+			eoclef.resize(tcount+1);
 			ekeysig.resize(tcount+1);
 			ekey.resize(tcount+1);
 			etimesig.resize(tcount+1);
@@ -55,12 +61,16 @@ class MeasureInfo {
 			int i;
 			for (i=0; i<tcount+1; i++) {
 				sclef[i].clear();
+				smclef[i].clear();
+				soclef[i].clear();
 				skeysig[i].clear();
 				skey[i].clear();
 				stimesig[i].clear();
 				smet[i].clear();
 				stempo[i].clear();
 				eclef[i].clear();
+				emclef[i].clear();
+				eoclef[i].clear();
 				ekeysig[i].clear();
 				ekey[i].clear();
 				etimesig[i].clear();
@@ -80,6 +90,8 @@ class MeasureInfo {
 
 		// musical settings at start of measure
 		vector<MyCoord> sclef;     // starting clef of segment
+		vector<MyCoord> smclef;    // starting mclef of segment
+		vector<MyCoord> soclef;    // starting oclef of segment
 		vector<MyCoord> skeysig;   // starting keysig of segment
 		vector<MyCoord> skey;      // starting key of segment
 		vector<MyCoord> stimesig;  // starting timesig of segment
@@ -88,6 +100,8 @@ class MeasureInfo {
 
 		// musical settings at start of measure
 		vector<MyCoord> eclef;     // ending clef    of segment
+		vector<MyCoord> emclef;    // ending mclef   of segment
+		vector<MyCoord> eoclef;    // ending oclef   of segment
 		vector<MyCoord> ekeysig;   // ending keysig  of segment
 		vector<MyCoord> ekey;      // ending key     of segment
 		vector<MyCoord> etimesig;  // ending timesig of segment

--- a/include/tool-myank.h
+++ b/include/tool-myank.h
@@ -34,11 +34,11 @@ class MeasureInfo {
 		MeasureInfo(void) { clear(); }
 		void clear(void)  { num = seg = start = stop = -1;
 			sclef.resize(0); smclef.resize(0); soclef.resize(0);
-			skeysig.resize(0); skey.resize(0);
-			stimesig.resize(0); smet.resize(0); stempo.resize(0);
+			smet.resize(0); smmet.resize(0); somet.resize(0);
+			skeysig.resize(0); skey.resize(0); stimesig.resize(0); stempo.resize(0);
 			eclef.resize(0); emclef.resize(0); eoclef.resize(0);
-			ekeysig.resize(0); ekey.resize(0);
-			etimesig.resize(0); emet.resize(0); etempo.resize(0);
+			emet.resize(0); emmet.resize(0); eomet.resize(0);
+			ekeysig.resize(0); ekey.resize(0); etimesig.resize(0); etempo.resize(0);
 			file = NULL;
 		}
 		void setTrackCount(int tcount) {
@@ -49,6 +49,8 @@ class MeasureInfo {
 			skey.resize(tcount+1);
 			stimesig.resize(tcount+1);
 			smet.resize(tcount+1);
+			smmet.resize(tcount+1);
+			somet.resize(tcount+1);
 			stempo.resize(tcount+1);
 			eclef.resize(tcount+1);
 			emclef.resize(tcount+1);
@@ -57,6 +59,8 @@ class MeasureInfo {
 			ekey.resize(tcount+1);
 			etimesig.resize(tcount+1);
 			emet.resize(tcount+1);
+			emmet.resize(tcount+1);
+			eomet.resize(tcount+1);
 			etempo.resize(tcount+1);
 			int i;
 			for (i=0; i<tcount+1; i++) {
@@ -67,6 +71,8 @@ class MeasureInfo {
 				skey[i].clear();
 				stimesig[i].clear();
 				smet[i].clear();
+				smmet[i].clear();
+				somet[i].clear();
 				stempo[i].clear();
 				eclef[i].clear();
 				emclef[i].clear();
@@ -75,6 +81,8 @@ class MeasureInfo {
 				ekey[i].clear();
 				etimesig[i].clear();
 				emet[i].clear();
+				emmet[i].clear();
+				eomet[i].clear();
 				etempo[i].clear();
 			}
 			tracks = tcount;
@@ -96,6 +104,8 @@ class MeasureInfo {
 		vector<MyCoord> skey;      // starting key of segment
 		vector<MyCoord> stimesig;  // starting timesig of segment
 		vector<MyCoord> smet;      // starting met of segment
+		vector<MyCoord> smmet;     // starting mmet of segment
+		vector<MyCoord> somet;     // starting omet of segment
 		vector<MyCoord> stempo;    // starting tempo of segment
 
 		// musical settings at start of measure
@@ -106,6 +116,8 @@ class MeasureInfo {
 		vector<MyCoord> ekey;      // ending key     of segment
 		vector<MyCoord> etimesig;  // ending timesig of segment
 		vector<MyCoord> emet;      // ending met     of segment
+		vector<MyCoord> emmet;     // ending mmet    of segment
+		vector<MyCoord> eomet;     // ending omet    of segment
 		vector<MyCoord> etempo;    // ending tempo   of segment
 };
 
@@ -158,8 +170,10 @@ class Tool_myank : public HumTool {
 		void      insertZerothMeasure  (vector<MeasureInfo>& measurelist,
 		                                HumdrumFile& infile);
 		void      getMetStates         (vector<vector<MyCoord> >& metstates,
+										vector<vector<MyCoord> >& mmetstates,
+										vector<vector<MyCoord> >& ometstates,
 		                                HumdrumFile& infile);
-		MyCoord   getLocalMetInfo      (HumdrumFile& infile, int row, int track);
+		MyCoord   getLocalMetInfo      (HumdrumFile& infile, int row, int track, string prefix = "");
 		int       atEndOfFile          (HumdrumFile& infile, int line);
 		void      processFile          (HumdrumFile& infile);
 		int       getSectionCount      (HumdrumFile& infile);
@@ -194,6 +208,8 @@ class Tool_myank : public HumTool {
 		vector<MeasureInfo> m_measureOutList; // used with -m option
 		vector<MeasureInfo> m_measureInList;  // used with -m option
 		vector<vector<MyCoord> > m_metstates;
+		vector<vector<MyCoord> > m_mmetstates;
+		vector<vector<MyCoord> > m_ometstates;
 
 		string      m_lineRange;              // used with -l option
 		vector<int> m_barNumbersPerLine;      // used with -l option

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Tue Feb  6 22:50:09 PST 2024
+// Last Modified: Mo 12 Feb 2024 13:00:50 CET
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -105137,6 +105137,8 @@ void Tool_myank::adjustGlobalInterpretations(HumdrumFile& infile, int ii,
 	//   }
 
 	int clefQ    = 0;
+	int mclefQ   = 0;
+	int oclefQ   = 0;
 	int keysigQ  = 0;
 	int keyQ     = 0;
 	int timesigQ = 0;
@@ -105167,6 +105169,30 @@ void Tool_myank::adjustGlobalInterpretations(HumdrumFile& infile, int ii,
 			if ((x>=0)&&(y>=0)&&(xo>=0)&&(yo>=0)) {
 				if (*infile.token(x, y) != *infile.token(xo, yo)) {
 					clefQ = 1;
+				}
+			}
+		}
+
+		if (!mclefQ && (outmeasures[index].smclef.size() > 0)) {
+			x  = outmeasures[index].smclef[i].x;
+			y  = outmeasures[index].smclef[i].y;
+			xo = outmeasures[index-1].emclef[i].x;
+			yo = outmeasures[index-1].emclef[i].y;
+			if ((x>=0)&&(y>=0)&&(xo>=0)&&(yo>=0)) {
+				if (*infile.token(x, y) != *infile.token(xo, yo)) {
+					mclefQ = 1;
+				}
+			}
+		}
+
+		if (!oclefQ && (outmeasures[index].soclef.size() > 0)) {
+			x  = outmeasures[index].soclef[i].x;
+			y  = outmeasures[index].soclef[i].y;
+			xo = outmeasures[index-1].eoclef[i].x;
+			yo = outmeasures[index-1].eoclef[i].y;
+			if ((x>=0)&&(y>=0)&&(xo>=0)&&(yo>=0)) {
+				if (*infile.token(x, y) != *infile.token(xo, yo)) {
+					oclefQ = 1;
 				}
 			}
 		}
@@ -105241,6 +105267,52 @@ void Tool_myank::adjustGlobalInterpretations(HumdrumFile& infile, int ii,
 			y  = outmeasures[index].sclef[track].y;
 			xo = outmeasures[index-1].eclef[track].x;
 			yo = outmeasures[index-1].eclef[track].y;
+			if ((x>=0)&&(y>=0)&&(xo>=0)&&(yo>=0)) {
+				if (*infile.token(x, y) != *infile.token(xo, yo)) {
+					m_humdrum_text << infile.token(x, y);
+				} else {
+					m_humdrum_text << "*";
+				}
+			} else {
+				m_humdrum_text << "*";
+			}
+			if (i < infile[ii].getFieldCount()-1) {
+				m_humdrum_text << "\t";
+			}
+		}
+		m_humdrum_text << "\n";
+	}
+
+	if (mclefQ) {
+		for (int i=0; i<infile[ii].getFieldCount(); i++) {
+			track = infile.token(ii, i)->getTrack();
+			x  = outmeasures[index].smclef[track].x;
+			y  = outmeasures[index].smclef[track].y;
+			xo = outmeasures[index-1].emclef[track].x;
+			yo = outmeasures[index-1].emclef[track].y;
+			if ((x>=0)&&(y>=0)&&(xo>=0)&&(yo>=0)) {
+				if (*infile.token(x, y) != *infile.token(xo, yo)) {
+					m_humdrum_text << infile.token(x, y);
+				} else {
+					m_humdrum_text << "*";
+				}
+			} else {
+				m_humdrum_text << "*";
+			}
+			if (i < infile[ii].getFieldCount()-1) {
+				m_humdrum_text << "\t";
+			}
+		}
+		m_humdrum_text << "\n";
+	}
+
+	if (oclefQ) {
+		for (int i=0; i<infile[ii].getFieldCount(); i++) {
+			track = infile.token(ii, i)->getTrack();
+			x  = outmeasures[index].soclef[track].x;
+			y  = outmeasures[index].soclef[track].y;
+			xo = outmeasures[index-1].eoclef[track].x;
+			yo = outmeasures[index-1].eoclef[track].y;
 			if ((x>=0)&&(y>=0)&&(xo>=0)&&(yo>=0)) {
 				if (*infile.token(x, y) != *infile.token(xo, yo)) {
 					m_humdrum_text << infile.token(x, y);
@@ -105391,6 +105463,8 @@ void Tool_myank::adjustGlobalInterpretationsStart(HumdrumFile& infile, int ii,
 	int i;
 
 	int clefQ    = 0;
+	int mclefQ   = 0;
+	int oclefQ   = 0;
 	int keysigQ  = 0;
 	int keyQ     = 0;
 	int timesigQ = 0;
@@ -105416,6 +105490,24 @@ void Tool_myank::adjustGlobalInterpretationsStart(HumdrumFile& infile, int ii,
 
 			if ((x>=0)&&(y>=0)) {
 				clefQ = 1;
+			}
+		}
+
+		if (!mclefQ) {
+			x  = outmeasures[index].smclef[i].x;
+			y  = outmeasures[index].smclef[i].y;
+
+			if ((x>=0)&&(y>=0)) {
+				mclefQ = 1;
+			}
+		}
+
+		if (!oclefQ) {
+			x  = outmeasures[index].soclef[i].x;
+			y  = outmeasures[index].soclef[i].y;
+
+			if ((x>=0)&&(y>=0)) {
+				oclefQ = 1;
 			}
 		}
 
@@ -105467,6 +105559,40 @@ void Tool_myank::adjustGlobalInterpretationsStart(HumdrumFile& infile, int ii,
 			ptrack = infile.token(ii, i)->getTrack();
 			x  = outmeasures[index].sclef[ptrack].x;
 			y  = outmeasures[index].sclef[ptrack].y;
+			if ((x>=0)&&(y>=0)) {
+				m_humdrum_text << infile.token(x, y);
+			} else {
+				m_humdrum_text << "*";
+			}
+			if (i < infile[ii].getFieldCount()-1) {
+				m_humdrum_text << "\t";
+			}
+		}
+		m_humdrum_text << "\n";
+	}
+
+	if (mclefQ) {
+		for (i=0; i<infile[ii].getFieldCount(); i++) {
+			ptrack = infile.token(ii, i)->getTrack();
+			x  = outmeasures[index].smclef[ptrack].x;
+			y  = outmeasures[index].smclef[ptrack].y;
+			if ((x>=0)&&(y>=0)) {
+				m_humdrum_text << infile.token(x, y);
+			} else {
+				m_humdrum_text << "*";
+			}
+			if (i < infile[ii].getFieldCount()-1) {
+				m_humdrum_text << "\t";
+			}
+		}
+		m_humdrum_text << "\n";
+	}
+
+	if (oclefQ) {
+		for (i=0; i<infile[ii].getFieldCount(); i++) {
+			ptrack = infile.token(ii, i)->getTrack();
+			x  = outmeasures[index].soclef[ptrack].x;
+			y  = outmeasures[index].soclef[ptrack].y;
 			if ((x>=0)&&(y>=0)) {
 				m_humdrum_text << infile.token(x, y);
 			} else {
@@ -106485,6 +106611,8 @@ void Tool_myank::fillGlobalDefaults(HumdrumFile& infile, vector<MeasureInfo>& me
 	// cerr << "MAX TRACKS " << tracks << " ===============================" << endl;
 
 	vector<MyCoord> currclef(tracks+1);
+	vector<MyCoord> currmclef(tracks+1);
+	vector<MyCoord> curroclef(tracks+1);
 	vector<MyCoord> currkeysig(tracks+1);
 	vector<MyCoord> currkey(tracks+1);
 	vector<MyCoord> currtimesig(tracks+1);
@@ -106495,6 +106623,8 @@ void Tool_myank::fillGlobalDefaults(HumdrumFile& infile, vector<MeasureInfo>& me
 	undefMyCoord.clear();
 
 	fill(currclef.begin(), currclef.end(), undefMyCoord);
+	fill(currmclef.begin(), currmclef.end(), undefMyCoord);
+	fill(curroclef.begin(), curroclef.end(), undefMyCoord);
 	fill(currkeysig.begin(), currkeysig.end(), undefMyCoord);
 	fill(currkey.begin(), currkey.end(), undefMyCoord);
 	fill(currtimesig.begin(), currtimesig.end(), undefMyCoord);
@@ -106520,6 +106650,8 @@ void Tool_myank::fillGlobalDefaults(HumdrumFile& infile, vector<MeasureInfo>& me
 			// store state of global music values at end of measure
 			if (currmeasure >= 0) {
 				measurein[inmap[currmeasure]].eclef    = currclef;
+				measurein[inmap[currmeasure]].emclef   = currmclef;
+				measurein[inmap[currmeasure]].eoclef   = curroclef;
 				measurein[inmap[currmeasure]].ekeysig  = currkeysig;
 				measurein[inmap[currmeasure]].ekey     = currkey;
 				measurein[inmap[currmeasure]].etimesig = currtimesig;
@@ -106544,6 +106676,8 @@ void Tool_myank::fillGlobalDefaults(HumdrumFile& infile, vector<MeasureInfo>& me
 // }
 // cerr << endl;
 				measurein[inmap[currmeasure]].sclef    = currclef;
+				measurein[inmap[currmeasure]].smclef   = currmclef;
+				measurein[inmap[currmeasure]].soclef   = curroclef;
 				measurein[inmap[currmeasure]].skeysig  = currkeysig;
 				measurein[inmap[currmeasure]].skey     = currkey;
 				measurein[inmap[currmeasure]].stimesig = currtimesig;
@@ -106566,6 +106700,12 @@ void Tool_myank::fillGlobalDefaults(HumdrumFile& infile, vector<MeasureInfo>& me
 					if (infile.token(i, j)->compare(0, 5, "*clef") == 0) {
 						measurein[inmap[currmeasure]].sclef[track].x = -1;
 						measurein[inmap[currmeasure]].sclef[track].y = -1;
+					} else if (infile.token(i, j)->compare(0, 6, "*mclef") == 0) {
+						measurein[inmap[currmeasure]].smclef[track].x = -1;
+						measurein[inmap[currmeasure]].smclef[track].y = -1;
+					} else if (infile.token(i, j)->compare(0, 6, "*oclef") == 0) {
+						measurein[inmap[currmeasure]].soclef[track].x = -1;
+						measurein[inmap[currmeasure]].soclef[track].y = -1;
 					} else if (hre.search(infile.token(i, j), "^\\*k\\[.*\\]", "")) {
 						measurein[inmap[currmeasure]].skeysig[track].x = -1;
 						measurein[inmap[currmeasure]].skeysig[track].y = -1;
@@ -106587,6 +106727,16 @@ void Tool_myank::fillGlobalDefaults(HumdrumFile& infile, vector<MeasureInfo>& me
 				if (infile.token(i, j)->compare(0, 5, "*clef") == 0) {
 					currclef[track].x = i;
 					currclef[track].y = j;
+					continue;
+				}
+				if (infile.token(i, j)->compare(0, 6, "*mclef") == 0) {
+					currmclef[track].x = i;
+					currmclef[track].y = j;
+					continue;
+				}
+				if (infile.token(i, j)->compare(0, 6, "*oclef") == 0) {
+					curroclef[track].x = i;
+					curroclef[track].y = j;
 					continue;
 				}
 				if (hre.search(infile.token(i, j), R"(^\*k\[.*\])")) {
@@ -106626,6 +106776,8 @@ void Tool_myank::fillGlobalDefaults(HumdrumFile& infile, vector<MeasureInfo>& me
 	if ((currmeasure >= 0) && (currmeasure < (int)inmap.size())
 			&& (inmap[currmeasure] >= 0)) {
 		measurein[inmap[currmeasure]].eclef    = currclef;
+		measurein[inmap[currmeasure]].emclef   = currmclef;
+		measurein[inmap[currmeasure]].eoclef   = curroclef;
 		measurein[inmap[currmeasure]].ekeysig  = currkeysig;
 		measurein[inmap[currmeasure]].ekey     = currkey;
 		measurein[inmap[currmeasure]].etimesig = currtimesig;
@@ -106640,17 +106792,49 @@ void Tool_myank::fillGlobalDefaults(HumdrumFile& infile, vector<MeasureInfo>& me
 			measurein[i].sclef.resize(tracks+1);
 			fill(measurein[i].sclef.begin(), measurein[i].sclef.end(), undefMyCoord);
 		}
+		if (measurein[i].smclef.size() == 0) {
+			measurein[i].smclef.resize(tracks+1);
+			fill(measurein[i].smclef.begin(), measurein[i].smclef.end(), undefMyCoord);
+		}
+		if (measurein[i].soclef.size() == 0) {
+			measurein[i].soclef.resize(tracks+1);
+			fill(measurein[i].soclef.begin(), measurein[i].soclef.end(), undefMyCoord);
+		}
 		if (measurein[i].eclef.size() == 0) {
 			measurein[i].eclef.resize(tracks+1);
 			fill(measurein[i].eclef.begin(), measurein[i].eclef.end(), undefMyCoord);
+		}
+		if (measurein[i].emclef.size() == 0) {
+			measurein[i].emclef.resize(tracks+1);
+			fill(measurein[i].emclef.begin(), measurein[i].emclef.end(), undefMyCoord);
+		}
+		if (measurein[i].eoclef.size() == 0) {
+			measurein[i].eoclef.resize(tracks+1);
+			fill(measurein[i].eoclef.begin(), measurein[i].eoclef.end(), undefMyCoord);
 		}
 		if (measurein[i+1].sclef.size() == 0) {
 			measurein[i+1].sclef.resize(tracks+1);
 			fill(measurein[i+1].sclef.begin(), measurein[i+1].sclef.end(), undefMyCoord);
 		}
+		if (measurein[i+1].smclef.size() == 0) {
+			measurein[i+1].smclef.resize(tracks+1);
+			fill(measurein[i+1].smclef.begin(), measurein[i+1].smclef.end(), undefMyCoord);
+		}
+		if (measurein[i+1].soclef.size() == 0) {
+			measurein[i+1].soclef.resize(tracks+1);
+			fill(measurein[i+1].soclef.begin(), measurein[i+1].soclef.end(), undefMyCoord);
+		}
 		if (measurein[i+1].eclef.size() == 0) {
 			measurein[i+1].eclef.resize(tracks+1);
 			fill(measurein[i+1].eclef.begin(), measurein[i+1].eclef.end(), undefMyCoord);
+		}
+		if (measurein[i+1].emclef.size() == 0) {
+			measurein[i+1].emclef.resize(tracks+1);
+			fill(measurein[i+1].emclef.begin(), measurein[i+1].emclef.end(), undefMyCoord);
+		}
+		if (measurein[i+1].eoclef.size() == 0) {
+			measurein[i+1].eoclef.resize(tracks+1);
+			fill(measurein[i+1].eoclef.begin(), measurein[i+1].eoclef.end(), undefMyCoord);
 		}
 		for (j=1; j<(int)measurein[i].sclef.size(); j++) {
 			if (!measurein[i].eclef[j].isValid()) {
@@ -106661,6 +106845,30 @@ void Tool_myank::fillGlobalDefaults(HumdrumFile& infile, vector<MeasureInfo>& me
 			if (!measurein[i+1].sclef[j].isValid()) {
 				if (measurein[i].eclef[j].isValid()) {
 					measurein[i+1].sclef[j] = measurein[i].eclef[j];
+				}
+			}
+		}
+		for (j=1; j<(int)measurein[i].smclef.size(); j++) {
+			if (!measurein[i].emclef[j].isValid()) {
+				if (measurein[i].smclef[j].isValid()) {
+					measurein[i].emclef[j] = measurein[i].smclef[j];
+				}
+			}
+			if (!measurein[i+1].smclef[j].isValid()) {
+				if (measurein[i].emclef[j].isValid()) {
+					measurein[i+1].smclef[j] = measurein[i].emclef[j];
+				}
+			}
+		}
+		for (j=1; j<(int)measurein[i].soclef.size(); j++) {
+			if (!measurein[i].eoclef[j].isValid()) {
+				if (measurein[i].soclef[j].isValid()) {
+					measurein[i].eoclef[j] = measurein[i].soclef[j];
+				}
+			}
+			if (!measurein[i+1].soclef[j].isValid()) {
+				if (measurein[i].eoclef[j].isValid()) {
+					measurein[i+1].soclef[j] = measurein[i].eoclef[j];
 				}
 			}
 		}
@@ -106880,6 +107088,8 @@ void Tool_myank::processFieldEntry(vector<MeasureInfo>& field,
 					current.stop = inmeasures[inmap[i]].stop;
 
 					current.sclef    = inmeasures[inmap[i]].sclef;
+					current.smclef   = inmeasures[inmap[i]].smclef;
+					current.soclef   = inmeasures[inmap[i]].soclef;
 					current.skeysig  = inmeasures[inmap[i]].skeysig;
 					current.skey     = inmeasures[inmap[i]].skey;
 					current.stimesig = inmeasures[inmap[i]].stimesig;
@@ -106887,6 +107097,8 @@ void Tool_myank::processFieldEntry(vector<MeasureInfo>& field,
 					current.stempo   = inmeasures[inmap[i]].stempo;
 
 					current.eclef    = inmeasures[inmap[i]].eclef;
+					current.emclef   = inmeasures[inmap[i]].emclef;
+					current.eoclef   = inmeasures[inmap[i]].eoclef;
 					current.ekeysig  = inmeasures[inmap[i]].ekeysig;
 					current.ekey     = inmeasures[inmap[i]].ekey;
 					current.etimesig = inmeasures[inmap[i]].etimesig;
@@ -106907,6 +107119,8 @@ void Tool_myank::processFieldEntry(vector<MeasureInfo>& field,
 					current.stop = inmeasures[inmap[i]].stop;
 
 					current.sclef    = inmeasures[inmap[i]].sclef;
+					current.smclef   = inmeasures[inmap[i]].smclef;
+					current.soclef   = inmeasures[inmap[i]].soclef;
 					current.skeysig  = inmeasures[inmap[i]].skeysig;
 					current.skey     = inmeasures[inmap[i]].skey;
 					current.stimesig = inmeasures[inmap[i]].stimesig;
@@ -106914,6 +107128,8 @@ void Tool_myank::processFieldEntry(vector<MeasureInfo>& field,
 					current.stempo   = inmeasures[inmap[i]].stempo;
 
 					current.eclef    = inmeasures[inmap[i]].eclef;
+					current.emclef   = inmeasures[inmap[i]].emclef;
+					current.eoclef   = inmeasures[inmap[i]].eoclef;
 					current.ekeysig  = inmeasures[inmap[i]].ekeysig;
 					current.ekey     = inmeasures[inmap[i]].ekey;
 					current.etimesig = inmeasures[inmap[i]].etimesig;
@@ -106943,6 +107159,8 @@ void Tool_myank::processFieldEntry(vector<MeasureInfo>& field,
 			current.stop = inmeasures[inmap[value]].stop;
 
 			current.sclef    = inmeasures[inmap[value]].sclef;
+			current.smclef   = inmeasures[inmap[value]].smclef;
+			current.soclef   = inmeasures[inmap[value]].soclef;
 			current.skeysig  = inmeasures[inmap[value]].skeysig;
 			current.skey     = inmeasures[inmap[value]].skey;
 			current.stimesig = inmeasures[inmap[value]].stimesig;
@@ -106950,6 +107168,8 @@ void Tool_myank::processFieldEntry(vector<MeasureInfo>& field,
 			current.stempo   = inmeasures[inmap[value]].stempo;
 
 			current.eclef    = inmeasures[inmap[value]].eclef;
+			current.emclef   = inmeasures[inmap[value]].emclef;
+			current.eoclef   = inmeasures[inmap[value]].eoclef;
 			current.ekeysig  = inmeasures[inmap[value]].ekeysig;
 			current.ekey     = inmeasures[inmap[value]].ekey;
 			current.etimesig = inmeasures[inmap[value]].etimesig;

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mo 12 Feb 2024 13:00:50 CET
+// Last Modified: Mo 12 Feb 2024 14:12:06 CET
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11
@@ -9240,11 +9240,11 @@ class MeasureInfo {
 		MeasureInfo(void) { clear(); }
 		void clear(void)  { num = seg = start = stop = -1;
 			sclef.resize(0); smclef.resize(0); soclef.resize(0);
-			skeysig.resize(0); skey.resize(0);
-			stimesig.resize(0); smet.resize(0); stempo.resize(0);
+			smet.resize(0); smmet.resize(0); somet.resize(0);
+			skeysig.resize(0); skey.resize(0); stimesig.resize(0); stempo.resize(0);
 			eclef.resize(0); emclef.resize(0); eoclef.resize(0);
-			ekeysig.resize(0); ekey.resize(0);
-			etimesig.resize(0); emet.resize(0); etempo.resize(0);
+			emet.resize(0); emmet.resize(0); eomet.resize(0);
+			ekeysig.resize(0); ekey.resize(0); etimesig.resize(0); etempo.resize(0);
 			file = NULL;
 		}
 		void setTrackCount(int tcount) {
@@ -9255,6 +9255,8 @@ class MeasureInfo {
 			skey.resize(tcount+1);
 			stimesig.resize(tcount+1);
 			smet.resize(tcount+1);
+			smmet.resize(tcount+1);
+			somet.resize(tcount+1);
 			stempo.resize(tcount+1);
 			eclef.resize(tcount+1);
 			emclef.resize(tcount+1);
@@ -9263,6 +9265,8 @@ class MeasureInfo {
 			ekey.resize(tcount+1);
 			etimesig.resize(tcount+1);
 			emet.resize(tcount+1);
+			emmet.resize(tcount+1);
+			eomet.resize(tcount+1);
 			etempo.resize(tcount+1);
 			int i;
 			for (i=0; i<tcount+1; i++) {
@@ -9273,6 +9277,8 @@ class MeasureInfo {
 				skey[i].clear();
 				stimesig[i].clear();
 				smet[i].clear();
+				smmet[i].clear();
+				somet[i].clear();
 				stempo[i].clear();
 				eclef[i].clear();
 				emclef[i].clear();
@@ -9281,6 +9287,8 @@ class MeasureInfo {
 				ekey[i].clear();
 				etimesig[i].clear();
 				emet[i].clear();
+				emmet[i].clear();
+				eomet[i].clear();
 				etempo[i].clear();
 			}
 			tracks = tcount;
@@ -9302,6 +9310,8 @@ class MeasureInfo {
 		vector<MyCoord> skey;      // starting key of segment
 		vector<MyCoord> stimesig;  // starting timesig of segment
 		vector<MyCoord> smet;      // starting met of segment
+		vector<MyCoord> smmet;     // starting mmet of segment
+		vector<MyCoord> somet;     // starting omet of segment
 		vector<MyCoord> stempo;    // starting tempo of segment
 
 		// musical settings at start of measure
@@ -9312,6 +9322,8 @@ class MeasureInfo {
 		vector<MyCoord> ekey;      // ending key     of segment
 		vector<MyCoord> etimesig;  // ending timesig of segment
 		vector<MyCoord> emet;      // ending met     of segment
+		vector<MyCoord> emmet;     // ending mmet    of segment
+		vector<MyCoord> eomet;     // ending omet    of segment
 		vector<MyCoord> etempo;    // ending tempo   of segment
 };
 
@@ -9364,8 +9376,10 @@ class Tool_myank : public HumTool {
 		void      insertZerothMeasure  (vector<MeasureInfo>& measurelist,
 		                                HumdrumFile& infile);
 		void      getMetStates         (vector<vector<MyCoord> >& metstates,
+										vector<vector<MyCoord> >& mmetstates,
+										vector<vector<MyCoord> >& ometstates,
 		                                HumdrumFile& infile);
-		MyCoord   getLocalMetInfo      (HumdrumFile& infile, int row, int track);
+		MyCoord   getLocalMetInfo      (HumdrumFile& infile, int row, int track, string prefix = "");
 		int       atEndOfFile          (HumdrumFile& infile, int line);
 		void      processFile          (HumdrumFile& infile);
 		int       getSectionCount      (HumdrumFile& infile);
@@ -9400,6 +9414,8 @@ class Tool_myank : public HumTool {
 		vector<MeasureInfo> m_measureOutList; // used with -m option
 		vector<MeasureInfo> m_measureInList;  // used with -m option
 		vector<vector<MyCoord> > m_metstates;
+		vector<vector<MyCoord> > m_mmetstates;
+		vector<vector<MyCoord> > m_ometstates;
 
 		string      m_lineRange;              // used with -l option
 		vector<int> m_barNumbersPerLine;      // used with -l option

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Tue Feb  6 22:50:09 PST 2024
+// Last Modified: Mo 12 Feb 2024 13:00:50 CET
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11
@@ -9239,20 +9239,26 @@ class MeasureInfo {
 	public:
 		MeasureInfo(void) { clear(); }
 		void clear(void)  { num = seg = start = stop = -1;
-			sclef.resize(0); skeysig.resize(0); skey.resize(0);
+			sclef.resize(0); smclef.resize(0); soclef.resize(0);
+			skeysig.resize(0); skey.resize(0);
 			stimesig.resize(0); smet.resize(0); stempo.resize(0);
-			eclef.resize(0); ekeysig.resize(0); ekey.resize(0);
+			eclef.resize(0); emclef.resize(0); eoclef.resize(0);
+			ekeysig.resize(0); ekey.resize(0);
 			etimesig.resize(0); emet.resize(0); etempo.resize(0);
 			file = NULL;
 		}
 		void setTrackCount(int tcount) {
 			sclef.resize(tcount+1);
+			smclef.resize(tcount+1);
+			soclef.resize(tcount+1);
 			skeysig.resize(tcount+1);
 			skey.resize(tcount+1);
 			stimesig.resize(tcount+1);
 			smet.resize(tcount+1);
 			stempo.resize(tcount+1);
 			eclef.resize(tcount+1);
+			emclef.resize(tcount+1);
+			eoclef.resize(tcount+1);
 			ekeysig.resize(tcount+1);
 			ekey.resize(tcount+1);
 			etimesig.resize(tcount+1);
@@ -9261,12 +9267,16 @@ class MeasureInfo {
 			int i;
 			for (i=0; i<tcount+1; i++) {
 				sclef[i].clear();
+				smclef[i].clear();
+				soclef[i].clear();
 				skeysig[i].clear();
 				skey[i].clear();
 				stimesig[i].clear();
 				smet[i].clear();
 				stempo[i].clear();
 				eclef[i].clear();
+				emclef[i].clear();
+				eoclef[i].clear();
 				ekeysig[i].clear();
 				ekey[i].clear();
 				etimesig[i].clear();
@@ -9286,6 +9296,8 @@ class MeasureInfo {
 
 		// musical settings at start of measure
 		vector<MyCoord> sclef;     // starting clef of segment
+		vector<MyCoord> smclef;    // starting mclef of segment
+		vector<MyCoord> soclef;    // starting oclef of segment
 		vector<MyCoord> skeysig;   // starting keysig of segment
 		vector<MyCoord> skey;      // starting key of segment
 		vector<MyCoord> stimesig;  // starting timesig of segment
@@ -9294,6 +9306,8 @@ class MeasureInfo {
 
 		// musical settings at start of measure
 		vector<MyCoord> eclef;     // ending clef    of segment
+		vector<MyCoord> emclef;    // ending mclef   of segment
+		vector<MyCoord> eoclef;    // ending oclef   of segment
 		vector<MyCoord> ekeysig;   // ending keysig  of segment
 		vector<MyCoord> ekey;      // ending key     of segment
 		vector<MyCoord> etimesig;  // ending timesig of segment

--- a/src/tool-myank.cpp
+++ b/src/tool-myank.cpp
@@ -889,6 +889,8 @@ void Tool_myank::adjustGlobalInterpretations(HumdrumFile& infile, int ii,
 	//   }
 
 	int clefQ    = 0;
+	int mclefQ   = 0;
+	int oclefQ   = 0;
 	int keysigQ  = 0;
 	int keyQ     = 0;
 	int timesigQ = 0;
@@ -919,6 +921,30 @@ void Tool_myank::adjustGlobalInterpretations(HumdrumFile& infile, int ii,
 			if ((x>=0)&&(y>=0)&&(xo>=0)&&(yo>=0)) {
 				if (*infile.token(x, y) != *infile.token(xo, yo)) {
 					clefQ = 1;
+				}
+			}
+		}
+
+		if (!mclefQ && (outmeasures[index].smclef.size() > 0)) {
+			x  = outmeasures[index].smclef[i].x;
+			y  = outmeasures[index].smclef[i].y;
+			xo = outmeasures[index-1].emclef[i].x;
+			yo = outmeasures[index-1].emclef[i].y;
+			if ((x>=0)&&(y>=0)&&(xo>=0)&&(yo>=0)) {
+				if (*infile.token(x, y) != *infile.token(xo, yo)) {
+					mclefQ = 1;
+				}
+			}
+		}
+
+		if (!oclefQ && (outmeasures[index].soclef.size() > 0)) {
+			x  = outmeasures[index].soclef[i].x;
+			y  = outmeasures[index].soclef[i].y;
+			xo = outmeasures[index-1].eoclef[i].x;
+			yo = outmeasures[index-1].eoclef[i].y;
+			if ((x>=0)&&(y>=0)&&(xo>=0)&&(yo>=0)) {
+				if (*infile.token(x, y) != *infile.token(xo, yo)) {
+					oclefQ = 1;
 				}
 			}
 		}
@@ -993,6 +1019,52 @@ void Tool_myank::adjustGlobalInterpretations(HumdrumFile& infile, int ii,
 			y  = outmeasures[index].sclef[track].y;
 			xo = outmeasures[index-1].eclef[track].x;
 			yo = outmeasures[index-1].eclef[track].y;
+			if ((x>=0)&&(y>=0)&&(xo>=0)&&(yo>=0)) {
+				if (*infile.token(x, y) != *infile.token(xo, yo)) {
+					m_humdrum_text << infile.token(x, y);
+				} else {
+					m_humdrum_text << "*";
+				}
+			} else {
+				m_humdrum_text << "*";
+			}
+			if (i < infile[ii].getFieldCount()-1) {
+				m_humdrum_text << "\t";
+			}
+		}
+		m_humdrum_text << "\n";
+	}
+
+	if (mclefQ) {
+		for (int i=0; i<infile[ii].getFieldCount(); i++) {
+			track = infile.token(ii, i)->getTrack();
+			x  = outmeasures[index].smclef[track].x;
+			y  = outmeasures[index].smclef[track].y;
+			xo = outmeasures[index-1].emclef[track].x;
+			yo = outmeasures[index-1].emclef[track].y;
+			if ((x>=0)&&(y>=0)&&(xo>=0)&&(yo>=0)) {
+				if (*infile.token(x, y) != *infile.token(xo, yo)) {
+					m_humdrum_text << infile.token(x, y);
+				} else {
+					m_humdrum_text << "*";
+				}
+			} else {
+				m_humdrum_text << "*";
+			}
+			if (i < infile[ii].getFieldCount()-1) {
+				m_humdrum_text << "\t";
+			}
+		}
+		m_humdrum_text << "\n";
+	}
+
+	if (oclefQ) {
+		for (int i=0; i<infile[ii].getFieldCount(); i++) {
+			track = infile.token(ii, i)->getTrack();
+			x  = outmeasures[index].soclef[track].x;
+			y  = outmeasures[index].soclef[track].y;
+			xo = outmeasures[index-1].eoclef[track].x;
+			yo = outmeasures[index-1].eoclef[track].y;
 			if ((x>=0)&&(y>=0)&&(xo>=0)&&(yo>=0)) {
 				if (*infile.token(x, y) != *infile.token(xo, yo)) {
 					m_humdrum_text << infile.token(x, y);
@@ -1143,6 +1215,8 @@ void Tool_myank::adjustGlobalInterpretationsStart(HumdrumFile& infile, int ii,
 	int i;
 
 	int clefQ    = 0;
+	int mclefQ   = 0;
+	int oclefQ   = 0;
 	int keysigQ  = 0;
 	int keyQ     = 0;
 	int timesigQ = 0;
@@ -1168,6 +1242,24 @@ void Tool_myank::adjustGlobalInterpretationsStart(HumdrumFile& infile, int ii,
 
 			if ((x>=0)&&(y>=0)) {
 				clefQ = 1;
+			}
+		}
+
+		if (!mclefQ) {
+			x  = outmeasures[index].smclef[i].x;
+			y  = outmeasures[index].smclef[i].y;
+
+			if ((x>=0)&&(y>=0)) {
+				mclefQ = 1;
+			}
+		}
+
+		if (!oclefQ) {
+			x  = outmeasures[index].soclef[i].x;
+			y  = outmeasures[index].soclef[i].y;
+
+			if ((x>=0)&&(y>=0)) {
+				oclefQ = 1;
 			}
 		}
 
@@ -1219,6 +1311,40 @@ void Tool_myank::adjustGlobalInterpretationsStart(HumdrumFile& infile, int ii,
 			ptrack = infile.token(ii, i)->getTrack();
 			x  = outmeasures[index].sclef[ptrack].x;
 			y  = outmeasures[index].sclef[ptrack].y;
+			if ((x>=0)&&(y>=0)) {
+				m_humdrum_text << infile.token(x, y);
+			} else {
+				m_humdrum_text << "*";
+			}
+			if (i < infile[ii].getFieldCount()-1) {
+				m_humdrum_text << "\t";
+			}
+		}
+		m_humdrum_text << "\n";
+	}
+
+	if (mclefQ) {
+		for (i=0; i<infile[ii].getFieldCount(); i++) {
+			ptrack = infile.token(ii, i)->getTrack();
+			x  = outmeasures[index].smclef[ptrack].x;
+			y  = outmeasures[index].smclef[ptrack].y;
+			if ((x>=0)&&(y>=0)) {
+				m_humdrum_text << infile.token(x, y);
+			} else {
+				m_humdrum_text << "*";
+			}
+			if (i < infile[ii].getFieldCount()-1) {
+				m_humdrum_text << "\t";
+			}
+		}
+		m_humdrum_text << "\n";
+	}
+
+	if (oclefQ) {
+		for (i=0; i<infile[ii].getFieldCount(); i++) {
+			ptrack = infile.token(ii, i)->getTrack();
+			x  = outmeasures[index].soclef[ptrack].x;
+			y  = outmeasures[index].soclef[ptrack].y;
 			if ((x>=0)&&(y>=0)) {
 				m_humdrum_text << infile.token(x, y);
 			} else {
@@ -2237,6 +2363,8 @@ void Tool_myank::fillGlobalDefaults(HumdrumFile& infile, vector<MeasureInfo>& me
 	// cerr << "MAX TRACKS " << tracks << " ===============================" << endl;
 
 	vector<MyCoord> currclef(tracks+1);
+	vector<MyCoord> currmclef(tracks+1);
+	vector<MyCoord> curroclef(tracks+1);
 	vector<MyCoord> currkeysig(tracks+1);
 	vector<MyCoord> currkey(tracks+1);
 	vector<MyCoord> currtimesig(tracks+1);
@@ -2247,6 +2375,8 @@ void Tool_myank::fillGlobalDefaults(HumdrumFile& infile, vector<MeasureInfo>& me
 	undefMyCoord.clear();
 
 	fill(currclef.begin(), currclef.end(), undefMyCoord);
+	fill(currmclef.begin(), currmclef.end(), undefMyCoord);
+	fill(curroclef.begin(), curroclef.end(), undefMyCoord);
 	fill(currkeysig.begin(), currkeysig.end(), undefMyCoord);
 	fill(currkey.begin(), currkey.end(), undefMyCoord);
 	fill(currtimesig.begin(), currtimesig.end(), undefMyCoord);
@@ -2272,6 +2402,8 @@ void Tool_myank::fillGlobalDefaults(HumdrumFile& infile, vector<MeasureInfo>& me
 			// store state of global music values at end of measure
 			if (currmeasure >= 0) {
 				measurein[inmap[currmeasure]].eclef    = currclef;
+				measurein[inmap[currmeasure]].emclef   = currmclef;
+				measurein[inmap[currmeasure]].eoclef   = curroclef;
 				measurein[inmap[currmeasure]].ekeysig  = currkeysig;
 				measurein[inmap[currmeasure]].ekey     = currkey;
 				measurein[inmap[currmeasure]].etimesig = currtimesig;
@@ -2296,6 +2428,8 @@ void Tool_myank::fillGlobalDefaults(HumdrumFile& infile, vector<MeasureInfo>& me
 // }
 // cerr << endl;
 				measurein[inmap[currmeasure]].sclef    = currclef;
+				measurein[inmap[currmeasure]].smclef   = currmclef;
+				measurein[inmap[currmeasure]].soclef   = curroclef;
 				measurein[inmap[currmeasure]].skeysig  = currkeysig;
 				measurein[inmap[currmeasure]].skey     = currkey;
 				measurein[inmap[currmeasure]].stimesig = currtimesig;
@@ -2318,6 +2452,12 @@ void Tool_myank::fillGlobalDefaults(HumdrumFile& infile, vector<MeasureInfo>& me
 					if (infile.token(i, j)->compare(0, 5, "*clef") == 0) {
 						measurein[inmap[currmeasure]].sclef[track].x = -1;
 						measurein[inmap[currmeasure]].sclef[track].y = -1;
+					} else if (infile.token(i, j)->compare(0, 6, "*mclef") == 0) {
+						measurein[inmap[currmeasure]].smclef[track].x = -1;
+						measurein[inmap[currmeasure]].smclef[track].y = -1;
+					} else if (infile.token(i, j)->compare(0, 6, "*oclef") == 0) {
+						measurein[inmap[currmeasure]].soclef[track].x = -1;
+						measurein[inmap[currmeasure]].soclef[track].y = -1;
 					} else if (hre.search(infile.token(i, j), "^\\*k\\[.*\\]", "")) {
 						measurein[inmap[currmeasure]].skeysig[track].x = -1;
 						measurein[inmap[currmeasure]].skeysig[track].y = -1;
@@ -2339,6 +2479,16 @@ void Tool_myank::fillGlobalDefaults(HumdrumFile& infile, vector<MeasureInfo>& me
 				if (infile.token(i, j)->compare(0, 5, "*clef") == 0) {
 					currclef[track].x = i;
 					currclef[track].y = j;
+					continue;
+				}
+				if (infile.token(i, j)->compare(0, 6, "*mclef") == 0) {
+					currmclef[track].x = i;
+					currmclef[track].y = j;
+					continue;
+				}
+				if (infile.token(i, j)->compare(0, 6, "*oclef") == 0) {
+					curroclef[track].x = i;
+					curroclef[track].y = j;
 					continue;
 				}
 				if (hre.search(infile.token(i, j), R"(^\*k\[.*\])")) {
@@ -2378,6 +2528,8 @@ void Tool_myank::fillGlobalDefaults(HumdrumFile& infile, vector<MeasureInfo>& me
 	if ((currmeasure >= 0) && (currmeasure < (int)inmap.size())
 			&& (inmap[currmeasure] >= 0)) {
 		measurein[inmap[currmeasure]].eclef    = currclef;
+		measurein[inmap[currmeasure]].emclef   = currmclef;
+		measurein[inmap[currmeasure]].eoclef   = curroclef;
 		measurein[inmap[currmeasure]].ekeysig  = currkeysig;
 		measurein[inmap[currmeasure]].ekey     = currkey;
 		measurein[inmap[currmeasure]].etimesig = currtimesig;
@@ -2392,17 +2544,49 @@ void Tool_myank::fillGlobalDefaults(HumdrumFile& infile, vector<MeasureInfo>& me
 			measurein[i].sclef.resize(tracks+1);
 			fill(measurein[i].sclef.begin(), measurein[i].sclef.end(), undefMyCoord);
 		}
+		if (measurein[i].smclef.size() == 0) {
+			measurein[i].smclef.resize(tracks+1);
+			fill(measurein[i].smclef.begin(), measurein[i].smclef.end(), undefMyCoord);
+		}
+		if (measurein[i].soclef.size() == 0) {
+			measurein[i].soclef.resize(tracks+1);
+			fill(measurein[i].soclef.begin(), measurein[i].soclef.end(), undefMyCoord);
+		}
 		if (measurein[i].eclef.size() == 0) {
 			measurein[i].eclef.resize(tracks+1);
 			fill(measurein[i].eclef.begin(), measurein[i].eclef.end(), undefMyCoord);
+		}
+		if (measurein[i].emclef.size() == 0) {
+			measurein[i].emclef.resize(tracks+1);
+			fill(measurein[i].emclef.begin(), measurein[i].emclef.end(), undefMyCoord);
+		}
+		if (measurein[i].eoclef.size() == 0) {
+			measurein[i].eoclef.resize(tracks+1);
+			fill(measurein[i].eoclef.begin(), measurein[i].eoclef.end(), undefMyCoord);
 		}
 		if (measurein[i+1].sclef.size() == 0) {
 			measurein[i+1].sclef.resize(tracks+1);
 			fill(measurein[i+1].sclef.begin(), measurein[i+1].sclef.end(), undefMyCoord);
 		}
+		if (measurein[i+1].smclef.size() == 0) {
+			measurein[i+1].smclef.resize(tracks+1);
+			fill(measurein[i+1].smclef.begin(), measurein[i+1].smclef.end(), undefMyCoord);
+		}
+		if (measurein[i+1].soclef.size() == 0) {
+			measurein[i+1].soclef.resize(tracks+1);
+			fill(measurein[i+1].soclef.begin(), measurein[i+1].soclef.end(), undefMyCoord);
+		}
 		if (measurein[i+1].eclef.size() == 0) {
 			measurein[i+1].eclef.resize(tracks+1);
 			fill(measurein[i+1].eclef.begin(), measurein[i+1].eclef.end(), undefMyCoord);
+		}
+		if (measurein[i+1].emclef.size() == 0) {
+			measurein[i+1].emclef.resize(tracks+1);
+			fill(measurein[i+1].emclef.begin(), measurein[i+1].emclef.end(), undefMyCoord);
+		}
+		if (measurein[i+1].eoclef.size() == 0) {
+			measurein[i+1].eoclef.resize(tracks+1);
+			fill(measurein[i+1].eoclef.begin(), measurein[i+1].eoclef.end(), undefMyCoord);
 		}
 		for (j=1; j<(int)measurein[i].sclef.size(); j++) {
 			if (!measurein[i].eclef[j].isValid()) {
@@ -2413,6 +2597,30 @@ void Tool_myank::fillGlobalDefaults(HumdrumFile& infile, vector<MeasureInfo>& me
 			if (!measurein[i+1].sclef[j].isValid()) {
 				if (measurein[i].eclef[j].isValid()) {
 					measurein[i+1].sclef[j] = measurein[i].eclef[j];
+				}
+			}
+		}
+		for (j=1; j<(int)measurein[i].smclef.size(); j++) {
+			if (!measurein[i].emclef[j].isValid()) {
+				if (measurein[i].smclef[j].isValid()) {
+					measurein[i].emclef[j] = measurein[i].smclef[j];
+				}
+			}
+			if (!measurein[i+1].smclef[j].isValid()) {
+				if (measurein[i].emclef[j].isValid()) {
+					measurein[i+1].smclef[j] = measurein[i].emclef[j];
+				}
+			}
+		}
+		for (j=1; j<(int)measurein[i].soclef.size(); j++) {
+			if (!measurein[i].eoclef[j].isValid()) {
+				if (measurein[i].soclef[j].isValid()) {
+					measurein[i].eoclef[j] = measurein[i].soclef[j];
+				}
+			}
+			if (!measurein[i+1].soclef[j].isValid()) {
+				if (measurein[i].eoclef[j].isValid()) {
+					measurein[i+1].soclef[j] = measurein[i].eoclef[j];
 				}
 			}
 		}
@@ -2632,6 +2840,8 @@ void Tool_myank::processFieldEntry(vector<MeasureInfo>& field,
 					current.stop = inmeasures[inmap[i]].stop;
 
 					current.sclef    = inmeasures[inmap[i]].sclef;
+					current.smclef   = inmeasures[inmap[i]].smclef;
+					current.soclef   = inmeasures[inmap[i]].soclef;
 					current.skeysig  = inmeasures[inmap[i]].skeysig;
 					current.skey     = inmeasures[inmap[i]].skey;
 					current.stimesig = inmeasures[inmap[i]].stimesig;
@@ -2639,6 +2849,8 @@ void Tool_myank::processFieldEntry(vector<MeasureInfo>& field,
 					current.stempo   = inmeasures[inmap[i]].stempo;
 
 					current.eclef    = inmeasures[inmap[i]].eclef;
+					current.emclef   = inmeasures[inmap[i]].emclef;
+					current.eoclef   = inmeasures[inmap[i]].eoclef;
 					current.ekeysig  = inmeasures[inmap[i]].ekeysig;
 					current.ekey     = inmeasures[inmap[i]].ekey;
 					current.etimesig = inmeasures[inmap[i]].etimesig;
@@ -2659,6 +2871,8 @@ void Tool_myank::processFieldEntry(vector<MeasureInfo>& field,
 					current.stop = inmeasures[inmap[i]].stop;
 
 					current.sclef    = inmeasures[inmap[i]].sclef;
+					current.smclef   = inmeasures[inmap[i]].smclef;
+					current.soclef   = inmeasures[inmap[i]].soclef;
 					current.skeysig  = inmeasures[inmap[i]].skeysig;
 					current.skey     = inmeasures[inmap[i]].skey;
 					current.stimesig = inmeasures[inmap[i]].stimesig;
@@ -2666,6 +2880,8 @@ void Tool_myank::processFieldEntry(vector<MeasureInfo>& field,
 					current.stempo   = inmeasures[inmap[i]].stempo;
 
 					current.eclef    = inmeasures[inmap[i]].eclef;
+					current.emclef   = inmeasures[inmap[i]].emclef;
+					current.eoclef   = inmeasures[inmap[i]].eoclef;
 					current.ekeysig  = inmeasures[inmap[i]].ekeysig;
 					current.ekey     = inmeasures[inmap[i]].ekey;
 					current.etimesig = inmeasures[inmap[i]].etimesig;
@@ -2695,6 +2911,8 @@ void Tool_myank::processFieldEntry(vector<MeasureInfo>& field,
 			current.stop = inmeasures[inmap[value]].stop;
 
 			current.sclef    = inmeasures[inmap[value]].sclef;
+			current.smclef   = inmeasures[inmap[value]].smclef;
+			current.soclef   = inmeasures[inmap[value]].soclef;
 			current.skeysig  = inmeasures[inmap[value]].skeysig;
 			current.skey     = inmeasures[inmap[value]].skey;
 			current.stimesig = inmeasures[inmap[value]].stimesig;
@@ -2702,6 +2920,8 @@ void Tool_myank::processFieldEntry(vector<MeasureInfo>& field,
 			current.stempo   = inmeasures[inmap[value]].stempo;
 
 			current.eclef    = inmeasures[inmap[value]].eclef;
+			current.emclef   = inmeasures[inmap[value]].emclef;
+			current.eoclef   = inmeasures[inmap[value]].eoclef;
 			current.ekeysig  = inmeasures[inmap[value]].ekeysig;
 			current.ekey     = inmeasures[inmap[value]].ekey;
 			current.etimesig = inmeasures[inmap[value]].etimesig;

--- a/src/tool-myank.cpp
+++ b/src/tool-myank.cpp
@@ -249,7 +249,7 @@ void Tool_myank::processFile(HumdrumFile& infile) {
 		return;
 	}
 
-	getMetStates(m_metstates, infile);
+	getMetStates(m_metstates, m_mmetstates, m_ometstates, infile);
 	getMeasureStartStop(m_measureInList, infile);
 
 	string measurestring = getString("measures");
@@ -420,11 +420,17 @@ string Tool_myank::expandMultipliers(const string& inputstring) {
 // in the score, keeping track of meter without metric symbols.
 //
 
-void Tool_myank::getMetStates(vector<vector<MyCoord> >& metstates,
-		HumdrumFile& infile) {
+void Tool_myank::getMetStates(vector<vector<MyCoord> >& metstates, vector<vector<MyCoord> >& mmetstates,
+	vector<vector<MyCoord> >& ometstates, HumdrumFile& infile) {
 	vector<MyCoord> current;
+	vector<MyCoord> mcurrent;
+	vector<MyCoord> ocurrent;
 	current.resize(infile.getMaxTrack()+1);
+	mcurrent.resize(infile.getMaxTrack()+1);
+	ocurrent.resize(infile.getMaxTrack()+1);
 	metstates.resize(infile.getLineCount());
+	mmetstates.resize(infile.getLineCount());
+	ometstates.resize(infile.getLineCount());
 	HumRegex hre;
 
 	int track;
@@ -435,8 +441,16 @@ void Tool_myank::getMetStates(vector<vector<MyCoord> >& metstates,
 				if (hre.search(infile.token(i, j), R"(^\*met\([^\)]+\))")) {
 					current[track].x = i;
 					current[track].y = j;
+				} else if (hre.search(infile.token(i, j), R"(^\*mmet\([^\)]+\))")) {
+					mcurrent[track].x = i;
+					mcurrent[track].y = j;
+				} else if (hre.search(infile.token(i, j), R"(^\*omet\([^\)]+\))")) {
+					ocurrent[track].x = i;
+					ocurrent[track].y = j;
 				} else if (hre.search(infile.token(i, j), R"(^\*M\d+\d+)")) {
 					current[track] = getLocalMetInfo(infile, i, track);
+					mcurrent[track] = getLocalMetInfo(infile, i, track, "m");
+					ocurrent[track] = getLocalMetInfo(infile, i, track, "o");
 				}
 			}
 		}
@@ -447,8 +461,12 @@ void Tool_myank::getMetStates(vector<vector<MyCoord> >& metstates,
 		//    metstates[i][j] = current[track];
 		// }
 		metstates[i].resize(infile.getMaxTrack()+1);
+		mmetstates[i].resize(infile.getMaxTrack()+1);
+		ometstates[i].resize(infile.getMaxTrack()+1);
 		for (int j=1; j<=infile.getMaxTrack(); j++) {
 			metstates[i][j] = current[j];
+			mmetstates[i][j] = mcurrent[j];
+			ometstates[i][j] = ocurrent[j];
 		}
 	}
 
@@ -477,7 +495,7 @@ void Tool_myank::getMetStates(vector<vector<MyCoord> >& metstates,
 // value if none found.
 //
 
-MyCoord Tool_myank::getLocalMetInfo(HumdrumFile& infile, int row, int track) {
+MyCoord Tool_myank::getLocalMetInfo(HumdrumFile& infile, int row, int track, string prefix) {
 	MyCoord output;
 	int startline = -1;
 	int stopline = -1;
@@ -516,7 +534,7 @@ MyCoord Tool_myank::getLocalMetInfo(HumdrumFile& infile, int row, int track) {
 			if (track != xtrac) {
 				continue;
 			}
-			if (hre.search(infile.token(i, j), R"(^\*met\([^\)]+\))")) {
+			if (hre.search(infile.token(i, j), R"(^\*)" + prefix + R"(met\([^\)]+\))")) {
 				output.x = i;
 				output.x = j;
 			}
@@ -895,6 +913,8 @@ void Tool_myank::adjustGlobalInterpretations(HumdrumFile& infile, int ii,
 	int keyQ     = 0;
 	int timesigQ = 0;
 	int metQ     = 0;
+	int mmetQ    = 0;
+	int ometQ    = 0;
 	int tempoQ   = 0;
 
 	int x, y;
@@ -993,6 +1013,30 @@ void Tool_myank::adjustGlobalInterpretations(HumdrumFile& infile, int ii,
 			if ((x>=0)&&(y>=0)&&(xo>=0)&&(yo>=0)) {
 				if (*infile.token(x, y) != *infile.token(xo, yo)) {
 					metQ = 1;
+				}
+			}
+		}
+
+		if (!mmetQ && (outmeasures[index].smmet.size() > 0)) {
+			x  = outmeasures[index].smmet[i].x;
+			y  = outmeasures[index].smmet[i].y;
+			xo = outmeasures[index-1].emmet[i].x;
+			yo = outmeasures[index-1].emmet[i].y;
+			if ((x>=0)&&(y>=0)&&(xo>=0)&&(yo>=0)) {
+				if (*infile.token(x, y) != *infile.token(xo, yo)) {
+					mmetQ = 1;
+				}
+			}
+		}
+
+		if (!ometQ && (outmeasures[index].somet.size() > 0)) {
+			x  = outmeasures[index].somet[i].x;
+			y  = outmeasures[index].somet[i].y;
+			xo = outmeasures[index-1].eomet[i].x;
+			yo = outmeasures[index-1].eomet[i].y;
+			if ((x>=0)&&(y>=0)&&(xo>=0)&&(yo>=0)) {
+				if (*infile.token(x, y) != *infile.token(xo, yo)) {
+					ometQ = 1;
 				}
 			}
 		}
@@ -1173,6 +1217,52 @@ void Tool_myank::adjustGlobalInterpretations(HumdrumFile& infile, int ii,
 		m_humdrum_text << "\n";
 	}
 
+	if (mmetQ) {
+		for (int i=0; i<infile[ii].getFieldCount(); i++) {
+			track = infile.token(ii, i)->getTrack();
+			x  = outmeasures[index].smmet[track].x;
+			y  = outmeasures[index].smmet[track].y;
+			xo = outmeasures[index-1].emmet[track].x;
+			yo = outmeasures[index-1].emmet[track].y;
+			if ((x>=0)&&(y>=0)&&(xo>=0)&&(yo>=0)) {
+				if (*infile.token(x, y) != *infile.token(xo, yo)) {
+					m_humdrum_text << infile.token(x, y);
+				} else {
+					m_humdrum_text << "*";
+				}
+			} else {
+				m_humdrum_text << "*";
+			}
+			if (i < infile[ii].getFieldCount()-1) {
+				m_humdrum_text << "\t";
+			}
+		}
+		m_humdrum_text << "\n";
+	}
+
+	if (ometQ) {
+		for (int i=0; i<infile[ii].getFieldCount(); i++) {
+			track = infile.token(ii, i)->getTrack();
+			x  = outmeasures[index].somet[track].x;
+			y  = outmeasures[index].somet[track].y;
+			xo = outmeasures[index-1].eomet[track].x;
+			yo = outmeasures[index-1].eomet[track].y;
+			if ((x>=0)&&(y>=0)&&(xo>=0)&&(yo>=0)) {
+				if (*infile.token(x, y) != *infile.token(xo, yo)) {
+					m_humdrum_text << infile.token(x, y);
+				} else {
+					m_humdrum_text << "*";
+				}
+			} else {
+				m_humdrum_text << "*";
+			}
+			if (i < infile[ii].getFieldCount()-1) {
+				m_humdrum_text << "\t";
+			}
+		}
+		m_humdrum_text << "\n";
+	}
+
 	if (tempoQ) {
 		for (int i=0; i<infile[ii].getFieldCount(); i++) {
 			track = infile.token(ii, i)->getTrack();
@@ -1221,6 +1311,8 @@ void Tool_myank::adjustGlobalInterpretationsStart(HumdrumFile& infile, int ii,
 	int keyQ     = 0;
 	int timesigQ = 0;
 	int metQ     = 0;
+	int mmetQ    = 0;
+	int ometQ    = 0;
 	int tempoQ   = 0;
 
 	int x, y;
@@ -1292,6 +1384,22 @@ void Tool_myank::adjustGlobalInterpretationsStart(HumdrumFile& infile, int ii,
 			y  = outmeasures[index].smet[i].y;
 			if ((x>=0)&&(y>=0)) {
 				metQ = 1;
+			}
+		}
+
+		if (!mmetQ) {
+			x  = outmeasures[index].smmet[i].x;
+			y  = outmeasures[index].smmet[i].y;
+			if ((x>=0)&&(y>=0)) {
+				mmetQ = 1;
+			}
+		}
+
+		if (!ometQ) {
+			x  = outmeasures[index].somet[i].x;
+			y  = outmeasures[index].somet[i].y;
+			if ((x>=0)&&(y>=0)) {
+				ometQ = 1;
 			}
 		}
 
@@ -1412,6 +1520,40 @@ void Tool_myank::adjustGlobalInterpretationsStart(HumdrumFile& infile, int ii,
 			ptrack = infile.token(ii, i)->getTrack();
 			x  = outmeasures[index].smet[ptrack].x;
 			y  = outmeasures[index].smet[ptrack].y;
+			if ((x>=0)&&(y>=0)) {
+				m_humdrum_text << infile.token(x, y);
+			} else {
+				m_humdrum_text << "*";
+			}
+			if (i < infile[ii].getFieldCount()-1) {
+				m_humdrum_text << "\t";
+			}
+		}
+		m_humdrum_text << "\n";
+	}
+
+	if (mmetQ) {
+		for (i=0; i<infile[ii].getFieldCount(); i++) {
+			ptrack = infile.token(ii, i)->getTrack();
+			x  = outmeasures[index].smmet[ptrack].x;
+			y  = outmeasures[index].smmet[ptrack].y;
+			if ((x>=0)&&(y>=0)) {
+				m_humdrum_text << infile.token(x, y);
+			} else {
+				m_humdrum_text << "*";
+			}
+			if (i < infile[ii].getFieldCount()-1) {
+				m_humdrum_text << "\t";
+			}
+		}
+		m_humdrum_text << "\n";
+	}
+
+	if (ometQ) {
+		for (i=0; i<infile[ii].getFieldCount(); i++) {
+			ptrack = infile.token(ii, i)->getTrack();
+			x  = outmeasures[index].somet[ptrack].x;
+			y  = outmeasures[index].somet[ptrack].y;
 			if ((x>=0)&&(y>=0)) {
 				m_humdrum_text << infile.token(x, y);
 			} else {
@@ -2369,6 +2511,8 @@ void Tool_myank::fillGlobalDefaults(HumdrumFile& infile, vector<MeasureInfo>& me
 	vector<MyCoord> currkey(tracks+1);
 	vector<MyCoord> currtimesig(tracks+1);
 	vector<MyCoord> currmet(tracks+1);
+	vector<MyCoord> currmmet(tracks+1);
+	vector<MyCoord> curromet(tracks+1);
 	vector<MyCoord> currtempo(tracks+1);
 
 	MyCoord undefMyCoord;
@@ -2381,6 +2525,8 @@ void Tool_myank::fillGlobalDefaults(HumdrumFile& infile, vector<MeasureInfo>& me
 	fill(currkey.begin(), currkey.end(), undefMyCoord);
 	fill(currtimesig.begin(), currtimesig.end(), undefMyCoord);
 	fill(currmet.begin(), currmet.end(), undefMyCoord);
+	fill(currmmet.begin(), currmmet.end(), undefMyCoord);
+	fill(curromet.begin(), curromet.end(), undefMyCoord);
 	fill(currtempo.begin(), currtempo.end(), undefMyCoord);
 
 	int currmeasure = -1;
@@ -2408,6 +2554,8 @@ void Tool_myank::fillGlobalDefaults(HumdrumFile& infile, vector<MeasureInfo>& me
 				measurein[inmap[currmeasure]].ekey     = currkey;
 				measurein[inmap[currmeasure]].etimesig = currtimesig;
 				measurein[inmap[currmeasure]].emet     = currmet;
+				measurein[inmap[currmeasure]].emmet     = currmmet;
+				measurein[inmap[currmeasure]].eomet     = curromet;
 				measurein[inmap[currmeasure]].etempo   = currtempo;
 			}
 
@@ -2435,6 +2583,8 @@ void Tool_myank::fillGlobalDefaults(HumdrumFile& infile, vector<MeasureInfo>& me
 				measurein[inmap[currmeasure]].stimesig = currtimesig;
 				// measurein[inmap[currmeasure]].smet     = metstates[i];
 				measurein[inmap[currmeasure]].smet     = currmet;
+				measurein[inmap[currmeasure]].smmet    = currmmet;
+				measurein[inmap[currmeasure]].somet    = curromet;
 				measurein[inmap[currmeasure]].stempo   = currtempo;
 			}
 
@@ -2470,6 +2620,12 @@ void Tool_myank::fillGlobalDefaults(HumdrumFile& infile, vector<MeasureInfo>& me
 					} else if (hre.search(infile.token(i, j), R"(^\*met\(.*\))")) {
 						measurein[inmap[currmeasure]].smet[track].x = -1;
 						measurein[inmap[currmeasure]].smet[track].y = -1;
+					} else if (hre.search(infile.token(i, j), R"(^\*mmet\(.*\))")) {
+						measurein[inmap[currmeasure]].smmet[track].x = -1;
+						measurein[inmap[currmeasure]].smmet[track].y = -1;
+					} else if (hre.search(infile.token(i, j), R"(^\*omet\(.*\))")) {
+						measurein[inmap[currmeasure]].somet[track].x = -1;
+						measurein[inmap[currmeasure]].somet[track].y = -1;
 					} else if (hre.search(infile.token(i, j), "^\\*MM\\d+", "i")) {
 						measurein[inmap[currmeasure]].stempo[track].x = -1;
 						measurein[inmap[currmeasure]].stempo[track].y = -1;
@@ -2511,6 +2667,16 @@ void Tool_myank::fillGlobalDefaults(HumdrumFile& infile, vector<MeasureInfo>& me
 					currmet[track].y = j;
 					continue;
 				}
+				if (hre.search(infile.token(i, j), R"(^\*mmet\(.*\))")) {
+					currmmet[track].x = i;
+					currmmet[track].y = j;
+					continue;
+				}
+				if (hre.search(infile.token(i, j), R"(^\*omet\(.*\))")) {
+					curromet[track].x = i;
+					curromet[track].y = j;
+					continue;
+				}
 				if (hre.search(infile.token(i, j), R"(^\*MM[\d.]+)")) {
 					currtempo[track].x = i;
 					currtempo[track].y = j;
@@ -2534,6 +2700,8 @@ void Tool_myank::fillGlobalDefaults(HumdrumFile& infile, vector<MeasureInfo>& me
 		measurein[inmap[currmeasure]].ekey     = currkey;
 		measurein[inmap[currmeasure]].etimesig = currtimesig;
 		measurein[inmap[currmeasure]].emet     = currmet;
+		measurein[inmap[currmeasure]].emmet    = currmmet;
+		measurein[inmap[currmeasure]].eomet    = curromet;
 		measurein[inmap[currmeasure]].etempo   = currtempo;
 	}
 
@@ -2716,17 +2884,49 @@ void Tool_myank::fillGlobalDefaults(HumdrumFile& infile, vector<MeasureInfo>& me
 			measurein[i].smet.resize(tracks+1);
 			fill(measurein[i].smet.begin(), measurein[i].smet.end(), undefMyCoord);
 		}
+		if (measurein[i].smmet.size() == 0) {
+			measurein[i].smmet.resize(tracks+1);
+			fill(measurein[i].smmet.begin(), measurein[i].smmet.end(), undefMyCoord);
+		}
+		if (measurein[i].somet.size() == 0) {
+			measurein[i].somet.resize(tracks+1);
+			fill(measurein[i].somet.begin(), measurein[i].somet.end(), undefMyCoord);
+		}
 		if (measurein[i].emet.size() == 0) {
 			measurein[i].emet.resize(tracks+1);
 			fill(measurein[i].emet.begin(), measurein[i].emet.end(), undefMyCoord);
+		}
+		if (measurein[i].emmet.size() == 0) {
+			measurein[i].emmet.resize(tracks+1);
+			fill(measurein[i].emmet.begin(), measurein[i].emmet.end(), undefMyCoord);
+		}
+		if (measurein[i].eomet.size() == 0) {
+			measurein[i].eomet.resize(tracks+1);
+			fill(measurein[i].eomet.begin(), measurein[i].eomet.end(), undefMyCoord);
 		}
 		if (measurein[i+1].smet.size() == 0) {
 			measurein[i+1].smet.resize(tracks+1);
 			fill(measurein[i+1].smet.begin(), measurein[i+1].smet.end(), undefMyCoord);
 		}
+		if (measurein[i+1].smmet.size() == 0) {
+			measurein[i+1].smmet.resize(tracks+1);
+			fill(measurein[i+1].smmet.begin(), measurein[i+1].smmet.end(), undefMyCoord);
+		}
+		if (measurein[i+1].somet.size() == 0) {
+			measurein[i+1].somet.resize(tracks+1);
+			fill(measurein[i+1].somet.begin(), measurein[i+1].somet.end(), undefMyCoord);
+		}
 		if (measurein[i+1].emet.size() == 0) {
 			measurein[i+1].emet.resize(tracks+1);
 			fill(measurein[i+1].emet.begin(), measurein[i+1].emet.end(), undefMyCoord);
+		}
+		if (measurein[i+1].emmet.size() == 0) {
+			measurein[i+1].emmet.resize(tracks+1);
+			fill(measurein[i+1].emmet.begin(), measurein[i+1].emmet.end(), undefMyCoord);
+		}
+		if (measurein[i+1].eomet.size() == 0) {
+			measurein[i+1].eomet.resize(tracks+1);
+			fill(measurein[i+1].eomet.begin(), measurein[i+1].eomet.end(), undefMyCoord);
 		}
 		for (j=1; j<(int)measurein[i].smet.size(); j++) {
 			if (!measurein[i].emet[j].isValid()) {
@@ -2737,6 +2937,30 @@ void Tool_myank::fillGlobalDefaults(HumdrumFile& infile, vector<MeasureInfo>& me
 			if (!measurein[i+1].smet[j].isValid()) {
 				if (measurein[i].emet[j].isValid()) {
 					measurein[i+1].smet[j] = measurein[i].emet[j];
+				}
+			}
+		}
+		for (j=1; j<(int)measurein[i].smmet.size(); j++) {
+			if (!measurein[i].emmet[j].isValid()) {
+				if (measurein[i].smmet[j].isValid()) {
+					measurein[i].emmet[j] = measurein[i].smmet[j];
+				}
+			}
+			if (!measurein[i+1].smmet[j].isValid()) {
+				if (measurein[i].emmet[j].isValid()) {
+					measurein[i+1].smmet[j] = measurein[i].emmet[j];
+				}
+			}
+		}
+		for (j=1; j<(int)measurein[i].somet.size(); j++) {
+			if (!measurein[i].eomet[j].isValid()) {
+				if (measurein[i].somet[j].isValid()) {
+					measurein[i].eomet[j] = measurein[i].somet[j];
+				}
+			}
+			if (!measurein[i+1].somet[j].isValid()) {
+				if (measurein[i].eomet[j].isValid()) {
+					measurein[i+1].somet[j] = measurein[i].eomet[j];
 				}
 			}
 		}
@@ -2846,6 +3070,8 @@ void Tool_myank::processFieldEntry(vector<MeasureInfo>& field,
 					current.skey     = inmeasures[inmap[i]].skey;
 					current.stimesig = inmeasures[inmap[i]].stimesig;
 					current.smet     = inmeasures[inmap[i]].smet;
+					current.smmet    = inmeasures[inmap[i]].smmet;
+					current.somet    = inmeasures[inmap[i]].somet;
 					current.stempo   = inmeasures[inmap[i]].stempo;
 
 					current.eclef    = inmeasures[inmap[i]].eclef;
@@ -2855,6 +3081,8 @@ void Tool_myank::processFieldEntry(vector<MeasureInfo>& field,
 					current.ekey     = inmeasures[inmap[i]].ekey;
 					current.etimesig = inmeasures[inmap[i]].etimesig;
 					current.emet     = inmeasures[inmap[i]].emet;
+					current.emmet    = inmeasures[inmap[i]].emmet;
+					current.eomet    = inmeasures[inmap[i]].eomet;
 					current.etempo   = inmeasures[inmap[i]].etempo;
 
 					field.push_back(current);
@@ -2877,6 +3105,8 @@ void Tool_myank::processFieldEntry(vector<MeasureInfo>& field,
 					current.skey     = inmeasures[inmap[i]].skey;
 					current.stimesig = inmeasures[inmap[i]].stimesig;
 					current.smet     = inmeasures[inmap[i]].smet;
+					current.smmet    = inmeasures[inmap[i]].smmet;
+					current.somet    = inmeasures[inmap[i]].somet;
 					current.stempo   = inmeasures[inmap[i]].stempo;
 
 					current.eclef    = inmeasures[inmap[i]].eclef;
@@ -2886,6 +3116,8 @@ void Tool_myank::processFieldEntry(vector<MeasureInfo>& field,
 					current.ekey     = inmeasures[inmap[i]].ekey;
 					current.etimesig = inmeasures[inmap[i]].etimesig;
 					current.emet     = inmeasures[inmap[i]].emet;
+					current.emmet    = inmeasures[inmap[i]].emmet;
+					current.eomet    = inmeasures[inmap[i]].eomet;
 					current.etempo   = inmeasures[inmap[i]].etempo;
 
 					field.push_back(current);
@@ -2917,6 +3149,8 @@ void Tool_myank::processFieldEntry(vector<MeasureInfo>& field,
 			current.skey     = inmeasures[inmap[value]].skey;
 			current.stimesig = inmeasures[inmap[value]].stimesig;
 			current.smet     = inmeasures[inmap[value]].smet;
+			current.smmet    = inmeasures[inmap[value]].smmet;
+			current.somet    = inmeasures[inmap[value]].somet;
 			current.stempo   = inmeasures[inmap[value]].stempo;
 
 			current.eclef    = inmeasures[inmap[value]].eclef;
@@ -2926,6 +3160,8 @@ void Tool_myank::processFieldEntry(vector<MeasureInfo>& field,
 			current.ekey     = inmeasures[inmap[value]].ekey;
 			current.etimesig = inmeasures[inmap[value]].etimesig;
 			current.emet     = inmeasures[inmap[value]].emet;
+			current.emmet    = inmeasures[inmap[value]].emmet;
+			current.eomet    = inmeasures[inmap[value]].eomet;
 			current.etempo   = inmeasures[inmap[value]].etempo;
 
 			field.push_back(current);


### PR DESCRIPTION
Closes #94

This is not the best solution as a lot of code is repeated, but it works… Having a look at `modori` we should probably also add `*ok` and `*mk`, `*oI"`, `*mI"`, `*oI'`, `*mI'`.

Could you please check the changes in `Tool_myank::getMetStates` ans especially the regex in `Tool_myank::getLocalMetInfo`. I'm not sure I caught this edge case.