### PR TITLE
Add new tool to output original line numbers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ set(SRCS
 	src/tool-filter.cpp
 	src/tool-hproof.cpp
 	src/tool-imitation.cpp
+    src/tool-lnnr.cpp
 	src/tool-mei2hum.cpp
 	src/tool-metlev.cpp
 	src/tool-msearch.cpp
@@ -154,6 +155,7 @@ set(HDRS
 	include/tool-fb.h
 	include/tool-hproof.h
 	include/tool-imitation.h
+    include/tool-lnnr.h
 	include/tool-mei2hum.h
 	include/tool-metlev.h
 	include/tool-msearch.h

--- a/Makefile
+++ b/Makefile
@@ -1356,6 +1356,15 @@ tool-kernview.o: tool-kernview.cpp tool-kernview.h \
   HumHash.h HumParamSet.h HumdrumFileStream.h \
   Convert.h HumRegex.h
 
+tool-lnnr.o: tool-lnnr.cpp tool-lnnr.h HumTool.h \
+  Options.h HumdrumFileSet.h HumdrumFile.h \
+  HumdrumFileContent.h HumdrumFileStructure.h \
+  HumdrumFileBase.h HumSignifiers.h \
+  HumSignifier.h HumdrumLine.h HumdrumToken.h \
+  HumNum.h HumAddress.h HumHash.h \
+  HumParamSet.h HumdrumFileStream.h NoteGrid.h \
+  NoteCell.h Convert.h HumRegex.h
+
 tool-mei2hum.o: tool-mei2hum.cpp tool-mei2hum.h \
   Options.h HumTool.h HumdrumFileSet.h \
   HumdrumFile.h HumdrumFileContent.h \

--- a/cli/lnnr.cpp
+++ b/cli/lnnr.cpp
@@ -1,0 +1,18 @@
+//
+// Programmer:    Wolfgang Drescher <drescher.wolfgang@gmail.com>
+// Creation Date: Sat Jul 13 2024 09:44:00 CET
+// Last Modified: Sat Jul 13 2024 09:44:00 CET
+// Filename:      cli/lnnr.cpp
+// URL:           https://github.com/craigsapp/humlib/blob/master/cli/lnnr.cpp
+// Syntax:        C++11
+// vim:           ts=3 noexpandtab nowrap
+//
+// Description:   Line number generating program.
+//
+
+#include "humlib.h"
+
+STREAM_INTERFACE(Tool_lnnr)
+
+
+

--- a/include/tool-lnnr.h
+++ b/include/tool-lnnr.h
@@ -1,0 +1,48 @@
+//
+// Programmer:    Wolfgang Drescher <drescher.wolfgang@gmail.com>
+// Creation Date: Sat Jul 13 2024 04:44:00 CET
+// Filename:      tool-lnnr.h
+// URL:           https://github.com/craigsapp/humlib/blob/master/include/tool-lnnr.h
+// Syntax:        C++11; humlib
+// vim:           syntax=cpp ts=3 noexpandtab nowrap
+//
+// Description:   Interface for lnnr tool
+//
+
+#ifndef _TOOL_LNNR_H
+#define _TOOL_LNNR_H
+
+#include "HumTool.h"
+#include "HumdrumFile.h"
+
+using namespace std;
+
+namespace hum {
+
+// START_MERGE
+
+class Tool_lnnr : public HumTool {
+
+	public:
+		     Tool_lnnr (void);
+		     ~Tool_lnnr() {};
+
+		bool run       (HumdrumFileSet& infiles);
+		bool run       (HumdrumFile& infile);
+		bool run       (const string& indata, ostream& out);
+		bool run       (HumdrumFile& infile, ostream& out);
+
+	protected:
+		void           initialize  (void);
+        void           processFile (HumdrumFile& infile);
+		vector<string> getTrackData(HumdrumFile& infile);
+
+	private:
+		bool m_indexQ = false;
+};
+
+// END_MERGE
+
+} // end namespace hum
+
+#endif /* _TOOL_LNNR_H */

--- a/include/tool-lnnr.h
+++ b/include/tool-lnnr.h
@@ -38,7 +38,8 @@ class Tool_lnnr : public HumTool {
 		vector<string> getTrackData(HumdrumFile& infile);
 
 	private:
-		bool m_indexQ = false;
+		bool m_indexQ   = false;
+		bool m_prependQ = false;
 };
 
 // END_MERGE

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Sa 13 Jul 2024 10:00:46 CEST
+// Last Modified: Sa 13 Jul 2024 10:40:06 CEST
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -92090,6 +92090,104 @@ void Tool_kernview::processFile(HumdrumFile& infile) {
 	int line = kernish[0]->getLineIndex();
 	infile[line].createLineFromTokens();
 
+}
+
+
+
+
+//////////////////////////////
+//
+// Tool_lnnr::Tool_lnnr -- Set the recognized options for the tool.
+//
+
+Tool_lnnr::Tool_lnnr(void) {
+	define("i|index=b", "output line indices instead of line numbers");
+}
+
+
+
+//////////////////////////////
+//
+// Tool_lnnr::run -- Do the main work of the tool.
+//
+
+bool Tool_lnnr::run(HumdrumFileSet &infiles) {
+	bool status = true;
+	for (int i = 0; i < infiles.getCount(); i++) {
+		status &= run(infiles[i]);
+	}
+	return status;
+}
+
+bool Tool_lnnr::run(const string &indata, ostream &out) {
+	HumdrumFile infile(indata);
+	bool status = run(infile);
+	if (hasAnyText()) {
+		getAllText(out);
+	} else {
+		out << infile;
+	}
+	return status;
+}
+
+bool Tool_lnnr::run(HumdrumFile &infile, ostream &out) {
+	bool status = run(infile);
+	if (hasAnyText()) {
+		getAllText(out);
+	} else {
+		out << infile;
+	}
+	return status;
+}
+
+bool Tool_lnnr::run(HumdrumFile &infile) {
+	initialize();
+	processFile(infile);
+	return true;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_lnnr::initialize --
+//
+
+void Tool_lnnr::initialize(void) {
+	m_indexQ = getBoolean("index");
+}
+
+
+
+//////////////////////////////
+//
+// Tool_lnnr::processFile --
+//
+
+void Tool_lnnr::processFile(HumdrumFile& infile) {
+	vector<string> trackData = getTrackData(infile);
+	string exinterp = m_indexQ ? "**lnidx" : "**lnnr";
+	infile.appendDataSpine(trackData, ".", exinterp);
+	m_humdrum_text << infile;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_lnnr::getTrackData --
+//
+
+vector<string> Tool_lnnr::getTrackData(HumdrumFile& infile) {
+	vector<string> trackData;
+	trackData.resize(infile.getLineCount());
+
+	for (int i = 0; i < infile.getLineCount(); i++) {
+		HLp line = infile.getLine(i);
+		trackData[i] = m_indexQ ? to_string(line->getLineIndex()) : to_string(line->getLineNumber());
+	}
+
+	return trackData;
 }
 
 

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Wed Jul  3 23:34:11 CEST 2024
+// Last Modified: Sa 13 Jul 2024 10:00:46 CEST
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -82228,7 +82228,7 @@ void Tool_fb::processFile(HumdrumFile& infile) {
 	lastNumbers.resize((int)grid.getVoiceCount());
 	vector<vector<int>> currentNumbers = {};
 
-	// Interate through the NoteGrid and fill the numbers vector with
+	// Iterate through the NoteGrid and fill the numbers vector with
 	// all generated FiguredBassNumbers
 	for (int i=0; i<(int)grid.getSliceCount(); i++) {
 		currentNumbers.clear();
@@ -82317,7 +82317,7 @@ void Tool_fb::processFile(HumdrumFile& infile) {
 			continue;
 		}
 
-		// Interate through each voice
+		// Iterate through each voice
 		for (int j=0; j<(int)grid.getVoiceCount(); j++) {
 			NoteCell* targetCell = grid.cell(j, i);
 

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Sa 13 Jul 2024 10:40:06 CEST
+// Last Modified: Sa 13 Jul 2024 10:45:50 CEST
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -92102,6 +92102,7 @@ void Tool_kernview::processFile(HumdrumFile& infile) {
 
 Tool_lnnr::Tool_lnnr(void) {
 	define("i|index=b", "output line indices instead of line numbers");
+	define("p|prepend=b", "add **lnnr spine as first spine");
 }
 
 
@@ -92155,6 +92156,7 @@ bool Tool_lnnr::run(HumdrumFile &infile) {
 
 void Tool_lnnr::initialize(void) {
 	m_indexQ = getBoolean("index");
+	m_prependQ = getBoolean("prepend");
 }
 
 
@@ -92167,7 +92169,11 @@ void Tool_lnnr::initialize(void) {
 void Tool_lnnr::processFile(HumdrumFile& infile) {
 	vector<string> trackData = getTrackData(infile);
 	string exinterp = m_indexQ ? "**lnidx" : "**lnnr";
-	infile.appendDataSpine(trackData, ".", exinterp);
+	if (m_prependQ) {
+		infile.insertDataSpineBefore(1, trackData, ".", exinterp);
+	} else {
+		infile.appendDataSpine(trackData, ".", exinterp);
+	}
 	m_humdrum_text << infile;
 }
 

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Sa 13 Jul 2024 10:00:46 CEST
+// Last Modified: Sa 13 Jul 2024 10:40:06 CEST
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11
@@ -8412,6 +8412,27 @@ class Tool_kernview : public HumTool {
 		std::string m_view_string;
 		std::string m_hide_string;
 
+};
+
+
+class Tool_lnnr : public HumTool {
+
+	public:
+		     Tool_lnnr (void);
+		     ~Tool_lnnr() {};
+
+		bool run       (HumdrumFileSet& infiles);
+		bool run       (HumdrumFile& infile);
+		bool run       (const string& indata, ostream& out);
+		bool run       (HumdrumFile& infile, ostream& out);
+
+	protected:
+		void           initialize  (void);
+        void           processFile (HumdrumFile& infile);
+		vector<string> getTrackData(HumdrumFile& infile);
+
+	private:
+		bool m_indexQ = false;
 };
 
 

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Sa 13 Jul 2024 10:40:06 CEST
+// Last Modified: Sa 13 Jul 2024 10:45:50 CEST
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11
@@ -8432,7 +8432,8 @@ class Tool_lnnr : public HumTool {
 		vector<string> getTrackData(HumdrumFile& infile);
 
 	private:
-		bool m_indexQ = false;
+		bool m_indexQ   = false;
+		bool m_prependQ = false;
 };
 
 

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Wed Jul  3 23:34:11 CEST 2024
+// Last Modified: Sa 13 Jul 2024 10:00:46 CEST
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11

--- a/src/tool-fb.cpp
+++ b/src/tool-fb.cpp
@@ -193,7 +193,7 @@ void Tool_fb::processFile(HumdrumFile& infile) {
 	lastNumbers.resize((int)grid.getVoiceCount());
 	vector<vector<int>> currentNumbers = {};
 
-	// Interate through the NoteGrid and fill the numbers vector with
+	// Iterate through the NoteGrid and fill the numbers vector with
 	// all generated FiguredBassNumbers
 	for (int i=0; i<(int)grid.getSliceCount(); i++) {
 		currentNumbers.clear();
@@ -282,7 +282,7 @@ void Tool_fb::processFile(HumdrumFile& infile) {
 			continue;
 		}
 
-		// Interate through each voice
+		// Iterate through each voice
 		for (int j=0; j<(int)grid.getVoiceCount(); j++) {
 			NoteCell* targetCell = grid.cell(j, i);
 

--- a/src/tool-lnnr.cpp
+++ b/src/tool-lnnr.cpp
@@ -1,0 +1,121 @@
+//
+// Programmer:    Wolfgang Drescher <drescher.wolfgang@gmail.com>
+// Creation Date: Sat Jul 13 2024 09:44:00 CET
+// Filename:      tool-lnnr.cpp
+// URL:           https://github.com/craigsapp/humlib/blob/master/src/tool-lnnr.cpp
+// Syntax:        C++11; humlib
+// vim:           syntax=cpp ts=3 noexpandtab nowrap
+//
+// Description:   Add line numbers or line indices as spine
+//
+
+#include "tool-lnnr.h"
+#include "Convert.h"
+#include "HumRegex.h"
+
+using namespace std;
+
+namespace hum {
+
+// START_MERGE
+
+//////////////////////////////
+//
+// Tool_lnnr::Tool_lnnr -- Set the recognized options for the tool.
+//
+
+Tool_lnnr::Tool_lnnr(void) {
+	define("i|index=b", "output line indices instead of line numbers");
+}
+
+
+
+//////////////////////////////
+//
+// Tool_lnnr::run -- Do the main work of the tool.
+//
+
+bool Tool_lnnr::run(HumdrumFileSet &infiles) {
+	bool status = true;
+	for (int i = 0; i < infiles.getCount(); i++) {
+		status &= run(infiles[i]);
+	}
+	return status;
+}
+
+bool Tool_lnnr::run(const string &indata, ostream &out) {
+	HumdrumFile infile(indata);
+	bool status = run(infile);
+	if (hasAnyText()) {
+		getAllText(out);
+	} else {
+		out << infile;
+	}
+	return status;
+}
+
+bool Tool_lnnr::run(HumdrumFile &infile, ostream &out) {
+	bool status = run(infile);
+	if (hasAnyText()) {
+		getAllText(out);
+	} else {
+		out << infile;
+	}
+	return status;
+}
+
+bool Tool_lnnr::run(HumdrumFile &infile) {
+	initialize();
+	processFile(infile);
+	return true;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_lnnr::initialize --
+//
+
+void Tool_lnnr::initialize(void) {
+	m_indexQ = getBoolean("index");
+}
+
+
+
+//////////////////////////////
+//
+// Tool_lnnr::processFile --
+//
+
+void Tool_lnnr::processFile(HumdrumFile& infile) {
+	vector<string> trackData = getTrackData(infile);
+	string exinterp = m_indexQ ? "**lnidx" : "**lnnr";
+	infile.appendDataSpine(trackData, ".", exinterp);
+	m_humdrum_text << infile;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_lnnr::getTrackData --
+//
+
+vector<string> Tool_lnnr::getTrackData(HumdrumFile& infile) {
+	vector<string> trackData;
+	trackData.resize(infile.getLineCount());
+
+	for (int i = 0; i < infile.getLineCount(); i++) {
+		HLp line = infile.getLine(i);
+		trackData[i] = m_indexQ ? to_string(line->getLineIndex()) : to_string(line->getLineNumber());
+	}
+
+	return trackData;
+}
+
+
+
+// END_MERGE
+
+} // end namespace hum

--- a/src/tool-lnnr.cpp
+++ b/src/tool-lnnr.cpp
@@ -26,6 +26,7 @@ namespace hum {
 
 Tool_lnnr::Tool_lnnr(void) {
 	define("i|index=b", "output line indices instead of line numbers");
+	define("p|prepend=b", "add **lnnr spine as first spine");
 }
 
 
@@ -79,6 +80,7 @@ bool Tool_lnnr::run(HumdrumFile &infile) {
 
 void Tool_lnnr::initialize(void) {
 	m_indexQ = getBoolean("index");
+	m_prependQ = getBoolean("prepend");
 }
 
 
@@ -91,7 +93,11 @@ void Tool_lnnr::initialize(void) {
 void Tool_lnnr::processFile(HumdrumFile& infile) {
 	vector<string> trackData = getTrackData(infile);
 	string exinterp = m_indexQ ? "**lnidx" : "**lnnr";
-	infile.appendDataSpine(trackData, ".", exinterp);
+	if (m_prependQ) {
+		infile.insertDataSpineBefore(1, trackData, ".", exinterp);
+	} else {
+		infile.appendDataSpine(trackData, ".", exinterp);
+	}
 	m_humdrum_text << infile;
 }
 


### PR DESCRIPTION
Some of the older programs (e.g. `beat`) sometimes make some lines of the kern score disappear. In order to be able to create a mapping between the original line numbers, I have created a program `lnnr` with which the line numbers can be displayed as new `**lnnr` spines.

test.krn:

```
!!!OTL: Test
**kern
*clefG2
*M4/4
=
!local comment
4c
4d
4e
4f
=
!!global comment
4g
4a
4h
4cc
==
*-
```

`lnnr test.krn`

```
!!!OTL: Test
**kern	**lnnr
*clefG2	*
*M4/4	*
=	=
!local comment	!
4c	7
4d	8
4e	9
4f	10
=	=
!!global comment
4g	13
4a	14
4h	15
4cc	16
==	==
*-	*-
```

`lnnr test.krn --index --prepend`

```
!!!OTL: Test
**lnidx	**kern
*	*clefG2
*	*M4/4
=	=
!	!local comment
6	4c
7	4d
8	4e
9	4f
=	=
!!global comment
12	4g
13	4a
14	4h
15	4cc
==	==
*-	*-
```