### PR TITLE
[shed] Fix issues with multiple expressions

### DIFF
--- a/include/tool-shed.h
+++ b/include/tool-shed.h
@@ -36,6 +36,7 @@ class Tool_shed : public HumTool {
 
 	protected:
 		void    processFile                      (HumdrumFile& infile);
+		void    processExpression                (HumdrumFile& infile);
 		void    searchAndReplaceInterpretation   (HumdrumFile& infile);
 		void    searchAndReplaceExinterp         (HumdrumFile& infile);
 		void    searchAndReplaceData             (HumdrumFile& infile);

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Thu Nov 14 07:42:35 PST 2024
+// Last Modified: Do 21 Nov 2024 21:59:25 CET
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -126363,10 +126363,7 @@ bool Tool_shed::run(HumdrumFile& infile) {
 		cerr << "Error: -e option is required" << endl;
 		return false;
 	}
-	for (int i=0; i<(int)m_options.size(); i++) {
-		prepareSearch(i);
-		processFile(infile);
-	}
+	processFile(infile);
 	return true;
 }
 
@@ -126658,6 +126655,21 @@ vector<string> Tool_shed::addToExInterpList(void) {
 //
 
 void Tool_shed::processFile(HumdrumFile& infile) {
+	for (int i=0; i<(int)m_options.size(); i++) {
+		prepareSearch(i);
+		processExpression(infile);
+	}
+	m_humdrum_text << infile;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_shed::processExpression --
+//
+
+void Tool_shed::processExpression(HumdrumFile& infile) {
 	if (m_search == "") {
 		// nothing to do
 		return;
@@ -126703,9 +126715,6 @@ void Tool_shed::processFile(HumdrumFile& infile) {
 	if (m_modified) {
 		infile.createLinesFromTokens();
 	}
-
-	// needed only for command-line version of tool?:
-	m_humdrum_text << infile;
 }
 
 

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Thu Nov 14 07:42:35 PST 2024
+// Last Modified: Do 21 Nov 2024 21:59:25 CET
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11
@@ -10856,6 +10856,7 @@ class Tool_shed : public HumTool {
 
 	protected:
 		void    processFile                      (HumdrumFile& infile);
+		void    processExpression                (HumdrumFile& infile);
 		void    searchAndReplaceInterpretation   (HumdrumFile& infile);
 		void    searchAndReplaceExinterp         (HumdrumFile& infile);
 		void    searchAndReplaceData             (HumdrumFile& infile);

--- a/src/tool-shed.cpp
+++ b/src/tool-shed.cpp
@@ -423,9 +423,6 @@ void Tool_shed::processFile(HumdrumFile& infile) {
 	if (m_modified) {
 		infile.createLinesFromTokens();
 	}
-
-	// needed only for command-line version of tool?:
-	m_humdrum_text << infile;
 }
 
 

--- a/src/tool-shed.cpp
+++ b/src/tool-shed.cpp
@@ -83,10 +83,7 @@ bool Tool_shed::run(HumdrumFile& infile) {
 		cerr << "Error: -e option is required" << endl;
 		return false;
 	}
-	for (int i=0; i<(int)m_options.size(); i++) {
-		prepareSearch(i);
-		processFile(infile);
-	}
+	processFile(infile);
 	return true;
 }
 
@@ -378,6 +375,21 @@ vector<string> Tool_shed::addToExInterpList(void) {
 //
 
 void Tool_shed::processFile(HumdrumFile& infile) {
+	for (int i=0; i<(int)m_options.size(); i++) {
+		prepareSearch(i);
+		processExpression(infile);
+	}
+	m_humdrum_text << infile;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_shed::processExpression --
+//
+
+void Tool_shed::processExpression(HumdrumFile& infile) {
 	if (m_search == "") {
 		// nothing to do
 		return;


### PR DESCRIPTION
This PR fixes an error introduced in 9b16d0a when shed is used with multiple expressions at once:

input.krn

```
**kern	**kern	**kern
*clefC4	*clefC3	*clefC1
1c	1e	1g
==	==	==
*-	*-	*-
```

command:

```
cat input.krn | shed -e "s/^clefC1/clefG2/I s/^clefC3/clefG2/I s/^clefC4/clefG2/I"
```

output:

```
**kern	**kern	**kern
*clefC4	*clefC3	*clefG2
1c	1e	1g
==	==	==
*-	*-	*-
**kern	**kern	**kern
*clefC4	*clefG2	*clefG2
1c	1e	1g
==	==	==
*-	*-	*-
**kern	**kern	**kern
*clefG2	*clefG2	*clefG2
1c	1e	1g
==	==	==
*-	*-	*-
```