### PR TITLE
Improvements for meter program

### DIFF
--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Fr 13 Dez 2024 10:53:41 CET
+// Last Modified: Fr 13 Dez 2024 22:20:34 CET
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -102568,6 +102568,14 @@ void Tool_meter::analyzePickupMeasures(HTp sstart) {
 			if (bardur.at(i) + bardur.at(i+1) == tsigdur.at(i)) {
 				pickup.at(i+1) = true;
 				i++;
+				continue;
+			}
+		}
+		if (bardur.at(i) < tsigdur.at(i)) {
+			HumRegex hre;
+			HTp barlineToken = barandtime.at(i).at(0);
+			if (barlineToken->isBarline() && hre.search(barlineToken, "\\|\\||:?\\|?!\\|?:?")) {
+				pickup.at(i) = true;
 				continue;
 			}
 		}

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Fri Nov 22 09:29:17 AM PST 2024
+// Last Modified: Fr 13 Dez 2024 10:28:28 CET
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -102717,7 +102717,7 @@ void Tool_meter::printLabelLine(HumdrumLine& line) {
 	bool printLabels = true;
 	for (int i=0; i<line.getFieldCount(); i++) {
 		HTp token = line.token(i);
-		if (token->isKern()) {
+		if (token->isKernLike()) {
 			i = printKernAndAnalysisSpine(line, i, printLabels, forceInterpretation);
 		} else {
 			m_humdrum_text << "*";
@@ -102740,7 +102740,7 @@ void Tool_meter::printHumdrumLine(HumdrumLine& line, bool printLabels) {
 
 	for (int i=0; i<line.getFieldCount(); i++) {
 		HTp token = line.token(i);
-		if (token->isKern()) {
+		if (token->isKernLike()) {
 			i = printKernAndAnalysisSpine(line, i, printLabels);
 		} else {
 			m_humdrum_text << token;
@@ -103046,7 +103046,7 @@ void Tool_meter::processLine(HumdrumLine& line, vector<HumNum>& curNum,
 	if (line.isBarline()) {
 		for (int i=0; i<fieldCount; i++) {
 			HTp token = line.token(i);
-			if (!token->isKern()) {
+			if (!token->isKernLike()) {
 				continue;
 			}
 			if (hre.search(token, "-")) {
@@ -103064,7 +103064,7 @@ void Tool_meter::processLine(HumdrumLine& line, vector<HumNum>& curNum,
 		// check for time signatures
 		for (int i=0; i<fieldCount; i++) {
 			HTp token = line.token(i);
-			if (!token->isKern()) {
+			if (!token->isKernLike()) {
 				continue;
 			}
 			if (hre.search(token, "^\\*M(\\d+)/(\\d+)")) {
@@ -103087,7 +103087,7 @@ void Tool_meter::processLine(HumdrumLine& line, vector<HumNum>& curNum,
 		// check for time signatures
 		for (int i=0; i<fieldCount; i++) {
 			HTp token = line.token(i);
-			if (!token->isKern()) {
+			if (!token->isKernLike()) {
 				continue;
 			}
 			if (token->isNull()) {

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Fr 13 Dez 2024 10:28:28 CET
+// Last Modified: Fr 13 Dez 2024 10:53:41 CET
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -102914,6 +102914,9 @@ int Tool_meter::printKernAndAnalysisSpine(HumdrumLine& line, int index, bool pri
 				meter = "*-";
 			} else if (token->isTimeSignature()) {
 				analysis = *token;
+				numerator = *token;
+				denominator = *token;
+				meter = *token;
 			} else {
 				analysis = "*";
 				numerator = "*";

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Fr 13 Dez 2024 22:20:34 CET
+// Last Modified: Fr 13 Dez 2024 22:27:49 CET
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -102498,7 +102498,7 @@ void Tool_meter::processFile(HumdrumFile& infile) {
 
 void Tool_meter::analyzePickupMeasures(HumdrumFile& infile) {
 	vector<HTp> sstarts;
-	infile.getKernSpineStartList(sstarts);
+	infile.getKernLikeSpineStartList(sstarts);
 	for (int i=0; i<(int)sstarts.size(); i++) {
 		analyzePickupMeasures(sstarts[i]);
 	}

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Fr 13 Dez 2024 10:28:28 CET
+// Last Modified: Fr 13 Dez 2024 10:53:41 CET
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Fri Nov 22 09:29:17 AM PST 2024
+// Last Modified: Fr 13 Dez 2024 10:28:28 CET
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Fr 13 Dez 2024 22:20:34 CET
+// Last Modified: Fr 13 Dez 2024 22:27:49 CET
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Fr 13 Dez 2024 10:53:41 CET
+// Last Modified: Fr 13 Dez 2024 22:20:34 CET
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11

--- a/src/tool-meter.cpp
+++ b/src/tool-meter.cpp
@@ -611,6 +611,9 @@ int Tool_meter::printKernAndAnalysisSpine(HumdrumLine& line, int index, bool pri
 				meter = "*-";
 			} else if (token->isTimeSignature()) {
 				analysis = *token;
+				numerator = *token;
+				denominator = *token;
+				meter = *token;
 			} else {
 				analysis = "*";
 				numerator = "*";

--- a/src/tool-meter.cpp
+++ b/src/tool-meter.cpp
@@ -268,6 +268,14 @@ void Tool_meter::analyzePickupMeasures(HTp sstart) {
 				continue;
 			}
 		}
+		if (bardur.at(i) < tsigdur.at(i)) {
+			HumRegex hre;
+			HTp barlineToken = barandtime.at(i).at(0);
+			if (barlineToken->isBarline() && hre.search(barlineToken, "\\|\\||:?\\|?!\\|?:?")) {
+				pickup.at(i) = true;
+				continue;
+			}
+		}
 	}
 
 	// check for first-measure pickup

--- a/src/tool-meter.cpp
+++ b/src/tool-meter.cpp
@@ -414,7 +414,7 @@ void Tool_meter::printLabelLine(HumdrumLine& line) {
 	bool printLabels = true;
 	for (int i=0; i<line.getFieldCount(); i++) {
 		HTp token = line.token(i);
-		if (token->isKern()) {
+		if (token->isKernLike()) {
 			i = printKernAndAnalysisSpine(line, i, printLabels, forceInterpretation);
 		} else {
 			m_humdrum_text << "*";
@@ -437,7 +437,7 @@ void Tool_meter::printHumdrumLine(HumdrumLine& line, bool printLabels) {
 
 	for (int i=0; i<line.getFieldCount(); i++) {
 		HTp token = line.token(i);
-		if (token->isKern()) {
+		if (token->isKernLike()) {
 			i = printKernAndAnalysisSpine(line, i, printLabels);
 		} else {
 			m_humdrum_text << token;
@@ -743,7 +743,7 @@ void Tool_meter::processLine(HumdrumLine& line, vector<HumNum>& curNum,
 	if (line.isBarline()) {
 		for (int i=0; i<fieldCount; i++) {
 			HTp token = line.token(i);
-			if (!token->isKern()) {
+			if (!token->isKernLike()) {
 				continue;
 			}
 			if (hre.search(token, "-")) {
@@ -761,7 +761,7 @@ void Tool_meter::processLine(HumdrumLine& line, vector<HumNum>& curNum,
 		// check for time signatures
 		for (int i=0; i<fieldCount; i++) {
 			HTp token = line.token(i);
-			if (!token->isKern()) {
+			if (!token->isKernLike()) {
 				continue;
 			}
 			if (hre.search(token, "^\\*M(\\d+)/(\\d+)")) {
@@ -784,7 +784,7 @@ void Tool_meter::processLine(HumdrumLine& line, vector<HumNum>& curNum,
 		// check for time signatures
 		for (int i=0; i<fieldCount; i++) {
 			HTp token = line.token(i);
-			if (!token->isKern()) {
+			if (!token->isKernLike()) {
 				continue;
 			}
 			if (token->isNull()) {

--- a/src/tool-meter.cpp
+++ b/src/tool-meter.cpp
@@ -195,7 +195,7 @@ void Tool_meter::processFile(HumdrumFile& infile) {
 
 void Tool_meter::analyzePickupMeasures(HumdrumFile& infile) {
 	vector<HTp> sstarts;
-	infile.getKernSpineStartList(sstarts);
+	infile.getKernLikeSpineStartList(sstarts);
 	for (int i=0; i<(int)sstarts.size(); i++) {
 		analyzePickupMeasures(sstarts[i]);
 	}


### PR DESCRIPTION
## Add support for kern like spines

input.krn:

```
**kern	**kern	**kern	**kern
*M3/4	*M3/4	*M3/4	*M3/4
4GG	4B	4d	4g
=1	=1	=1	=1
4G	4B	4d	2g
4E	8cL	4e	.
.	8BJ	.	.
4F#	4A	4d	4dd
=2	=2	=2	=2
4G	4G	2d	4.b
4D	4F#	.	.
.	.	.	8a
4E	4G	4B	4g
=3	=3	=3	=3
4C	8cL	8eL	4.g
.	8BJ	8d	.
8BBL	4c	8e	.
8AAJ	.	8f#J	8a
4GG	4d	4g	4b
=4	=4	=4	=4
2D;	2d;	2f#;	2a;
*-	*-	*-	*-

```

`cat input.krn | composite -x | meter -L`

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

```
**kern-comp
*M3/4
4eR
=1
4eR
8eRL
8eRJ
4eR
=2
4eR
8eRL
8eRJ
4eR
=3
8eRL
8eRJ
8eRL
8eRJ
4eR
=4
2eR
*-
```

</td><td>

```
**kern-comp	**cdata-beat
*M3/4	*M3/4
4eR	3
=1	=1
4eR	1
8eRL	2
8eRJ	2+1/2
4eR	3
=2	=2
4eR	1
8eRL	2
8eRJ	2+1/2
4eR	3
=3	=3
8eRL	1
8eRJ	1+1/2
8eRL	2
8eRJ	2+1/2
4eR	3
=4	=4
2eR	1
*-	*-
```

</td></tr>
</table>

## Fix wrong tandem interpretation in tsig spine

Input as above

`cat input.krn | extractxx -k $ | meter -t`

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

```
**kern	**cdata-beat	**cdata-tsig
*M3/4	*M3/4	.
*	*vi:beat:	*vi:tsig:
4g	3	3/4
=1	=1	=1
2g	1	3/4
.	.	.
.	.	.
4dd	3	3/4
=2	=2	=2
4.b	1	3/4
.	.	.
8a	2+1/2	3/4
4g	3	3/4
=3	=3	=3
4.g	1	3/4
.	.	.
.	.	.
8a	2+1/2	3/4
4b	3	3/4
=4	=4	=4
2a;	1	3/4
*-	*-	*-
```

</td><td>

```
**kern	**cdata-beat	**cdata-tsig
*M3/4	*M3/4	*M3/4
*	*vi:beat:	*vi:tsig:
4g	3	3/4
=1	=1	=1
2g	1	3/4
.	.	.
.	.	.
4dd	3	3/4
=2	=2	=2
4.b	1	3/4
.	.	.
8a	2+1/2	3/4
4g	3	3/4
=3	=3	=3
4.g	1	3/4
.	.	.
.	.	.
8a	2+1/2	3/4
4b	3	3/4
=4	=4	=4
2a;	1	3/4
*-	*-	*-
```

</td></tr>
</table>

## Improve pickup analysis in the middle of a piece

Marks a measure as a pickup when `bardur < tsigdur` and the barline token contains `||` or `:?|?!|?:?`.

Input: https://github.com/WolfgangDrescher/mendelssohn-choral-works/blob/master/kern/48-6-herbstlied.krn

Measure 40 will be analyzed as a pickup.

Input: https://github.com/WolfgangDrescher/mendelssohn-choral-works/blob/master/kern/59-2-fruehzeitiger-fruehling.krn

Measure 41 will be analyzed as a pickup.

Input: https://github.com/WolfgangDrescher/mendelssohn-choral-works/blob/master/kern/100-1-andenken.krn

Measure 21 will be analyzed as a pickup.