### PR TITLE
Add missing includes in `1520ify`

### DIFF
--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Sun Oct  6 10:03:46 PDT 2024
+// Last Modified: Fr 11 Okt 2024 00:16:02 CEST
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Sun Oct  6 10:03:46 PDT 2024
+// Last Modified: Fr 11 Okt 2024 00:16:02 CEST
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11

--- a/src/tool-1520ify.cpp
+++ b/src/tool-1520ify.cpp
@@ -17,6 +17,8 @@
 #include "HumRegex.h"
 
 #include <algorithm>
+#include <chrono>
+#include <iomanip>
 
 using namespace std;
 


### PR DESCRIPTION
Ubuntu could not build humlib without `#include <chrono>` and `#include <iomanip>`.