### PR TITLE
Add new tool to mark sections of a kern score

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,7 @@ set(SRCS
 	src/tool-msearch.cpp
 	src/tool-musicxml2hum.cpp
 	src/tool-myank.cpp
+    src/tool-notemark.cpp
 	src/tool-recip.cpp
 	src/tool-restfill.cpp
 	src/tool-ruthfix.cpp
@@ -159,6 +160,7 @@ set(HDRS
 	include/tool-msearch.h
 	include/tool-musicxml2hum.h
 	include/tool-myank.h
+	include/tool-notemark.h
 	include/tool-recip.h
 	include/tool-restfill.h
 	include/tool-ruthfix.h

--- a/Makefile
+++ b/Makefile
@@ -1191,7 +1191,7 @@ tool-filter.o: tool-filter.cpp tool-filter.h \
   GridPart.h GridStaff.h GridSide.h \
   GridVoice.h tool-melisma.h tool-mens2kern.h \
   tool-meter.h tool-metlev.h tool-modori.h \
-  tool-msearch.h Convert.h tool-myank.h \
+  tool-msearch.h Convert.h tool-myank.h tool-notemark.h \
   tool-nproof.h tool-ordergps.h tool-phrase.h \
   tool-pline.h tool-recip.h tool-restfill.h \
   tool-rid.h tool-sab2gs.h tool-satb2gs.h \

--- a/Makefile
+++ b/Makefile
@@ -1464,6 +1464,15 @@ tool-myank.o: tool-myank.cpp tool-myank.h HumTool.h \
   HumParamSet.h HumdrumFileStream.h HumRegex.h \
   Convert.h
 
+tool-notemark.o: tool-notemark.cpp tool-notemark.h HumTool.h \
+  Options.h HumdrumFileSet.h HumdrumFile.h \
+  HumdrumFileContent.h HumdrumFileStructure.h \
+  HumdrumFileBase.h HumSignifiers.h \
+  HumSignifier.h HumdrumLine.h HumdrumToken.h \
+  HumNum.h HumAddress.h HumHash.h \
+  HumParamSet.h HumdrumFileStream.h NoteGrid.h \
+  NoteCell.h Convert.h HumRegex.h
+
 tool-nproof.o: tool-nproof.cpp tool-nproof.h \
   HumTool.h Options.h HumdrumFileSet.h \
   HumdrumFile.h HumdrumFileContent.h \

--- a/cli/notemark.cpp
+++ b/cli/notemark.cpp
@@ -1,0 +1,17 @@
+//
+// Programmer:    Wolfgang Drescher <drescher.wolfgang@gmail.com>
+// Creation Date: Mon Oct 14 19:24:00 UTC 2024
+// Filename:      cli/notemark.cpp
+// URL:           https://github.com/craigsapp/humlib/blob/master/cli/notemark.cpp
+// Syntax:        C++11
+// vim:           ts=3 noexpandtab nowrap
+//
+// Description:   Adds note markers for specific lines and voices
+//
+
+#include "humlib.h"
+
+STREAM_INTERFACE(Tool_notemark)
+
+
+

--- a/include/tool-notemark.h
+++ b/include/tool-notemark.h
@@ -1,0 +1,60 @@
+//
+// Programmer:    Wolfgang Drescher <drescher.wolfgang@gmail.com>
+// Creation Date: Mon Oct 14 19:24:00 UTC 2024
+// Filename:      tool-notemark.h
+// URL:           https://github.com/craigsapp/humlib/blob/master/include/tool-notemark.h
+// Syntax:        C++11; humlib
+// vim:           syntax=cpp ts=3 noexpandtab nowrap
+//
+// Description:   Interface for notemark tool
+//
+
+#ifndef _TOOL_NOTEMARK_H
+#define _TOOL_NOTEMARK_H
+
+#include "HumTool.h"
+#include "HumdrumFile.h"
+
+using namespace std;
+
+namespace hum {
+
+// START_MERGE
+
+class Tool_notemark : public HumTool {
+
+	public:
+		     Tool_notemark (void);
+		     ~Tool_notemark() {};
+
+		bool run           (HumdrumFileSet& infiles);
+		bool run           (HumdrumFile& infile);
+		bool run           (const string& indata, ostream& out);
+		bool run           (HumdrumFile& infile, ostream& out);
+
+	protected:
+		void               initialize         (void);
+        void               processFile        (HumdrumFile& infile);
+		int                getStartLineNumber (void);
+		int                getEndLineNumber   (void);
+		std::vector<int>   setupSpineInfo     (HumdrumFile& infile);
+
+	private:
+		// m_kernSpines: list of all **kern spines found in file.
+		std::vector<HTp> m_kernSpines;
+
+		// m_selectedKernSpines: list of only the **kern spines that will be analyzed.
+		std::vector<HTp> m_selectedKernSpines;
+
+		std::string m_kernTracks;  // used with -s option
+		std::string m_spineTracks; // used with -k option
+		std::string m_lineRange;   // used with -l option
+		std::string m_signifier;   // used with --signifier option
+		std::string m_color;       // used with --color option
+};
+
+// END_MERGE
+
+} // end namespace hum
+
+#endif /* _TOOL_NOTEMARK_H */

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Fr 11 Okt 2024 00:16:02 CEST
+// Last Modified: Mo 14 Okt 2024 23:10:24 CEST
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -115579,6 +115579,217 @@ void Tool_myank::example(void) {
 void Tool_myank::usage(const string& ommand) {
 
 }
+
+
+
+//////////////////////////////
+//
+// Tool_notemark::Tool_notemark -- Set the recognized options for the tool.
+//
+
+Tool_notemark::Tool_notemark(void) {
+	define("k|kern-tracks=s",      "process only the specified kern spines");
+	define("s|spine-tracks=s",     "process only the specified spines");
+	define("l|lines|line-range=s", "line numbers range to yank (e.g. 40-50)");
+	define("signifier=s",          "signifier to mark the notes (default: @)");
+	define("color=s",              "color for marked notes (default: #ef4444)");
+
+}
+
+
+
+//////////////////////////////
+//
+// Tool_notemark::run -- Do the main work of the tool.
+//
+
+bool Tool_notemark::run(HumdrumFileSet &infiles) {
+	bool status = true;
+	for (int i = 0; i < infiles.getCount(); i++) {
+		status &= run(infiles[i]);
+	}
+	return status;
+}
+
+bool Tool_notemark::run(const string &indata, ostream &out) {
+	HumdrumFile infile(indata);
+	bool status = run(infile);
+	if (hasAnyText()) {
+		getAllText(out);
+	} else {
+		out << infile;
+	}
+	return status;
+}
+
+bool Tool_notemark::run(HumdrumFile &infile, ostream &out) {
+	bool status = run(infile);
+	if (hasAnyText()) {
+		getAllText(out);
+	} else {
+		out << infile;
+	}
+	return status;
+}
+
+bool Tool_notemark::run(HumdrumFile &infile) {
+	initialize();
+	processFile(infile);
+	infile.createLinesFromTokens();
+	return true;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_notemark::initialize --
+//
+
+void Tool_notemark::initialize(void) {
+	m_kernTracks = getString("kern-tracks");
+	m_spineTracks = getString("spine-tracks");
+	m_lineRange = getString("lines");
+	m_signifier = getBoolean("signifier") ? getString("signifier") : "@";
+	m_color = getBoolean("color") ? getString("color") : "#ef4444";
+}
+
+
+
+//////////////////////////////
+//
+// Tool_notemark::processFile --
+//
+
+void Tool_notemark::processFile(HumdrumFile& infile) {
+
+	std::vector<int> selectedSpineIndices = setupSpineInfo(infile);
+
+	bool hasMarkers = false;
+
+	if (getBoolean("lines")) {
+		int startLineNumber = getStartLineNumber();
+		int endLineNumber = getEndLineNumber();
+		if ((startLineNumber > endLineNumber) || (endLineNumber > infile.getLineCount())) {
+			// Disallow when end line number is bigger then line count or when
+			// start line number greather than end line number
+			return;
+		}
+
+		for (int i = startLineNumber; i <= endLineNumber; i++) {
+			HLp line = infile.getLine(i-1);
+			if (line->isData()) {
+				vector<HTp> tokens;
+				line->getTokens(tokens);
+				for (int j = 0; j < tokens.size(); j++) {
+					HTp token = tokens[j];
+					if (token->isNonNullData()) {
+						if (std::find(selectedSpineIndices.begin(), selectedSpineIndices.end(), token->getSpineIndex()) != selectedSpineIndices.end() || selectedSpineIndices.size() == 0) {
+							token->setText(token->getText() + m_signifier);
+							hasMarkers = true;
+						}
+					}
+				}
+				line->createLineFromTokens();
+			}
+		}
+	}
+
+	if (hasMarkers) {
+		infile.appendLine("!!!RDF**kern: " + m_signifier + " = marked note color=\"" + m_color + "\"");
+	}
+
+
+	m_humdrum_text << infile;
+
+}
+
+
+
+////////////////////////
+//
+// Tool_notemark::getStartLineNumber -- Get start line number from --lines
+//
+
+int Tool_notemark::getStartLineNumber(void) {
+	HumRegex hre;
+	if (hre.search(m_lineRange, "^(\\d+)\\-(\\d+)$")) {
+		return hre.getMatchInt(1);
+	}
+	return -1;
+}
+
+
+
+////////////////////////
+//
+// Tool_notemark::getEndLineNumber -- Get end line number from --lines
+//
+
+int Tool_notemark::getEndLineNumber(void) {
+	HumRegex hre;
+	if (hre.search(m_lineRange, "^(\\d+)\\-(\\d+)$")) {
+		return hre.getMatchInt(2);
+	}
+	return -1;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_notemark::setupSpineInfo --
+//
+
+std::vector<int> Tool_notemark::setupSpineInfo(HumdrumFile& infile) {
+
+	infile.getKernSpineStartList(m_kernSpines);
+
+	m_selectedKernSpines.clear();
+
+	if (!m_kernTracks.empty()) {
+		vector<int> tracks = Convert::extractIntegerList(m_kernTracks, (int)m_kernSpines.size());
+		// don't allow out-of-sequence values for the tracks list:
+		sort(tracks.begin(),tracks.end());
+		tracks.erase(unique(tracks.begin(), tracks.end()), tracks.end());
+		for (int i=0; i<(int)tracks.size(); i++) {
+			int index = tracks.at(i) - 1;
+			if ((index < 0) || (index > (int)m_kernSpines.size() - 1)) {
+				continue;
+			}
+			m_selectedKernSpines.push_back(m_kernSpines.at(index));
+		}
+	} else if (!m_spineTracks.empty()) {
+		int maxTrack = infile.getMaxTrack();
+		vector<int> tracks = Convert::extractIntegerList(m_spineTracks, maxTrack);
+		sort(tracks.begin(),tracks.end());
+		tracks.erase(unique(tracks.begin(), tracks.end()), tracks.end());
+		for (int i=0; i<(int)tracks.size(); i++) {
+			int track = tracks.at(i);
+			if ((track < 1) || (track > maxTrack)) {
+				continue;
+			}
+			for (int j=0; j<(int)m_kernSpines.size(); j++) {
+				int ktrack = m_kernSpines.at(j)->getTrack();
+				if (ktrack == track) {
+					m_selectedKernSpines.push_back(m_kernSpines.at(j));
+				}
+			}
+		}
+	} else {
+		// analyzing all **kern tracks
+		m_selectedKernSpines = m_kernSpines;
+	}
+
+ 	std::vector<int> spineIndices(m_selectedKernSpines.size());
+	std::transform(m_selectedKernSpines.begin(), m_selectedKernSpines.end(), spineIndices.begin(),
+        [](const HTp token) {
+            return token->getSpineIndex();
+        });
+
+	return spineIndices;
+}
+
 
 
 

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mo 14 Okt 2024 23:10:24 CEST
+// Last Modified: Mo 14 Okt 2024 23:28:35 CEST
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -87016,6 +87016,8 @@ bool Tool_filter::run(HumdrumFileSet& infiles) {
 			RUNTOOL(modori, infile, commands[i].second, status);
 		} else if (commands[i].first == "msearch") {
 			RUNTOOL(msearch, infile, commands[i].second, status);
+		} else if (commands[i].first == "notemark") {
+			RUNTOOL(notemark, infile, commands[i].second, status);
 		} else if (commands[i].first == "nproof") {
 			RUNTOOL(nproof, infile, commands[i].second, status);
 		} else if (commands[i].first == "ordergps") {

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Do 21 Nov 2024 22:24:14 CET
+// Last Modified: Do 21 Nov 2024 22:30:16 CET
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -115995,9 +115995,10 @@ void Tool_notemark::processFile(HumdrumFile& infile) {
 				vector<HTp> tokens;
 				line->getTokens(tokens);
 				for (HTp& token : tokens) {
-					if (token->isNonNullData()) {
-						if (std::find(selectedSpineIndices.begin(), selectedSpineIndices.end(), token->getSpineIndex()) != selectedSpineIndices.end() || selectedSpineIndices.size() == 0) {
-							token->setText(token->getText() + m_signifier);
+					HTp resolvedToken = token->resolveNull();
+					if (resolvedToken->isNonNullData()) {
+						if (std::find(selectedSpineIndices.begin(), selectedSpineIndices.end(), resolvedToken->getSpineIndex()) != selectedSpineIndices.end() || selectedSpineIndices.size() == 0) {
+							resolvedToken->resolveNull()->setText(resolvedToken->getText() + m_signifier);
 							hasMarkers = true;
 						}
 					}
@@ -116007,10 +116008,11 @@ void Tool_notemark::processFile(HumdrumFile& infile) {
 		}
 	}
 
+	infile.createLinesFromTokens();
+
 	if (hasMarkers) {
 		infile.appendLine("!!!RDF**kern: " + m_signifier + " = marked note color=\"" + m_color + "\"");
 	}
-
 
 	m_humdrum_text << infile;
 

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Do 21 Nov 2024 22:19:21 CET
+// Last Modified: Do 21 Nov 2024 22:24:14 CET
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -116028,6 +116028,9 @@ int Tool_notemark::getStartLineNumber(void) {
 	if (hre.search(m_lineRange, "^(\\d+)\\-(\\d+)$")) {
 		return hre.getMatchInt(1);
 	}
+	if (hre.search(m_lineRange, "^(\\d+)$")) {
+		return hre.getMatchInt(1);
+	}
 	return -1;
 }
 
@@ -116042,6 +116045,9 @@ int Tool_notemark::getEndLineNumber(void) {
 	HumRegex hre;
 	if (hre.search(m_lineRange, "^(\\d+)\\-(\\d+)$")) {
 		return hre.getMatchInt(2);
+	}
+	if (hre.search(m_lineRange, "^(\\d+)$")) {
+		return hre.getMatchInt(1);
 	}
 	return -1;
 }

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Do 21 Nov 2024 22:30:16 CET
+// Last Modified: Do 21 Nov 2024 22:52:39 CET
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -115998,8 +115998,11 @@ void Tool_notemark::processFile(HumdrumFile& infile) {
 					HTp resolvedToken = token->resolveNull();
 					if (resolvedToken->isNonNullData()) {
 						if (std::find(selectedSpineIndices.begin(), selectedSpineIndices.end(), resolvedToken->getSpineIndex()) != selectedSpineIndices.end() || selectedSpineIndices.size() == 0) {
-							resolvedToken->resolveNull()->setText(resolvedToken->getText() + m_signifier);
-							hasMarkers = true;
+							std::string tokenText = resolvedToken->getText();
+							if (m_signifier.size() > tokenText.size() || tokenText.compare(tokenText.size() - m_signifier.size(), m_signifier.size(), m_signifier) != 0) {
+								resolvedToken->resolveNull()->setText(tokenText + m_signifier);
+								hasMarkers = true;
+							}
 						}
 					}
 				}

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mo 14 Okt 2024 23:28:35 CEST
+// Last Modified: Di 15 Okt 2024 23:09:44 CEST
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -115683,8 +115683,7 @@ void Tool_notemark::processFile(HumdrumFile& infile) {
 			if (line->isData()) {
 				vector<HTp> tokens;
 				line->getTokens(tokens);
-				for (int j = 0; j < tokens.size(); j++) {
-					HTp token = tokens[j];
+				for (HTp& token : tokens) {
 					if (token->isNonNullData()) {
 						if (std::find(selectedSpineIndices.begin(), selectedSpineIndices.end(), token->getSpineIndex()) != selectedSpineIndices.end() || selectedSpineIndices.size() == 0) {
 							token->setText(token->getText() + m_signifier);

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Fr 11 Okt 2024 00:16:02 CEST
+// Last Modified: Mo 14 Okt 2024 23:10:24 CEST
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11
@@ -10035,6 +10035,39 @@ class Tool_myank : public HumTool {
 		bool m_hideStarting;                  // used with --hide-starting option
 		bool m_hideEnding;                    // used with --hide-ending option
 
+};
+
+
+class Tool_notemark : public HumTool {
+
+	public:
+		     Tool_notemark (void);
+		     ~Tool_notemark() {};
+
+		bool run           (HumdrumFileSet& infiles);
+		bool run           (HumdrumFile& infile);
+		bool run           (const string& indata, ostream& out);
+		bool run           (HumdrumFile& infile, ostream& out);
+
+	protected:
+		void               initialize         (void);
+        void               processFile        (HumdrumFile& infile);
+		int                getStartLineNumber (void);
+		int                getEndLineNumber   (void);
+		std::vector<int>   setupSpineInfo     (HumdrumFile& infile);
+
+	private:
+		// m_kernSpines: list of all **kern spines found in file.
+		std::vector<HTp> m_kernSpines;
+
+		// m_selectedKernSpines: list of only the **kern spines that will be analyzed.
+		std::vector<HTp> m_selectedKernSpines;
+
+		std::string m_kernTracks;  // used with -s option
+		std::string m_spineTracks; // used with -k option
+		std::string m_lineRange;   // used with -l option
+		std::string m_signifier;   // used with --signifier option
+		std::string m_color;       // used with --color option
 };
 
 

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Do 21 Nov 2024 22:19:21 CET
+// Last Modified: Do 21 Nov 2024 22:24:14 CET
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Do 21 Nov 2024 22:30:16 CET
+// Last Modified: Do 21 Nov 2024 22:52:39 CET
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mo 14 Okt 2024 23:28:35 CEST
+// Last Modified: Di 15 Okt 2024 23:09:44 CEST
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Do 21 Nov 2024 22:24:14 CET
+// Last Modified: Do 21 Nov 2024 22:30:16 CET
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mo 14 Okt 2024 23:10:24 CEST
+// Last Modified: Mo 14 Okt 2024 23:28:35 CEST
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11

--- a/src/tool-filter.cpp
+++ b/src/tool-filter.cpp
@@ -61,6 +61,7 @@
 #include "tool-modori.h"
 #include "tool-msearch.h"
 #include "tool-myank.h"
+#include "tool-notemark.h"
 #include "tool-nproof.h"
 #include "tool-ordergps.h"
 #include "tool-pbar.h"
@@ -323,6 +324,8 @@ bool Tool_filter::run(HumdrumFileSet& infiles) {
 			RUNTOOL(modori, infile, commands[i].second, status);
 		} else if (commands[i].first == "msearch") {
 			RUNTOOL(msearch, infile, commands[i].second, status);
+		} else if (commands[i].first == "notemark") {
+			RUNTOOL(notemark, infile, commands[i].second, status);
 		} else if (commands[i].first == "nproof") {
 			RUNTOOL(nproof, infile, commands[i].second, status);
 		} else if (commands[i].first == "ordergps") {

--- a/src/tool-notemark.cpp
+++ b/src/tool-notemark.cpp
@@ -1,0 +1,238 @@
+//
+// Programmer:    Wolfgang Drescher <drescher.wolfgang@gmail.com>
+// Creation Date: Mon Oct 14 19:24:00 UTC 2024
+// Filename:      tool-notemark.cpp
+// URL:           https://github.com/craigsapp/humlib/blob/master/src/tool-notemark.cpp
+// Syntax:        C++11; humlib
+// vim:           syntax=cpp ts=3 noexpandtab nowrap
+//
+// Description:   Adds note markers for specific lines and voices
+//
+
+#include <iostream>
+#include <vector>
+#include <algorithm> 
+
+#include "tool-notemark.h"
+#include "HumRegex.h"
+#include "Convert.h"
+
+using namespace std;
+
+namespace hum {
+
+// START_MERGE
+
+//////////////////////////////
+//
+// Tool_notemark::Tool_notemark -- Set the recognized options for the tool.
+//
+
+Tool_notemark::Tool_notemark(void) {
+	define("k|kern-tracks=s",      "process only the specified kern spines");
+	define("s|spine-tracks=s",     "process only the specified spines");
+	define("l|lines|line-range=s", "line numbers range to yank (e.g. 40-50)");
+	define("signifier=s",          "signifier to mark the notes (default: @)");
+	define("color=s",              "color for marked notes (default: #ef4444)");
+
+}
+
+
+
+//////////////////////////////
+//
+// Tool_notemark::run -- Do the main work of the tool.
+//
+
+bool Tool_notemark::run(HumdrumFileSet &infiles) {
+	bool status = true;
+	for (int i = 0; i < infiles.getCount(); i++) {
+		status &= run(infiles[i]);
+	}
+	return status;
+}
+
+bool Tool_notemark::run(const string &indata, ostream &out) {
+	HumdrumFile infile(indata);
+	bool status = run(infile);
+	if (hasAnyText()) {
+		getAllText(out);
+	} else {
+		out << infile;
+	}
+	return status;
+}
+
+bool Tool_notemark::run(HumdrumFile &infile, ostream &out) {
+	bool status = run(infile);
+	if (hasAnyText()) {
+		getAllText(out);
+	} else {
+		out << infile;
+	}
+	return status;
+}
+
+bool Tool_notemark::run(HumdrumFile &infile) {
+	initialize();
+	processFile(infile);
+	infile.createLinesFromTokens();
+	return true;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_notemark::initialize --
+//
+
+void Tool_notemark::initialize(void) {
+	m_kernTracks = getString("kern-tracks");
+	m_spineTracks = getString("spine-tracks");
+	m_lineRange = getString("lines");
+	m_signifier = getBoolean("signifier") ? getString("signifier") : "@";
+	m_color = getBoolean("color") ? getString("color") : "#ef4444";
+}
+
+
+
+//////////////////////////////
+//
+// Tool_notemark::processFile --
+//
+
+void Tool_notemark::processFile(HumdrumFile& infile) {
+
+	std::vector<int> selectedSpineIndices = setupSpineInfo(infile);
+
+	bool hasMarkers = false;
+
+	if (getBoolean("lines")) {
+		int startLineNumber = getStartLineNumber();
+		int endLineNumber = getEndLineNumber();
+		if ((startLineNumber > endLineNumber) || (endLineNumber > infile.getLineCount())) {
+			// Disallow when end line number is bigger then line count or when
+			// start line number greather than end line number
+			return;
+		}
+
+		for (int i = startLineNumber; i <= endLineNumber; i++) {
+			HLp line = infile.getLine(i-1);
+			if (line->isData()) {
+				vector<HTp> tokens;
+				line->getTokens(tokens);
+				for (int j = 0; j < tokens.size(); j++) {
+					HTp token = tokens[j];
+					if (token->isNonNullData()) {
+						if (std::find(selectedSpineIndices.begin(), selectedSpineIndices.end(), token->getSpineIndex()) != selectedSpineIndices.end() || selectedSpineIndices.size() == 0) {
+							token->setText(token->getText() + m_signifier);
+							hasMarkers = true;
+						}
+					}
+				}
+				line->createLineFromTokens();
+			}
+		}
+	}
+
+	if (hasMarkers) {
+		infile.appendLine("!!!RDF**kern: " + m_signifier + " = marked note color=\"" + m_color + "\"");
+	}
+
+
+	m_humdrum_text << infile;
+
+}
+
+
+
+////////////////////////
+//
+// Tool_notemark::getStartLineNumber -- Get start line number from --lines
+//
+
+int Tool_notemark::getStartLineNumber(void) {
+	HumRegex hre;
+	if (hre.search(m_lineRange, "^(\\d+)\\-(\\d+)$")) {
+		return hre.getMatchInt(1);
+	}
+	return -1;
+}
+
+
+
+////////////////////////
+//
+// Tool_notemark::getEndLineNumber -- Get end line number from --lines
+//
+
+int Tool_notemark::getEndLineNumber(void) {
+	HumRegex hre;
+	if (hre.search(m_lineRange, "^(\\d+)\\-(\\d+)$")) {
+		return hre.getMatchInt(2);
+	}
+	return -1;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_notemark::setupSpineInfo --
+//
+
+std::vector<int> Tool_notemark::setupSpineInfo(HumdrumFile& infile) {
+
+	infile.getKernSpineStartList(m_kernSpines);
+
+	m_selectedKernSpines.clear();
+
+	if (!m_kernTracks.empty()) {
+		vector<int> tracks = Convert::extractIntegerList(m_kernTracks, (int)m_kernSpines.size());
+		// don't allow out-of-sequence values for the tracks list:
+		sort(tracks.begin(),tracks.end());
+		tracks.erase(unique(tracks.begin(), tracks.end()), tracks.end());
+		for (int i=0; i<(int)tracks.size(); i++) {
+			int index = tracks.at(i) - 1;
+			if ((index < 0) || (index > (int)m_kernSpines.size() - 1)) {
+				continue;
+			}
+			m_selectedKernSpines.push_back(m_kernSpines.at(index));
+		}
+	} else if (!m_spineTracks.empty()) {
+		int maxTrack = infile.getMaxTrack();
+		vector<int> tracks = Convert::extractIntegerList(m_spineTracks, maxTrack);
+		sort(tracks.begin(),tracks.end());
+		tracks.erase(unique(tracks.begin(), tracks.end()), tracks.end());
+		for (int i=0; i<(int)tracks.size(); i++) {
+			int track = tracks.at(i);
+			if ((track < 1) || (track > maxTrack)) {
+				continue;
+			}
+			for (int j=0; j<(int)m_kernSpines.size(); j++) {
+				int ktrack = m_kernSpines.at(j)->getTrack();
+				if (ktrack == track) {
+					m_selectedKernSpines.push_back(m_kernSpines.at(j));
+				}
+			}
+		}
+	} else {
+		// analyzing all **kern tracks
+		m_selectedKernSpines = m_kernSpines;
+	}
+
+ 	std::vector<int> spineIndices(m_selectedKernSpines.size());
+	std::transform(m_selectedKernSpines.begin(), m_selectedKernSpines.end(), spineIndices.begin(),
+        [](const HTp token) {
+            return token->getSpineIndex();
+        });
+
+	return spineIndices;
+}
+
+
+
+// END_MERGE
+
+} // end namespace hum

--- a/src/tool-notemark.cpp
+++ b/src/tool-notemark.cpp
@@ -122,7 +122,7 @@ void Tool_notemark::processFile(HumdrumFile& infile) {
 			if (line->isData()) {
 				vector<HTp> tokens;
 				line->getTokens(tokens);
-				for (int j = 0; j < tokens.size(); j++) {
+				for (auto j = 0; j < tokens.size(); j++) {
 					HTp token = tokens[j];
 					if (token->isNonNullData()) {
 						if (std::find(selectedSpineIndices.begin(), selectedSpineIndices.end(), token->getSpineIndex()) != selectedSpineIndices.end() || selectedSpineIndices.size() == 0) {

--- a/src/tool-notemark.cpp
+++ b/src/tool-notemark.cpp
@@ -122,8 +122,7 @@ void Tool_notemark::processFile(HumdrumFile& infile) {
 			if (line->isData()) {
 				vector<HTp> tokens;
 				line->getTokens(tokens);
-				for (auto j = 0; j < tokens.size(); j++) {
-					HTp token = tokens[j];
+				for (HTp& token : tokens) {
 					if (token->isNonNullData()) {
 						if (std::find(selectedSpineIndices.begin(), selectedSpineIndices.end(), token->getSpineIndex()) != selectedSpineIndices.end() || selectedSpineIndices.size() == 0) {
 							token->setText(token->getText() + m_signifier);

--- a/src/tool-notemark.cpp
+++ b/src/tool-notemark.cpp
@@ -156,6 +156,9 @@ int Tool_notemark::getStartLineNumber(void) {
 	if (hre.search(m_lineRange, "^(\\d+)\\-(\\d+)$")) {
 		return hre.getMatchInt(1);
 	}
+	if (hre.search(m_lineRange, "^(\\d+)$")) {
+		return hre.getMatchInt(1);
+	}
 	return -1;
 }
 
@@ -170,6 +173,9 @@ int Tool_notemark::getEndLineNumber(void) {
 	HumRegex hre;
 	if (hre.search(m_lineRange, "^(\\d+)\\-(\\d+)$")) {
 		return hre.getMatchInt(2);
+	}
+	if (hre.search(m_lineRange, "^(\\d+)$")) {
+		return hre.getMatchInt(1);
 	}
 	return -1;
 }

--- a/src/tool-notemark.cpp
+++ b/src/tool-notemark.cpp
@@ -123,9 +123,10 @@ void Tool_notemark::processFile(HumdrumFile& infile) {
 				vector<HTp> tokens;
 				line->getTokens(tokens);
 				for (HTp& token : tokens) {
-					if (token->isNonNullData()) {
-						if (std::find(selectedSpineIndices.begin(), selectedSpineIndices.end(), token->getSpineIndex()) != selectedSpineIndices.end() || selectedSpineIndices.size() == 0) {
-							token->setText(token->getText() + m_signifier);
+					HTp resolvedToken = token->resolveNull();
+					if (resolvedToken->isNonNullData()) {
+						if (std::find(selectedSpineIndices.begin(), selectedSpineIndices.end(), resolvedToken->getSpineIndex()) != selectedSpineIndices.end() || selectedSpineIndices.size() == 0) {
+							resolvedToken->resolveNull()->setText(resolvedToken->getText() + m_signifier);
 							hasMarkers = true;
 						}
 					}
@@ -135,10 +136,11 @@ void Tool_notemark::processFile(HumdrumFile& infile) {
 		}
 	}
 
+	infile.createLinesFromTokens();
+
 	if (hasMarkers) {
 		infile.appendLine("!!!RDF**kern: " + m_signifier + " = marked note color=\"" + m_color + "\"");
 	}
-
 
 	m_humdrum_text << infile;
 

--- a/src/tool-notemark.cpp
+++ b/src/tool-notemark.cpp
@@ -126,8 +126,11 @@ void Tool_notemark::processFile(HumdrumFile& infile) {
 					HTp resolvedToken = token->resolveNull();
 					if (resolvedToken->isNonNullData()) {
 						if (std::find(selectedSpineIndices.begin(), selectedSpineIndices.end(), resolvedToken->getSpineIndex()) != selectedSpineIndices.end() || selectedSpineIndices.size() == 0) {
-							resolvedToken->resolveNull()->setText(resolvedToken->getText() + m_signifier);
-							hasMarkers = true;
+							std::string tokenText = resolvedToken->getText();
+							if (m_signifier.size() > tokenText.size() || tokenText.compare(tokenText.size() - m_signifier.size(), m_signifier.size(), m_signifier) != 0) {
+								resolvedToken->resolveNull()->setText(tokenText + m_signifier);
+								hasMarkers = true;
+							}
 						}
 					}
 				}


### PR DESCRIPTION
To highlight certain moments or sections in a score, I currently often use small JavaScript functions. Since this is unreliable, especially with spine splits, I have now added a tool called `notemark`. So you can easily highlight certain parts in the browser by adding a line `!!!filter: notemark -l 19` or something similar before the score is rendered with Verovio.

`notemark` is perhaps not the best naming. I am open to better suggestions. How about `notemarker` or `notehighlight`?

Currently the highlighting of notes is only supported via line numbers. In the future it might be useful to implement support for measures or `beat` segments.

test.krn:

```
**kern	**kern	**kern	**kern
*clefF4	*clefGv2	*clefG2	*clefG2
*k[f#]	*k[f#]	*k[f#]	*k[f#]
*M3/4	*M3/4	*M3/4	*M3/4
4GG	4B	4d	4g
=1	=1	=1	=1
4G	4B	4d	2g
4E	8cL	4e	.
.	8BJ	.	.
4F#	4A	4d	4dd
=2	=2	=2	=2
4G	4G	2d	4.b
4D	4F#	.	.
.	.	.	8a
4E	4G	4B	4g
=3	=3	=3	=3
4C	8cL	8eL	4.g
.	8BJ	8d	.
8BBL	4c	8e	.
8AAJ	.	8f#J	8a
4GG	4d	4g	4b
=4	=4	=4	=4
2D;	2d;	2f#;	2a;
==	==	==	==
*-	*-	*-	*-
```

`notemark test.krn -l 19`:

```
**kern	**kern	**kern	**kern
*clefF4	*clefGv2	*clefG2	*clefG2
*k[f#]	*k[f#]	*k[f#]	*k[f#]
*M3/4	*M3/4	*M3/4	*M3/4
4GG	4B	4d	4g
=1	=1	=1	=1
4G	4B	4d	2g
4E	8cL	4e	.
.	8BJ	.	.
4F#	4A	4d	4dd
=2	=2	=2	=2
4G	4G	2d	4.b
4D	4F#	.	.
.	.	.	8a
4E	4G	4B	4g
=3	=3	=3	=3
4C	8cL	8eL	4.g@
.	8BJ	8d	.
8BBL@	4c@	8e@	.
8AAJ	.	8f#J	8a
4GG	4d	4g	4b
=4	=4	=4	=4
2D;	2d;	2f#;	2a;
==	==	==	==
*-	*-	*-	*-
!!!RDF**kern: @ = marked note color="#ef4444"
```

`notemark test.krn -l 11-15 -k 1,4`

```
**kern	**kern	**kern	**kern
*clefF4	*clefGv2	*clefG2	*clefG2
*k[f#]	*k[f#]	*k[f#]	*k[f#]
*M3/4	*M3/4	*M3/4	*M3/4
4GG	4B	4d	4g
=1	=1	=1	=1
4G	4B	4d	2g
4E	8cL	4e	.
.	8BJ	.	.
4F#	4A	4d	4dd
=2	=2	=2	=2
4G@	4G	2d	4.b@
4D@	4F#	.	.
.	.	.	8a@
4E@	4G	4B	4g@
=3	=3	=3	=3
4C	8cL	8eL	4.g
.	8BJ	8d	.
8BBL	4c	8e	.
8AAJ	.	8f#J	8a
4GG	4d	4g	4b
=4	=4	=4	=4
2D;	2d;	2f#;	2a;
==	==	==	==
*-	*-	*-	*-
!!!RDF**kern: @ = marked note color="#ef4444"
```