### PR TITLE
Update 1520ify filter

### DIFF
--- a/cli/jrpize.cpp
+++ b/cli/jrpize.cpp
@@ -1,0 +1,2474 @@
+//
+// Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu> and Benjamin Ory <benjaminory@gmail.com>
+// Creation Date: Wed Oct 18 13:40:23 PDT 2017
+// Last Modified: Fri Nov 14 17:00:00 PDT 2025
+// Filename:      tool-1520ify.cpp
+// URL:           https://github.com/craigsapp/humlib/blob/master/src/tool-1520ify.cpp
+// Syntax:        C++11; humlib
+// vim:           syntax=cpp ts=3 noexpandtab nowrap
+//
+// Description:   Refinements and corrections for TiM scores imported
+//                from Finale/Sibelius/MuseScore.
+//
+
+#include "tool-1520ify.h"
+#include "tool-shed.h"
+#include "Convert.h"
+#include "HumRegex.h"
+
+#include <algorithm>
+#include <chrono>
+#include <iomanip>
+#include <sstream>
+
+// include filesystem for grabbing the filename
+#include <filesystem>
+
+// for title
+#include <regex>
+
+using namespace std;
+
+namespace hum {
+
+// START_MERGE
+
+static std::string getMetForMensurationLabel(const std::string& text) {
+	static const std::vector<std::pair<std::string, std::string>> mappings = {
+		{"MenCircleOver3", "*met(O/3)"},
+		{"MenCutCircle3", "*met(O|3)"},
+		{"MenCircleDot", "*met(O.)"},
+		{"MenCutCDot", "*met(C.|)"},
+		{"MenReverseC", "*met(Cr)"},
+		{"Men3Over2", "*met(3/2)"},
+		{"MenCutCircle", "*met(O|)"},
+		{"MenCutC3", "*met(C|3)"},
+		{"MenCutC2", "*met(C|2)"},
+		{"MenCircle3", "*met(O3)"},
+		{"MenCircle2", "*met(O2)"},
+		{"MenCutC", "*met(C|)"},
+		{"MenCDot", "*met(C.)"},
+		{"MenC3", "*met(C3)"},
+		{"MenC2", "*met(C2)"},
+		{"MenCircle", "*met(O)"},
+		{"MenC", "*met(C)"},
+		{"Men3", "*met(3)"},
+		{"Men2", "*met(2)"}
+	};
+
+	for (const auto& mapping : mappings) {
+		size_t pos = text.find(mapping.first);
+		if (pos == std::string::npos) {
+			continue;
+		}
+		size_t end = pos + mapping.first.size();
+		if ((end < text.size()) && std::isalnum(static_cast<unsigned char>(text[end]))) {
+			continue;
+		}
+		return mapping.second;
+	}
+
+	return "";
+}
+
+
+static std::string getNearbyMensurationLabelMet(HumdrumFile& infile, int mensline) {
+	for (int i=mensline + 1; i<infile.getLineCount(); ++i) {
+		if (infile[i].isData() || infile[i].isBarline() || infile[i].isTerminator()) {
+			break;
+		}
+		if (infile[i].isInterpretation()) {
+			continue;
+		}
+		if (!infile[i].isLocalComment() && !infile[i].isGlobalComment()) {
+			continue;
+		}
+		for (int j=0; j<infile[i].getFieldCount(); ++j) {
+			HTp tok = infile.token(i, j);
+			if (!tok) {
+				continue;
+			}
+			std::string met = getMetForMensurationLabel(tok->getText());
+			if (!met.empty()) {
+				return met;
+			}
+		}
+	}
+
+	return "";
+}
+
+
+static void deleteNearbyMensurationLabel(HumdrumFile& infile, int mensline) {
+	for (int i=mensline + 1; i<infile.getLineCount(); ++i) {
+		if (infile[i].isData() || infile[i].isBarline() || infile[i].isTerminator()) {
+			break;
+		}
+		if (infile[i].isInterpretation()) {
+			continue;
+		}
+		if (!infile[i].isLocalComment() && !infile[i].isGlobalComment()) {
+			continue;
+		}
+
+		bool changed = false;
+		for (int j=0; j<infile[i].getFieldCount(); ++j) {
+			HTp tok = infile.token(i, j);
+			if (!tok) {
+				continue;
+			}
+			if (getMetForMensurationLabel(tok->getText()).empty()) {
+				continue;
+			}
+			if (infile[i].isGlobalComment()) {
+				infile.deleteLine(i);
+				return;
+			}
+			tok->setText("!");
+			changed = true;
+		}
+
+		if (!changed) {
+			continue;
+		}
+
+		bool empty = true;
+		for (int j=0; j<infile[i].getFieldCount(); ++j) {
+			HTp tok = infile.token(i, j);
+			if (tok && (*tok != "!")) {
+				empty = false;
+				break;
+			}
+		}
+		if (empty) {
+			infile.deleteLine(i);
+		}
+		return;
+	}
+}
+
+
+static void applyMensurationLabelMetOverrides(HumdrumFile& infile) {
+	for (int i=0; i<infile.getLineCount(); ++i) {
+		if (!infile[i].isInterpretation()) {
+			continue;
+		}
+
+		bool hasMens = false;
+		for (int j=0; j<infile[i].getFieldCount(); ++j) {
+			HTp tok = infile.token(i, j);
+			if (tok && (tok->compare(0, 2, "*M") == 0)) {
+				hasMens = true;
+				break;
+			}
+		}
+		if (!hasMens) {
+			continue;
+		}
+
+		std::string labelMet = getNearbyMensurationLabelMet(infile, i);
+		if (labelMet.empty()) {
+			continue;
+		}
+
+		for (int j=i + 1; j<infile.getLineCount(); ++j) {
+			if (infile[j].isData() || infile[j].isBarline() || infile[j].isTerminator()) {
+				break;
+			}
+			if (!infile[j].isInterpretation()) {
+				continue;
+			}
+
+			bool hasMet = false;
+			for (int k=0; k<infile[j].getFieldCount(); ++k) {
+				HTp tok = infile.token(j, k);
+				if (tok && (tok->compare(0, 5, "*met(") == 0)) {
+					hasMet = true;
+					break;
+				}
+			}
+			if (!hasMet) {
+				continue;
+			}
+
+			for (int k=0; k<infile[j].getFieldCount(); ++k) {
+				HTp tok = infile.token(j, k);
+				if (tok && !tok->isNull()) {
+					tok->setText(labelMet);
+				}
+			}
+			deleteNearbyMensurationLabel(infile, i);
+			break;
+		}
+	}
+}
+
+
+static std::string addMeasureNumberToBarlineToken(const std::string& text, int number) {
+	std::string output;
+	for (int i=0; i<(int)text.size(); ++i) {
+		if ((text[i] == '=') && ((i + 1 >= (int)text.size()) || (text[i + 1] != '='))) {
+			output += '=';
+			output += std::to_string(number);
+		} else if (!std::isdigit(static_cast<unsigned char>(text[i]))) {
+			output += text[i];
+		}
+	}
+	return output;
+}
+
+
+static void addAllMeasureNumbers(HumdrumFile& infile) {
+	int number = 1;
+	for (int i=0; i<infile.getLineCount(); ++i) {
+		if (!infile[i].isBarline()) {
+			continue;
+		}
+
+		bool finalQ = false;
+		for (int j=0; j<infile[i].getFieldCount(); ++j) {
+			HTp tok = infile.token(i, j);
+			if (tok && (tok->find("==") != std::string::npos)) {
+				finalQ = true;
+				break;
+			}
+		}
+		if (finalQ) {
+			continue;
+		}
+
+		for (int j=0; j<infile[i].getFieldCount(); ++j) {
+			HTp tok = infile.token(i, j);
+			if (tok) {
+				tok->setText(addMeasureNumberToBarlineToken(tok->getText(), number));
+			}
+		}
+		number++;
+	}
+}
+
+
+static std::string getDefaultMetForMensuration(HTp token) {
+	if (!token || token->isNull()) {
+		return "";
+	}
+	if (*token == "*M2/1") {
+		return "*met(C|)";
+	}
+	if (*token == "*M3/1") {
+		return "*met(O)";
+	}
+	if (*token == "*M6/2") {
+		return "*met(C.)";
+	}
+	if (*token == "*M9/2") {
+		return "*met(O.)";
+	}
+	return "";
+}
+
+
+static bool hasNonemptyReference(HumdrumFile& infile, const std::string& key) {
+	std::string prefix = "!!!" + key + ":";
+	for (int i=0; i<infile.getLineCount(); ++i) {
+		if (!infile[i].isReference()) {
+			continue;
+		}
+		HTp tok = infile.token(i, 0);
+		if (!tok || (tok->compare(0, prefix.size(), prefix) != 0)) {
+			continue;
+		}
+		std::string text = tok->getText();
+		size_t colon = text.find(':');
+		if (colon == std::string::npos) {
+			return false;
+		}
+		for (size_t p=colon + 1; p<text.size(); ++p) {
+			if (!std::isspace(static_cast<unsigned char>(text[p]))) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	return false;
+}
+
+
+static bool hasMuse2psRecord(HumdrumFile& infile) {
+	for (int i=0; i<infile.getLineCount(); ++i) {
+		if (!infile[i].isGlobalComment()) {
+			continue;
+		}
+		HTp tok = infile.token(i, 0);
+		if (tok && (tok->compare(0, 10, "!!muse2ps:") == 0)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+
+static bool hasTextSpines(HumdrumFile& infile) {
+	for (int i=0; i<infile.getLineCount(); ++i) {
+		if (!infile[i].isExclusive()) {
+			continue;
+		}
+		for (int j=0; j<infile[i].getFieldCount(); ++j) {
+			HTp tok = infile.token(i, j);
+			if (tok && (*tok == "**text")) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+
+static std::string getMuse2psSpacing(int voices, bool texted) {
+	if (texted) {
+		if (voices == 3) {
+			return "i2I150v90,90,120c122z18l2700t130";
+		}
+		if (voices == 4) {
+			return "i2I150v90,90,90,120c122z18l2700t130";
+		}
+		if (voices == 5) {
+			return "i2I150v75,75,75,75,110c122z18l2780t100";
+		}
+		if (voices == 6) {
+			return "i2I150v85,85,85,85,85,100z18l2550t200c122";
+		}
+		return "";
+	}
+
+	if (voices == 3) {
+		return "i2I150v90,90,120c120z18l2770t130";
+	}
+	if (voices == 4) {
+		return "i2I150v90,90,90,120c120z18l2770t130";
+	}
+	if (voices == 5) {
+		return "i2I150v90,90,90,90,120c120z18l2770t130";
+	}
+	if (voices == 6) {
+		return "i2I150v85,85,85,85,85,100z18l2550t200c122";
+	}
+
+	return "";
+}
+
+
+static void addMuse2psRecord(HumdrumFile& infile) {
+	if (hasMuse2psRecord(infile)) {
+		return;
+	}
+
+	int voices = (int)infile.getKernSpineStartList().size();
+	std::string spacing = getMuse2psSpacing(voices, hasTextSpines(infile));
+	if (spacing.empty()) {
+		return;
+	}
+
+	std::string prefix = "C^@{COM}^";
+	if (hasNonemptyReference(infile, "OPR")) {
+		prefix = "T^@{OPR}^u^@{ONM}{. }@{OTL}^C^@{COM}^";
+	}
+
+	infile.appendLine("!!muse2ps: " + prefix + spacing);
+}
+
+
+static void splitEncoderDate(HumdrumFile& infile) {
+	HumRegex hre;
+	int encLine = -1;
+	int endLine = -1;
+	std::string encoder;
+	std::string endDate;
+
+	for (int i=0; i<infile.getLineCount(); ++i) {
+		if (!infile[i].isReference()) {
+			continue;
+		}
+		HTp tok = infile.token(i, 0);
+		if (!tok) {
+			continue;
+		}
+		if ((encLine < 0) && (tok->compare(0, 7, "!!!ENC:") == 0)) {
+			std::string text = tok->getText().substr(7);
+			while (!text.empty() && std::isspace(static_cast<unsigned char>(text.front()))) {
+				text.erase(text.begin());
+			}
+			while (!text.empty() && std::isspace(static_cast<unsigned char>(text.back()))) {
+				text.pop_back();
+			}
+			if (hre.search(text, "^(.+?)\\s+((?:\\d{4}/\\d{1,2}/\\d{1,2})|(?:\\d{1,2}-\\d{1,2}-\\d{4}))/?$")) {
+				encoder = hre.getMatch(1);
+				endDate = hre.getMatch(2);
+				encLine = i;
+			}
+		} else if ((endLine < 0) && (tok->compare(0, 7, "!!!END:") == 0)) {
+			endLine = i;
+		}
+	}
+
+	if (encLine < 0) {
+		return;
+	}
+
+	while (!encoder.empty() && std::isspace(static_cast<unsigned char>(encoder.back()))) {
+		encoder.pop_back();
+	}
+	infile.token(encLine, 0)->setText("!!!ENC: " + encoder);
+
+	if (endLine >= 0) {
+		HTp tok = infile.token(endLine, 0);
+		std::string text = tok ? tok->getText() : "";
+		size_t colon = text.find(':');
+		bool hasContent = false;
+		if (colon != std::string::npos) {
+			for (size_t p=colon + 1; p<text.size(); ++p) {
+				if (!std::isspace(static_cast<unsigned char>(text[p]))) {
+					hasContent = true;
+					break;
+				}
+			}
+		}
+		if (!hasContent && tok) {
+			tok->setText("!!!END: " + endDate);
+		}
+	} else {
+		infile.insertLine(encLine + 1, "!!!END: " + endDate);
+	}
+}
+
+
+/////////////////////////////////
+//
+// Tool_1520ify::Tool_1520ify -- Set the recognized options for the tool.
+//
+
+Tool_1520ify::Tool_1520ify(void) {
+	define("R|no-reference-records=b",                "do not add reference records");
+	define("r|only-add-reference-records=b",          "only add reference records");
+
+	define("B|do-not-delete-breaks=b",                "do not delete system/page break markers");
+	define("b|only-delete-breaks=b",                  "only delete breaks");
+
+	define("A|do-not-fix-instrument-abbreviations=b", "do not fix instrument abbreviations");
+	define("a|only-fix-instrument-abbreviations=b",   "only fix instrument abbreviations");
+
+	define("E|do-not-fix-editorial-accidentals=b",    "do not fix instrument abbreviations");
+	define("e|only-fix-editorial-accidentals=b",      "only fix editorial accidentals");
+
+	define("T|do-not-add-terminal-longs=b",           "do not add terminal long markers");
+	define("t|only-add-terminal-longs=b",             "only add terminal longs");
+
+	define("N|do-not-remove-empty-transpositions=b",  "do not remove empty transposition instructions");
+	define ("n|only-remove-empty-transpositions=b",   "only remove empty transpositions");
+}
+
+
+
+/////////////////////////////////
+//
+// Tool_1520ify::run -- Primary interfaces to the tool.
+//
+
+bool Tool_1520ify::run(HumdrumFileSet& infiles) {
+	bool status = true;
+	for (int i=0; i<infiles.getCount(); i++) {
+		status &= run(infiles[i]);
+	}
+	return status;
+}
+
+
+bool Tool_1520ify::run(const string& indata, ostream& out) {
+	HumdrumFile infile(indata);
+	bool status = run(infile);
+	if (hasAnyText()) {
+		getAllText(out);
+	} else {
+		out << infile;
+	}
+	return status;
+}
+
+
+bool Tool_1520ify::run(HumdrumFile& infile, ostream& out) {
+	bool status = run(infile);
+	if (hasAnyText()) {
+		getAllText(out);
+	} else {
+		out << infile;
+	}
+	return status;
+}
+
+//
+// In-place processing of file:
+//
+
+bool Tool_1520ify::run(HumdrumFile& infile) {
+	processFile(infile);
+
+	// Re-load the text for each line from their tokens.
+	infile.createLinesFromTokens();
+
+	// Need to adjust the line numbers for tokens for later
+	// processing.
+	m_humdrum_text << infile;
+	return true;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_1520ify::processFile --
+//
+
+void Tool_1520ify::processFile(HumdrumFile& infile) {
+
+	bool abbreviationsQ  = true;
+	bool accidentalsQ    = true;
+	bool referencesQ     = true;
+	bool terminalsQ      = true;
+	bool breaksQ         = true;
+	bool transpositionsQ = true;
+
+	if (getBoolean("no-reference-records")) { referencesQ = false; }
+	if (getBoolean("only-add-reference-records")) {
+		abbreviationsQ  = false;
+		accidentalsQ    = false;
+		referencesQ     = true;
+		terminalsQ      = false;
+		breaksQ         = false;
+		transpositionsQ = false;
+	}
+
+	if (getBoolean("do-not-delete-breaks")) { breaksQ = false; }
+	if (getBoolean("only-delete-breaks")) {
+		abbreviationsQ  = false;
+		accidentalsQ    = false;
+		referencesQ     = false;
+		terminalsQ      = false;
+		breaksQ         = true;
+		transpositionsQ = false;
+	}
+
+	if (getBoolean("do-not-fix-instrument-abbreviations")) { abbreviationsQ = false; }
+	if (getBoolean("only-fix-instrument-abbreviations")) {
+		abbreviationsQ  = true;
+		accidentalsQ    = false;
+		referencesQ     = false;
+		terminalsQ      = false;
+		breaksQ         = false;
+		transpositionsQ = false;
+	}
+
+	if (getBoolean("do-not-fix-editorial-accidentals")) { accidentalsQ = false; }
+	if (getBoolean("only-fix-editorial-accidentals")) {
+		abbreviationsQ  = false;
+		accidentalsQ    = true;
+		referencesQ     = false;
+		terminalsQ      = false;
+		breaksQ         = false;
+		transpositionsQ = false;
+	}
+
+	if (getBoolean("do-not-add-terminal-longs")) { terminalsQ = false; }
+	if (getBoolean("only-add-terminal-longs")) {
+		abbreviationsQ  = false;
+		accidentalsQ    = false;
+		referencesQ     = false;
+		terminalsQ      = true;
+		breaksQ         = false;
+		transpositionsQ = false;
+	}
+
+	if (getBoolean("do-not-remove-empty-transpositions")) { transpositionsQ = false; }
+	if (getBoolean("only-remove-empty-transpositions")) {
+		abbreviationsQ  = false;
+		accidentalsQ    = false;
+		referencesQ     = false;
+		terminalsQ      = false;
+		breaksQ         = false;
+		transpositionsQ = true;
+	}
+
+	if (abbreviationsQ)  { fixInstrumentAbbreviations(infile); }
+	if (accidentalsQ)    { fixEditorialAccidentals(infile); }
+	if (referencesQ)     { addBibliographicRecords(infile); }
+	if (terminalsQ)      { addTerminalLongs(infile); }
+	if (breaksQ)         { deleteBreaks(infile); }
+	if (transpositionsQ) { deleteDummyTranspositions(infile); }
+
+	adjustSystemDecoration(infile);
+
+	// --- 1) Normalize mensurations ---
+	for (int i = 0; i < infile.getLineCount(); ++i) {
+		if (!infile[i].isInterpretation()) {
+			continue;
+		}
+
+		for (int j = 0; j < infile[i].getFieldCount(); ++j) {
+			HTp tok = infile.token(i, j);
+			if (!tok || tok->isNull()) {
+				continue;
+			}
+
+			// Any of these → *M2/1
+			if ((*tok == "*M2/2") ||
+			    (*tok == "*M4/2") ||
+			    (*tok == "*M4/4")) {
+				tok->setText("*M2/1");
+			}
+		}
+	}
+
+	// --- 2) Normalize existing *met(...) lines and remove duplicates ---
+	for (int i = 0; i < infile.getLineCount(); ++i) {
+		if (!infile[i].isInterpretation()) {
+			continue;
+		}
+
+		// Does this line contain any *met(...) tokens?
+		bool hasMet = false;
+		for (int j = 0; j < infile[i].getFieldCount(); ++j) {
+			HTp tok = infile.token(i, j);
+			if (tok->compare(0, 5, "*met(") == 0) {
+				hasMet = true;
+				break;
+			}
+		}
+		if (!hasMet) continue;
+
+		// If there is a mensuration line just above, use it to decide canonical *met(...)
+		int mensLine = i - 1;
+		if (mensLine >= 0 && infile[mensLine].isInterpretation()) {
+			std::string labelMet = getNearbyMensurationLabelMet(infile, mensLine);
+			for (int j = 0; j < infile[i].getFieldCount(); ++j) {
+				HTp metTok  = infile.token(i, j);
+				HTp mensTok = infile.token(mensLine, j);
+
+				// Default: leave non-*met tokens alone on this line unless a
+				// mensuration label applies to the whole mensuration block.
+				if (!metTok || metTok->isNull()) {
+				    continue;
+				}
+
+				if (labelMet.empty() && (metTok->compare(0, 5, "*met(") != 0)) {
+				    continue;
+				}
+
+				// Decide canonical met from the mensuration just above
+				const char* repl = "*";   // if we can’t decide, blank it
+
+				if (!labelMet.empty()) {
+					repl = labelMet.c_str();
+				} else {
+					std::string defaultMet = getDefaultMetForMensuration(mensTok);
+					if (!defaultMet.empty()) {
+						repl = defaultMet.c_str();
+					}
+				}
+				metTok->setText(repl);
+			}
+		}
+
+		// If the whole line is now only "*" (no real *met left), delete it.
+		bool emptyLine = true;
+		for (int j = 0; j < infile[i].getFieldCount(); ++j) {
+			HTp tok = infile.token(i, j);
+			if (tok && *tok != "*") {
+				emptyLine = false;
+				break;
+			}
+		}
+		if (emptyLine) {
+			infile.deleteLine(i); --i; continue;
+		}
+
+		// If another *met line immediately follows, remove the later duplicate(s)
+		while (i + 1 < infile.getLineCount() && infile[i + 1].isInterpretation()) {
+			bool nextHasMet = false;
+			for (int j = 0; j < infile[i + 1].getFieldCount(); ++j) {
+				HTp tok = infile.token(i + 1, j);
+				if (tok && tok->compare(0, 5, "*met(") == 0) {
+					nextHasMet = true;
+					break;
+				}
+			}
+			if (!nextHasMet) {
+				break;
+			}
+			infile.deleteLine(i + 1); // drop duplicate *met line
+		}
+	}
+
+	// After normalization passes, add *met() interpretations if missing
+	for (int i = 0; i < infile.getLineCount(); ++i) {
+		if (!infile[i].isInterpretation()) {
+			continue;
+		}
+
+
+		// Does this interpretation line contain any mensuration?
+		bool hasMens = false;
+		for (int j = 0; j < infile[i].getFieldCount(); ++j) {
+			HTp tok = infile.token(i, j);
+			if (tok && tok->compare(0, 2, "*M") == 0) {
+				hasMens = true;
+				break;
+			}
+		}
+		if (!hasMens) {
+			continue;
+		}
+
+		// If the next line already contains *met(...), don't insert another
+		if (i + 1 < infile.getLineCount() && infile[i + 1].isInterpretation()) {
+			bool nextHasMet = false;
+			for (int k = 0; k < infile[i + 1].getFieldCount(); ++k) {
+				HTp nt = infile.token(i + 1, k);
+				if (nt && nt->compare(0, 5, "*met(") == 0) {
+					nextHasMet = true;
+					break;
+				}
+			}
+			if (nextHasMet) {
+				continue;
+			}
+		}
+
+		// Build a *met(...) line for recognized JRP mensuration signs.
+		std::string newline;
+		bool willInsert = false;
+		std::string labelMet = getNearbyMensurationLabelMet(infile, i);
+
+		for (int j = 0; j < infile[i].getFieldCount(); ++j) {
+			HTp tok = infile.token(i, j);
+			std::string out = "*";
+			if (tok && !tok->isNull()) {
+				if (!labelMet.empty() && (tok->compare(0, 2, "*M") == 0)) {
+					out = labelMet;
+					willInsert = true;
+				} else {
+					std::string defaultMet = getDefaultMetForMensuration(tok);
+					if (!defaultMet.empty()) {
+						out = defaultMet;
+						willInsert = true;
+					}
+				}
+			}
+			newline += out;
+			if (j < infile[i].getFieldCount() - 1) {
+				newline += "\t";
+			}
+		}
+
+		if (willInsert) {
+			infile.insertLine(i + 1, newline);
+			i++;  // skip the line we just inserted
+		}
+	}
+
+	applyMensurationLabelMetOverrides(infile);
+
+	// Convert LO:TX Section lines in-place to !!section and !!!OMD
+	for (int i = 0; i < infile.getLineCount(); ++i) {
+		if (!infile[i].isLocalComment()) {
+			continue;
+		}
+		bool matched = false;
+		std::string sectionTitle;
+
+		for (int j = 0; j < infile[i].getFieldCount(); ++j) {
+			HTp tok = infile.token(i, j);
+			if (!tok) {
+				continue;
+			}
+
+			// Look for: !LO:TX:<stuff>:t=Section&colon; <Title>
+			// Capture everything after "Section&colon;" including leading spaces
+			// Example token: !LO:TX:a:t=Section&colon; Pater, peccavi
+			std::string text = tok->getText();
+			const std::string key = "Section&colon;";
+			size_t pos = text.find(key);
+			if (text.rfind("!LO:TX:", 0) == 0 && pos != std::string::npos) {
+				// Extract after "Section&colon;"
+				sectionTitle = text.substr(pos + key.size());
+				// Trim leading spaces (but not first real character!)
+				while (!sectionTitle.empty() && std::isspace((unsigned char)sectionTitle.front())) {
+					sectionTitle.erase(sectionTitle.begin());
+				}
+				// If the title ended up empty, ignore this match
+				if (!sectionTitle.empty()) {
+					matched = true;
+					break; // use first matching token on the line
+				}
+			}
+		}
+
+		if (!matched) {
+			continue;
+		}
+
+		// Replace this local-comment line with two new global comments right here
+		// Insert in order: !!section then !!!OMD, then remove the original line
+		infile.insertLine(i, "!!section: " + sectionTitle);
+		infile.insertLine(i + 1, "!!!OMD: " + sectionTitle);
+		infile.deleteLine(i + 2); // original LO:TX line has shifted to i+2 after the two inserts
+
+		// Skip past the two lines we just inserted
+		i += 1;
+	}
+
+	// Refresh token/line relationships after structural edits so section-based
+	// voice counting sees correct line indexes.
+	infile.createLinesFromTokens();
+
+	// Populate !!!voices after labelled section comments have been created.
+	{
+		std::string voiceText = getVoicesReference(infile);
+
+		if (!voiceText.empty()) {
+			for (int li = 0; li < infile.getLineCount(); ++li) {
+				if (!infile[li].isReference()) {
+					continue;
+				}
+				HTp tok = infile.token(li, 0);
+				if (!tok) {
+					continue;
+				}
+				if (tok->compare(0, 10, "!!!voices:") != 0) {
+					continue;
+				}
+
+				std::string cur = tok->getText();
+				size_t colon = cur.find(':');
+				bool hasContent = false;
+				if (colon != std::string::npos) {
+					for (size_t p = colon + 1; p < cur.size(); ++p) {
+						if (!std::isspace(static_cast<unsigned char>(cur[p]))) {
+							hasContent = true;
+							break;
+						}
+					}
+				}
+
+				bool overwriteQ = (voiceText.find('-') != std::string::npos);
+				if (!hasContent || overwriteQ) {
+					tok->setText("!!!voices: " + voiceText);
+				}
+				break;
+			}
+		}
+	}
+
+	// Input lyrics may contain "=" signs which are to be converted into
+	// spaces in **text data, and into elisions when displaying with verovio.
+	Tool_shed shed;
+	vector<string> argv;
+	argv.push_back("shed");
+	argv.push_back("-x");     // only apply to **text spines
+	argv.push_back("text");
+	argv.push_back("-e");
+	argv.push_back("s/=/ /g");
+	shed.process(argv);
+	shed.run(infile);
+
+	addAllMeasureNumbers(infile);
+}
+
+
+
+//////////////////////////////
+//
+// Tool_1520ify::adjustSystemDecoration --
+//    !!!system-decoration: [(s1)(s2)(s3)(s4)]
+// to:
+//    !!!system-decoration: [*]
+//
+
+void Tool_1520ify::adjustSystemDecoration(HumdrumFile& infile) {
+	for (int i=infile.getLineCount() - 1; i>=0; i--) {
+		if (!infile[i].isReference()) {
+			continue;
+		}
+		HTp token = infile.token(i, 0);
+		if (*token == "!!!system-decoration:") {
+			token->setText("!!!system-decoration: [*]");
+			break;
+		}
+	}
+}
+
+
+
+//////////////////////////////
+//
+// Tool_1520ify::deleteDummyTranspositions -- Somehow empty
+//    transpositions that go to the same pitch can appear in the
+//    MusicXML data, so remove them here.  Example:
+// 		*Trd0c0
+//
+
+void Tool_1520ify::deleteDummyTranspositions(HumdrumFile& infile) {
+	std::vector<int> ldel;
+	for (int i=0; i<infile.getLineCount(); i++) {
+		if (!infile[i].hasSpines()) {
+			continue;
+		}
+		if (!infile[i].isInterpretation()) {
+			continue;
+		}
+		bool empty = true;
+		for (int j=0; j<infile[i].getFieldCount(); j++) {
+			HTp token = infile.token(i, j);
+			if (*token == "*") {
+				continue;
+			}
+			if (!token->isKern()) {
+				empty = false;
+				continue;
+			}
+			if (*token == "*Trd0c0") {
+				token->setText("*");
+			} else {
+				empty = false;
+			}
+		}
+		if (empty) {
+			ldel.push_back(i);
+		}
+	}
+
+	if (ldel.size() == 1) {
+		infile.deleteLine(ldel[0]);
+	} else if (ldel.size() > 1) {
+		cerr << "Warning: multiple transposition lines, not deleting them" << endl;
+	}
+
+}
+
+
+//////////////////////////////
+//
+// Tool_1520ify::fixEditorialAccidentals -- checkDataLine() does
+//       all of the work for this function, which only manages
+//       key signature and barline processing.
+//    Rules for accidentals in Tasso in Music Project:
+//    (1) Only note accidentals printed in the source editions
+//        are displayed as regular accidentals.  These accidentals
+//        are postfixed with an "X" in the **kern data.
+//    (2) Editorial accidentals are given an "i" marker but not
+//        a "X" marker in the **kern data.  This editorial accidental
+//        is displayed above the note.
+//    This algorithm makes adjustments to the input data because
+//    Sibelius will drop editorial information after the frist
+//    editorial accidental on that pitch in the measure.
+//    (3) If a note is the same pitch as a previous note in the
+//        measure and the previous note has an editorial accidental,
+//        then make the note an editorial note.  However, if the
+//        accidental state of the note matches the key-signature,
+//        then do not add an editorial accidental, and there will be
+//        no accidental displayed on the note.  In that case, add a "y"
+//        after the accidental to indicate that it is interpreted
+//        and not visible in the original score.
+//
+
+void Tool_1520ify::fixEditorialAccidentals(HumdrumFile& infile) {
+	m_pstates.resize(infile.getMaxTrack() + 1);
+	m_estates.resize(infile.getMaxTrack() + 1);
+	m_kstates.resize(infile.getMaxTrack() + 1);
+
+	for (int i=0; i<(int)m_pstates.size(); i++) {
+		m_pstates[i].resize(70);
+		fill(m_pstates[i].begin(), m_pstates[i].end(), 0);
+		m_kstates[i].resize(70);
+		fill(m_kstates[i].begin(), m_kstates[i].end(), 0);
+		m_estates[i].resize(70);
+		fill(m_estates[i].begin(), m_estates[i].end(), false);
+	}
+
+	for (int i=0; i<infile.getLineCount(); i++) {
+		if (infile[i].isInterpretation()) {
+			updateKeySignatures(infile, i);
+			continue;
+		} else if (infile[i].isBarline()) {
+			clearStates();
+			continue;
+		} else if (infile[i].isData()) {
+			checkDataLine(infile, i);
+		}
+	}
+}
+
+
+
+//////////////////////////////
+//
+// Tool_1520ify::addTerminalLongs -- Convert all last notes to terminal longs
+//    Also probably add terminal longs before double barlines as in JRP.
+//
+
+void Tool_1520ify::addTerminalLongs(HumdrumFile& infile) {
+	for (int i=0; i<infile.getLineCount(); ++i) {
+		if (!isInternalSectionBoundary(infile, i)) {
+			continue;
+		}
+		for (int j=0; j<infile[i].getFieldCount(); ++j) {
+			HTp token = infile.token(i, j);
+			if (!token || !token->isKern()) {
+				continue;
+			}
+			if (token->find("||") == string::npos) {
+				continue;
+			}
+			markPreviousNoteAsLong(token, true);
+		}
+	}
+
+	int scount = infile.getStrandCount();
+	for (int i=0; i<scount; i++) {
+		HTp cur = infile.getStrandEnd(i);
+		if (*cur != "*-") {
+			continue;
+		}
+		if (!cur->isKern()) {
+			continue;
+		}
+		markPreviousNoteAsLong(cur, false);
+	}
+}
+
+
+
+//////////////////////////////
+//
+// Tool_1520ify::isInternalSectionBoundary -- Identify internal double barlines
+//    that are followed by a new section rather than score termination.
+//
+
+bool Tool_1520ify::isInternalSectionBoundary(HumdrumFile& infile, int lineindex) {
+	if ((lineindex < 0) || (lineindex >= infile.getLineCount())) {
+		return false;
+	}
+	if (!infile[lineindex].isBarline()) {
+		return false;
+	}
+
+	bool doubleQ = false;
+	for (int j=0; j<infile[lineindex].getFieldCount(); ++j) {
+		HTp token = infile.token(lineindex, j);
+		if (token && token->find("||") != string::npos) {
+			doubleQ = true;
+			break;
+		}
+	}
+	if (!doubleQ) {
+		return false;
+	}
+
+	bool restartQ = false;
+	for (int i=lineindex + 1; i<infile.getLineCount(); ++i) {
+		if (infile[i].isTerminator()) {
+			return false;
+		}
+		if (infile[i].isBarline()) {
+			return false;
+		}
+		if (infile[i].isGlobalComment()) {
+			HTp token = infile.token(i, 0);
+			if (!token) {
+				continue;
+			}
+			if ((token->compare(0, 10, "!!section:") == 0) ||
+			    (token->compare(0, 7, "!!!OMD:") == 0)) {
+				restartQ = true;
+			}
+			continue;
+		}
+		if (infile[i].isLocalComment() || infile[i].isReference() || infile[i].isEmpty()) {
+			continue;
+		}
+		if (infile[i].isInterpretation()) {
+			for (int j=0; j<infile[i].getFieldCount(); ++j) {
+				HTp token = infile.token(i, j);
+				if (!token || token->isNull()) {
+					continue;
+				}
+				if ((token->compare(0, 2, "*M") == 0) ||
+				    (token->compare(0, 5, "*met(") == 0)) {
+					restartQ = true;
+				}
+			}
+			continue;
+		}
+		if (infile[i].isData()) {
+			return restartQ;
+		}
+	}
+
+	return false;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_1520ify::markPreviousNoteAsLong -- Walk backwards within a strand
+//    and mark the last note attack as a long.  For internal boundaries,
+//    stopAtRest prevents adding a long when the voice has already dropped
+//    out into rests before the section break.
+//
+
+bool Tool_1520ify::markPreviousNoteAsLong(HTp token, bool stopAtRest) {
+	if (!token) {
+		return false;
+	}
+
+	HTp cur = token->getPreviousToken();
+	while (cur) {
+		if (!cur->isData()) {
+			cur = cur->getPreviousToken();
+			continue;
+		}
+		if (cur->isNull()) {
+			cur = cur->getPreviousToken();
+			continue;
+		}
+		if (cur->isRest()) {
+			if (stopAtRest) {
+				return false;
+			}
+			cur = cur->getPreviousToken();
+			continue;
+		}
+		if (cur->isSecondaryTiedNote()) {
+			cur = cur->getPreviousToken();
+			continue;
+		}
+		if (cur->find("l") != std::string::npos) {
+			return true;
+		}
+
+		string newtext = *cur;
+		newtext += "l";
+		cur->setText(newtext);
+		return true;
+	}
+
+	return false;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_1520ify::getVoicesReference -- Return a voice-count reference string
+//    based on active voices in labelled internal sections.  If sections
+//    differ in active voice counts, report a range such as "2-4".
+//
+
+std::string Tool_1520ify::getVoicesReference(HumdrumFile& infile) {
+	std::vector<HTp> kerns = infile.getKernSpineStartList();
+	if (kerns.empty()) {
+		return "";
+	}
+
+	auto isLabeledSectionBoundary = [&](int lineindex) -> bool {
+		if ((lineindex < 0) || (lineindex >= infile.getLineCount())) {
+			return false;
+		}
+		if (!infile[lineindex].isBarline()) {
+			return false;
+		}
+
+		bool doubleQ = false;
+		for (int j=0; j<infile[lineindex].getFieldCount(); ++j) {
+			HTp token = infile.token(lineindex, j);
+			if (token && token->find("||") != string::npos) {
+				doubleQ = true;
+				break;
+			}
+		}
+		if (!doubleQ) {
+			return false;
+		}
+
+		for (int i=lineindex + 1; i<infile.getLineCount(); ++i) {
+			if (infile[i].isTerminator()) {
+				return false;
+			}
+			if (infile[i].isBarline()) {
+				return false;
+			}
+			if (infile[i].isGlobalComment()) {
+				HTp token = infile.token(i, 0);
+				if (!token) {
+					continue;
+				}
+				if ((token->compare(0, 10, "!!section:") == 0) ||
+				    (token->compare(0, 7, "!!!OMD:") == 0)) {
+					return true;
+				}
+				continue;
+			}
+			if (infile[i].isLocalComment() || infile[i].isReference() ||
+			    infile[i].isInterpretation() || infile[i].isEmpty()) {
+				continue;
+			}
+			if (infile[i].isData()) {
+				return false;
+			}
+		}
+		return false;
+	};
+
+	std::vector<std::pair<int, int>> sections;
+	int startline = -1;
+	for (int i=0; i<infile.getLineCount(); ++i) {
+		if (infile[i].isData()) {
+			startline = i;
+			break;
+		}
+	}
+	if (startline < 0) {
+		return "";
+	}
+
+	for (int i=0; i<infile.getLineCount(); ++i) {
+		if (!isLabeledSectionBoundary(i)) {
+			continue;
+		}
+		sections.push_back(std::make_pair(startline, i));
+		for (int j=i + 1; j<infile.getLineCount(); ++j) {
+			if (infile[j].isData()) {
+				startline = j;
+				break;
+			}
+		}
+	}
+
+	int endline = -1;
+	for (int i=infile.getLineCount() - 1; i>=0; --i) {
+		if (infile[i].isData()) {
+			endline = i;
+			break;
+		}
+	}
+	if ((startline >= 0) && (endline >= startline)) {
+		sections.push_back(std::make_pair(startline, endline));
+	}
+
+	if (sections.empty()) {
+		return std::to_string((int)kerns.size());
+	}
+
+	int minVoices = (int)kerns.size();
+	int maxVoices = 0;
+
+	for (int i=0; i<(int)sections.size(); ++i) {
+		std::vector<bool> active(kerns.size(), false);
+		for (int line=sections[i].first; line<=sections[i].second; ++line) {
+			if (!infile[line].isData()) {
+				continue;
+			}
+			int kindex = 0;
+			for (int field=0; field<infile[line].getFieldCount(); ++field) {
+				HTp tok = infile.token(line, field);
+				if (!tok || !tok->isKern()) {
+					continue;
+				}
+				if (kindex >= (int)active.size()) {
+					break;
+				}
+				if (!tok->isNull() && !tok->isRest() && !tok->isSecondaryTiedNote()) {
+					active[kindex] = true;
+				}
+				kindex++;
+			}
+		}
+
+		int activeCount = 0;
+		for (int j=0; j<(int)active.size(); ++j) {
+			if (active[j]) {
+				activeCount++;
+			}
+		}
+		minVoices = std::min(minVoices, activeCount);
+		maxVoices = std::max(maxVoices, activeCount);
+	}
+
+	if (minVoices == maxVoices) {
+		return std::to_string(minVoices);
+	}
+	return std::to_string(minVoices) + "-" + std::to_string(maxVoices);
+}
+
+
+
+//////////////////////////////
+//
+// Tool_1520ify::fixInstrumentAbbreviations --
+//
+
+void Tool_1520ify::fixInstrumentAbbreviations(HumdrumFile& infile) {
+	int iline = -1;
+	int aline = -1;
+
+	std::vector<HTp> kerns = infile.getKernSpineStartList();
+	if (kerns.empty()) {
+		return;
+	}
+
+	HTp cur = kerns[0];
+	while (cur) {
+		if (cur->isData()) {
+			break;
+		}
+		if (cur->compare(0, 3, "*I\"") == 0) {
+			iline = cur->getLineIndex();
+		} else if (cur->compare(0, 3, "*I'") == 0) {
+			aline = cur->getLineIndex();
+		}
+		cur = cur->getNextToken();
+	}
+
+	// Must have parallel *I" (full name) and *I' (abbr) lines of equal width
+	if (iline < 0){
+		return;
+	}
+	if (aline < 0){
+		return;
+	}
+	if (infile[iline].getFieldCount() != infile[aline].getFieldCount()){
+		return;
+	}
+
+	HumRegex hre;
+
+	//-----------------------------------------------------------
+	// Helper: split voice name into canonical base + Roman numeral
+	//-----------------------------------------------------------
+	auto parseVoiceName = [&](const std::string& s) -> std::pair<std::string,std::string> {
+		// Split on whitespace
+		std::vector<std::string> words;
+		std::string tmp;
+		for (char c : s) {
+			if (std::isspace((unsigned char)c)) {
+				if (!tmp.empty()) {
+					words.push_back(tmp); tmp.clear();
+				}
+			} else {
+				tmp.push_back(c);
+			}
+		}
+		if (!tmp.empty()){
+			words.push_back(tmp);
+		}
+
+		std::string base;
+		std::string roman;
+
+		if (words.empty()){
+			return { "", "" };
+		}
+
+		// Canonical voice names:
+		//   Superius, Altus, Tenor, Bassus
+		std::string first = words[0];
+		std::string lower;
+		for (char c : first){
+			lower.push_back(std::tolower((unsigned char)c));
+		}
+		if (lower == "superius" || lower == "cantus"){
+			base = "Superius";
+		} else if (lower == "altus"){
+			base = "Altus";
+		} else if (lower == "tenor"){
+			base = "Tenor";
+		} else if (lower == "bassus"){
+			base = "Bassus";
+		} else {
+			base = first; // fallback
+		}
+
+		// Check for Roman numeral as second word
+		if (words.size() >= 2) {
+			std::string w2 = words[1];
+			std::string up;
+			for (char c : w2){
+				up.push_back(std::toupper((unsigned char)c));
+			}
+			if (hre.search(up, "^(I|II|III|IV|V|VI|VII|VIII|IX|X)$")){
+				roman = w2;
+			}
+		}
+
+		return { base, roman };
+	};
+
+	// Abbreviation rules:
+	// - plain SATB uses no period (S A T B)
+	// - numbered voices use period before Roman numeral (S. I, A. II, ...)
+	auto baseToAbbr = [&](const std::string& base, bool numbered) -> std::string {
+		if (base == "Superius"){
+			return numbered ? "S." : "S";
+		}
+		if (base == "Altus"){
+			return numbered ? "A." : "A";
+		}
+		if (base == "Tenor"){
+			return numbered ? "T." : "T";
+		}
+		if (base == "Bassus"){
+			return numbered ? "B." : "B";
+		}
+		// fallback: first letter, with period only for numbered voices
+		std::string letter(1, std::toupper((unsigned char)base[0]));
+		if (numbered) {
+			letter += ".";
+		}
+		return letter;
+	};
+
+	// Process each spine and rewrite abbreviation
+	for (int j = 0; j < infile[iline].getFieldCount(); j++) {
+		HTp tokFull = infile.token(iline, j);
+		HTp tokAbbr = infile.token(aline, j);
+
+		if (!tokFull || !tokAbbr || !tokFull->isKern()){
+			continue;
+		}
+
+		// Extract raw name after *I"
+		std::string text = tokFull->getText();
+		std::string raw;
+		if (hre.search(text, "^\\*I\"(.*)$")){
+			raw = hre.getMatch(1);
+		} else {
+			continue;
+		}
+
+		auto parsed = parseVoiceName(raw);
+		std::string base  = parsed.first;
+		std::string roman = parsed.second;
+
+		std::string abbr = "*I'";
+		abbr += baseToAbbr(base, !roman.empty());
+		if (!roman.empty()){
+			abbr += " " + roman;
+		}
+
+		tokAbbr->setText(abbr);
+	}
+}
+
+
+
+//////////////////////////////
+//
+// Tool_1520ify::deleteBreaks --
+//
+
+void Tool_1520ify::deleteBreaks(HumdrumFile& infile) {
+	HumRegex hre;
+	for (int i=infile.getLineCount()-1; i>= 0; i--) {
+		if (!infile[i].isGlobalComment()) {
+			continue;
+		}
+		if (hre.search(*infile.token(i, 0), "linebreak\\s*:\\s*original")) {
+			infile.deleteLine(i);
+		}
+		else if (hre.search(*infile.token(i, 0), "pagebreak\\s*:\\s*original")) {
+			infile.deleteLine(i);
+		}
+	}
+}
+
+
+
+////////////////////////////////
+//
+// Tool_1520ify::addBibliographicRecords --
+//
+// !!!!SEGMENT:
+// !!!jrpid:
+// !!!AGN:
+// !!!voices:
+// !!!COM:
+// !!!OTL:
+// !!!OPR:
+//
+// At end:
+// !!!RDF**kern: l = terminal long        (if needed)
+// !!!RDF**kern: i = editorial accidental (if needed)
+// !!!ENC: Benjamin Ory
+// !!!END:
+// !!!EED: Benjamin Ory
+// !!!EEV: <DATE>
+// !!!YEC: Copyright <YEAR> Benjamin Ory, All Rights Reserved
+// !!!ONB: Translated from MusicXML and edited on $DATE
+//
+
+void Tool_1520ify::addBibliographicRecords(HumdrumFile& infile) {
+	std::vector<HLp> refinfo = infile.getReferenceRecords();
+	std::map<string, HLp> refs;
+	for (int i=0; i<(int)refinfo.size(); i++) {
+		string key = refinfo[i]->getReferenceKey();
+		refs[key] = refinfo[i];
+	}
+
+	// header records (inserted in reverse order)
+	// automatic placement before/after existing records
+	// could be improved later.
+	if (refs.find("OPR") == refs.end()) {
+		if (infile.token(0, 0)->find("!!!OPR") != std::string::npos) {
+			infile.insertLine(1, "!!!OPR:");
+		} else {
+			infile.insertLine(0, "!!!OPR:");
+		}
+	}
+
+	if (refs.find("OTL") == refs.end()) {
+		if (infile.token(0, 0)->find("!!!OTL") != std::string::npos) {
+			infile.insertLine(1, "!!!OTL:");
+		} else {
+			infile.insertLine(0, "!!!OTL:");
+		}
+	}
+
+	if (refs.find("COM") == refs.end()) {
+		if (infile.token(0, 0)->find("!!!COM") != std::string::npos) {
+			infile.insertLine(1, "!!!COM:");
+		} else {
+			infile.insertLine(0, "!!!COM:");
+		}
+	}
+
+	if (refs.find("voices") == refs.end()) {
+		if (infile.token(0, 0)->find("!!!voices") != std::string::npos) {
+			infile.insertLine(1, "!!!voices:");
+		} else {
+			infile.insertLine(0, "!!!voices:");
+		}
+	}
+
+	if (refs.find("AGN") == refs.end()) {
+		if (infile.token(0, 0)->find("!!!AGN") != std::string::npos) {
+			infile.insertLine(1, "!!!AGN:");
+		} else {
+			infile.insertLine(0, "!!!AGN:");
+		}
+	}
+
+	if (refs.find("SMS") == refs.end()) {
+		if (infile.token(0, 0)->find("!!!SMS") != std::string::npos) {
+			infile.insertLine(1, "!!!SMS:");
+		} else {
+			infile.insertLine(0, "!!!SMS:");
+		}
+	}
+
+	// Create !!!!SEGMENT
+	// Try to get a usable "basename" for this piece.
+	// 1) Prefer the actual filename if present.
+	// 2) If reading from stdin (pipelines), fall back to existing !!!OTL: value.
+
+	std::string filename = infile.getFilename();
+	std::string basename;
+
+	// Case 1: real filename
+	if (!filename.empty()) {
+		size_t slash = filename.find_last_of("/\\");
+		if (slash == std::string::npos) {
+			basename = filename;
+		} else {
+			basename = filename.substr(slash + 1);
+		}
+	}
+
+	// Case 2: fall back to existing !!!OTL: if filename is empty
+	if (basename.empty()) {
+		for (int li = 0; li < infile.getLineCount(); ++li) {
+			if (!infile[li].isReference()) {
+				continue;
+			}
+			HTp tok = infile.token(li, 0);
+			if (!tok) {
+				continue;
+			}
+
+			if (tok->compare(0, 7, "!!!OTL:") == 0) {
+				std::string text = tok->getText();
+				size_t colon = text.find(':');
+				if (colon != std::string::npos) {
+					basename = text.substr(colon + 1);
+					// trim leading spaces
+					while (!basename.empty() && std::isspace((unsigned char)basename.front())) {
+						basename.erase(basename.begin());
+					}
+				}
+				break;
+			}
+		}
+	}
+
+	if (!basename.empty()) {
+		size_t dot = basename.find_last_of('.');
+		if ((dot != std::string::npos) && (basename.substr(dot) == ".krn")) {
+			// already in the desired form
+		} else if (dot != std::string::npos) {
+			basename = basename.substr(0, dot) + ".krn";
+		} else {
+			basename += ".krn";
+		}
+	}
+
+	// Build the segment line
+	std::string segmentLine = "!!!!SEGMENT: " + basename;
+
+	// Insert it at the top of the file
+	infile.insertLine(0, segmentLine);
+
+	int year = getYear();
+	string date = getDate();
+
+	// Extract ID from filename (before first '-')
+	std::string id;
+	size_t dashPos = basename.find('-');
+	if (dashPos != std::string::npos) {
+	    id = basename.substr(0, dashPos);
+	} else {
+	    id = basename;  // fallback if no dash
+	}
+
+	// Remove any extension (e.g., .krn) from the ID
+	size_t dotPos = id.find('.');
+	if (dotPos != std::string::npos) {
+	    id = id.substr(0, dotPos);
+	}
+
+	// Insert the JRP ID line right after the SEGMENT line
+	std::string idLine = "!!!jrpid: " + id;
+	infile.insertLine(1, idLine);
+
+
+	// Figure out an insertion anchor for new refs (after SEGMENT/jrpid if present)
+	int afterHeader = 0;
+	for (int li = 0; li < infile.getLineCount(); ++li) {
+	    if (!infile[li].isReference()) {
+	    	continue;
+	    }
+	    HTp tok = infile.token(li, 0);
+	    if (tok->compare(0, 13, "!!!!SEGMENT: ") == 0) {
+	    	afterHeader = li + 1;
+	    }
+	    if (tok->compare(0, 10, "!!!jrpid: ")   == 0) {
+	    	afterHeader = li + 1;
+	    }
+	}
+
+	// Work on a stem without .krn, only for parsing
+	std::string stem = basename;
+	size_t p = stem.find('.');
+	if (p != std::string::npos) {
+	    stem = stem.substr(0, p);
+	}
+
+	// Split off optional “--suffix”
+	std::string mainPart = stem;
+	std::string suffixPart;
+	size_t dd = stem.find("--");
+	if (dd != std::string::npos) {
+	    mainPart   = stem.substr(0, dd);
+	    suffixPart = stem.substr(dd + 2);
+	}
+
+	// Split mainPart on single dashes
+	std::vector<std::string> chunks;
+	{
+	    size_t start = 0;
+	    while (true) {
+	        size_t pos = mainPart.find('-', start);
+		        if (pos == std::string::npos) {
+		            chunks.push_back(mainPart.substr(start));
+		            break;
+		        }
+	        chunks.push_back(mainPart.substr(start, pos - start));
+	        start = pos + 1;
+	    }
+	}
+
+	// helper: underscores → spaces
+	auto us2sp = [](std::string s) {
+		std::replace(s.begin(), s.end(), '_', ' ');
+		return s;
+	};
+
+	// Compute desired OTL / OPR
+	std::string wantOTL, wantOPR;
+
+	if (chunks.size() >= 3) {
+	    // e.g. Con2008-Missa_Spes_salutis-Kyrie--Paris_1555
+	    wantOTL = us2sp(chunks.back());  // subtitle
+	    // join middle chunks as main work title
+	    std::string mainWork;
+	    for (size_t k = 1; k + 1 < chunks.size(); ++k) {
+	        if (!mainWork.empty()){
+	        	mainWork += ' ';
+	        }
+	        mainWork += us2sp(chunks[k]);
+	    }
+	    wantOPR = mainWork;
+	    if (!suffixPart.empty()) {
+	    	wantOPR += " (" + us2sp(suffixPart) + ")";
+	    }
+	} else {
+	    // only one or two chunks — just an OTL
+	    std::string title = (chunks.size() >= 2) ? chunks[1] : chunks[0];
+	    wantOTL = us2sp(title);
+	    if (!suffixPart.empty()) {
+	    	wantOTL += " (" + us2sp(suffixPart) + ")";
+	    }
+	}
+
+	// If there is a “--suffix” part (e.g. Paris_1555), put it into !!!SMS:
+	if (!suffixPart.empty()) {
+	    std::string smsText = us2sp(suffixPart);  // underscores → spaces
+
+	    for (int li = 0; li < infile.getLineCount(); ++li) {
+	        if (!infile[li].isReference()) {
+	        	continue;
+	        }
+	        HTp tok = infile.token(li, 0);
+	        if (!tok) {
+	        	continue;
+	        }
+
+	        if (tok->compare(0, 7, "!!!SMS:") == 0) {
+	            std::string cur = tok->getText();
+
+	            // Check whether there is already non-whitespace after the colon
+	            size_t colon = cur.find(':');
+	            bool hasContent = false;
+	            if (colon != std::string::npos) {
+	                for (size_t p = colon + 1; p < cur.size(); ++p) {
+	                    if (!std::isspace(static_cast<unsigned char>(cur[p]))) {
+	                        hasContent = true;
+	                        break;
+	                    }
+	                }
+	            }
+
+	            // Only fill auto if it was effectively empty
+	            if (!hasContent) {
+	                tok->setText("!!!SMS: " + smsText);
+	            }
+	            break; // done with SMS
+	        }
+	    }
+	}
+
+
+	// Update or insert OTL
+	{
+	    bool updated = false;
+	    for (int li = 0; li < infile.getLineCount(); ++li) {
+	        if (!infile[li].isReference()) {
+	        	continue;
+	        }
+	        HTp tok = infile.token(li, 0);
+	        if (tok->compare(0, 7, "!!!OTL:") == 0) {
+	            tok->setText("!!!OTL: " + wantOTL);
+	            updated = true;
+	            break;
+	        }
+	    }
+	    if (!updated) {
+	        infile.insertLine(afterHeader, "!!!OTL: " + wantOTL);
+	        ++afterHeader;
+	    }
+	}
+
+	// Handle OPR: keep if needed, remove otherwise
+	bool needOPR = !wantOPR.empty();
+	bool foundOPR = false;
+	int oprLine = -1;
+
+	for (int li = 0; li < infile.getLineCount(); ++li) {
+	    if (!infile[li].isReference()) {
+	    	continue;
+	    }
+	    HTp tok = infile.token(li, 0);
+	    if (tok->compare(0, 7, "!!!OPR:") == 0) {
+	        foundOPR = true;
+	        oprLine = li;
+	        break;
+	    }
+	}
+
+	if (needOPR) {
+	    if (foundOPR) {
+	        infile.token(oprLine, 0)->setText("!!!OPR: " + wantOPR);
+	    } else {
+	        infile.insertLine(afterHeader, "!!!OPR: " + wantOPR);
+	        ++afterHeader;
+	    }
+	} else if (foundOPR) {
+	    infile.deleteLine(oprLine);
+	}
+
+	// --- Auto-fill AGN (genre + optional movement name) based on numeric id ---
+
+	{
+	    // Extract first 4 digits from id (e.g., Con2008 → 2008)
+	    int workNumber = -1;
+	    std::string digits;
+	    for (char c : id) {
+	        if (std::isdigit(static_cast<unsigned char>(c))) {
+	            digits.push_back(c);
+	        }
+	    }
+	    if (digits.size() >= 4) {
+	        try {
+	            workNumber = std::stoi(digits.substr(0, 4));
+	        } catch (...) {
+	            workNumber = -1;
+	        }
+	    }
+
+	    std::string agnLine;
+
+	    // Determine AGN logic
+	    if (workNumber >= 1000 && workNumber < 2000) {
+	        // --- Mass movement ---
+	        agnLine = "!!!AGN: Mass; " + wantOTL;
+	    }
+	    else if (workNumber >= 2000 && workNumber < 3000) {
+	        // --- Motet ---
+	        agnLine = "!!!AGN: Motet";
+	    }
+	    else if (workNumber >= 3000 && workNumber < 4000) {
+	        // --- Secular work ---
+	        agnLine = "!!!AGN: Secular work";
+	    }
+
+	    if (!agnLine.empty()) {
+	        // Apply only if AGN exists and is empty
+	        for (int li = 0; li < infile.getLineCount(); ++li) {
+	            if (!infile[li].isReference()) {
+	            	continue;
+	            }
+	            HTp tok = infile.token(li, 0);
+	            if (!tok) {
+	            	continue;
+	            }
+
+	            if (tok->compare(0, 7, "!!!AGN:") == 0) {
+	                std::string cur = tok->getText();
+	                size_t colon = cur.find(':');
+	                bool hasContent = false;
+
+	                if (colon != std::string::npos) {
+	                    for (size_t p = colon + 1; p < cur.size(); ++p) {
+	                        if (!std::isspace(static_cast<unsigned char>(cur[p]))) {
+	                            hasContent = true;
+	                            break;
+	                        }
+	                    }
+	                }
+
+	                if (!hasContent) {
+	                    tok->setText(agnLine);
+	                }
+	                break;
+	            }
+	        }
+	    }
+	}
+
+
+	// trailer records
+	bool foundi = false;
+	bool foundl = false;
+	for (int i=0; i<infile.getLineCount(); i++) {
+		if (!infile[i].isReference()) {
+			continue;
+		}
+		if (infile.token(i, 0)->find("!!!RDF**kern:") == std::string::npos) {
+			continue;
+		}
+		if (infile.token(i, 0)->find("terminal long") != std::string::npos) {
+			foundl = true;
+		} else if (infile.token(i, 0)->find("editorial accidental") != std::string::npos) {
+			foundi = true;
+		}
+	}
+
+	// Always ensure RDF records appear together and in the correct order:
+	if (!foundi && !foundl) {
+		infile.appendLine("!!!RDF**kern: i = editorial accidental");
+		infile.appendLine("!!!RDF**kern: l = terminal long");
+	} else if (!foundi) {
+		infile.appendLine("!!!RDF**kern: i = editorial accidental");
+	} else if (!foundl) {
+		// Insert directly after the editorial accidental RDF line
+		for (int i = 0; i < infile.getLineCount(); i++) {
+			if (infile[i].isReference() && infile.token(i, 0)->find("!!!RDF**kern: i = editorial accidental") != std::string::npos) {
+				infile.insertLine(i + 1, "!!!RDF**kern: l = terminal long");
+				break;
+			}
+		}
+	}
+
+	// --- Rewrite ENC name from "Last, First" → "First Last" if applicable ---
+	{
+	    for (int li = 0; li < infile.getLineCount(); ++li) {
+	        if (!infile[li].isReference()) {
+	        	continue;
+	        }
+	        HTp tok = infile.token(li, 0);
+	        if (!tok) {
+	        	continue;
+	        }
+
+	        if (tok->compare(0, 7, "!!!ENC:") == 0) {
+	            std::string text = tok->getText();  // "!!!ENC: Last, First"
+
+	            // Extract the part after the colon
+	            size_t colon = text.find(':');
+	            if (colon == std::string::npos) {
+	            	break;
+	            }
+
+	            std::string name = text.substr(colon + 1);
+	            // Trim leading spaces
+	            while (!name.empty() && std::isspace((unsigned char)name.front())){
+	                name.erase(name.begin());
+	            }
+
+	            // Look for the comma separating "Last, First"
+	            size_t comma = name.find(',');
+	            if (comma != std::string::npos) {
+	                std::string last  = name.substr(0, comma);
+	                std::string first = name.substr(comma + 1);
+
+	                // Trim spaces
+	                auto trim = [](std::string& s) {
+	                    while (!s.empty() && std::isspace((unsigned char)s.front()))
+	                        s.erase(s.begin());
+	                    while (!s.empty() && std::isspace((unsigned char)s.back()))
+	                        s.pop_back();
+	                };
+
+	                trim(last);
+	                trim(first);
+
+	                if (!last.empty() && !first.empty()) {
+	                    std::string fixed = "!!!ENC: " + first + " " + last;
+	                    tok->setText(fixed);
+	                }
+	            }
+
+	            break; // Only one ENC line exists
+	        }
+	    }
+	}
+
+	// Helper: trim leading/trailing whitespace (in-place)
+	auto trim = [](std::string& s) {
+	    while (!s.empty() && std::isspace((unsigned char)s.front())) {
+	        s.erase(s.begin());
+	    }
+	    while (!s.empty() && std::isspace((unsigned char)s.back())) {
+	        s.pop_back();
+	    }
+	};
+
+	// Helper: normalize a composer name so that
+	// "Willaert, Adrian" ≈ "Adrian Willaert" for comparison.
+	auto normalizeComposer = [&](std::string s) -> std::string {
+	    trim(s);
+
+	    // If there is a comma, assume "Last, First ..." and flip to "First ... Last"
+	    size_t comma = s.find(',');
+	    if (comma != std::string::npos) {
+	        std::string last  = s.substr(0, comma);
+	        std::string first = s.substr(comma + 1);
+	        trim(last);
+	        trim(first);
+	        if (!first.empty() && !last.empty()) {
+	            s = first + " " + last;
+	        }
+	    }
+
+	    // Lowercase and strip non-alphanumerics for comparison
+	    std::string out;
+	    for (unsigned char c : s) {
+	        if (std::isalnum(c)) {
+	            out.push_back(std::tolower(c));
+	        }
+	    }
+	    return out;
+	};
+
+	// --- Resolve possible duplicate or conflicting !!!COM: records ---
+	int firstComLine = -1;
+	int lastComLine  = -1;
+	std::string firstComName;
+	std::string lastComName;
+
+	for (int i = 0; i < infile.getLineCount(); ++i) {
+	    if (!infile[i].isReference()) {
+	    	continue;
+	    }
+	    HTp tok = infile.token(i, 0);
+	    if (!tok) {
+	    	continue;
+	    }
+
+	    if (tok->compare(0, 7, "!!!COM:") == 0) {
+	        std::string text = tok->getText();      // "!!!COM: Adrian Willaert"
+	        std::string name = text.substr(7);      // " Adrian Willaert"
+	        trim(name);
+
+	        if (firstComLine < 0) {
+	            firstComLine  = i;
+	            firstComName  = name;
+	        }
+	        lastComLine = i;
+	        lastComName = name;
+	    }
+	}
+
+	// If there are two distinct COM lines (header + trailer)
+	if (firstComLine >= 0 && lastComLine >= 0 && firstComLine != lastComLine) {
+
+	    std::string normFirst = normalizeComposer(firstComName);
+	    std::string normLast  = normalizeComposer(lastComName);
+
+	    bool bothNonEmpty = !normFirst.empty() && !normLast.empty();
+
+	    // Only report a conflict if the *normalized* names really differ
+	    if (bothNonEmpty && normFirst != normLast) {
+	        std::string msg = "!!!ONB: Composer conflict between \"" +
+	                          firstComName + "\" and \"" + lastComName + "\"";
+	        infile.appendLine(msg);
+	    }
+
+	    // Always delete the trailing COM — keep the earlier one as canonical
+	    infile.deleteLine(lastComLine);
+	}
+
+	if (refs.find("ENC") == refs.end()) {
+		infile.appendLine("!!!ENC: Benjamin Ory");
+	}
+	if (refs.find("END") == refs.end()) {
+		infile.appendLine("!!!END:");
+	}
+	if (refs.find("EED") == refs.end()) {
+		infile.appendLine("!!!EED: Jesse Rodin");
+	}
+	if (refs.find("EEV") == refs.end()) {
+		string line = "!!!EEV: " + date;
+		infile.appendLine(line);
+	}
+	if (refs.find("YEC") == refs.end()) {
+		string line = "!!!YEC: Copyright ";
+		line += to_string(year);
+		line += " Jesse Rodin, All Rights Reserved";
+		infile.appendLine(line);
+	}
+	if (refs.find("ONB") == refs.end()) {
+		string line = "!!!ONB: Translated from MusicXML on " + date;
+		infile.appendLine(line);
+	}
+
+	splitEncoderDate(infile);
+
+	// --- Remove !!!SMS: if it contains no content ---
+	{
+	    for (int li = 0; li < infile.getLineCount(); ++li) {
+	        if (!infile[li].isReference()) {
+	        	continue;
+	        }
+	        HTp tok = infile.token(li, 0);
+	        if (!tok) {
+	        	continue;
+	        }
+
+	        if (tok->compare(0, 7, "!!!SMS:") == 0) {
+	            std::string text = tok->getText();
+
+	            // Find colon and check if anything nonspace follows
+	            size_t colon = text.find(':');
+	            bool hasContent = false;
+
+	            if (colon != std::string::npos) {
+	                for (size_t p = colon + 1; p < text.size(); ++p) {
+	                    if (!std::isspace(static_cast<unsigned char>(text[p]))) {
+	                        hasContent = true;
+	                        break;
+	                    }
+	                }
+	            }
+
+	            // Delete the line if it is empty
+	            if (!hasContent) {
+	                infile.deleteLine(li);
+	            }
+
+	            break;  // Only one SMS line exists
+	        }
+	    }
+	}
+
+	addMuse2psRecord(infile);
+}
+
+
+
+////////////////////////////////
+//
+// Tool_1520ify::checkDataLine --
+//
+
+void Tool_1520ify::checkDataLine(HumdrumFile& infile, int lineindex) {
+	HumdrumLine& line = infile[lineindex];
+
+	HumRegex hre;
+	HTp token;
+	bool haseditQ;
+	int base7;
+	int accid;
+	int track;
+	bool removeQ;
+	for (int i=0; i<line.getFieldCount(); i++) {
+		token = line.token(i);
+		track = token->getTrack();
+		if (!token->isKern()) {
+			continue;
+		}
+		if (token->isNull()) {
+			continue;
+		}
+		if (token->isRest()) {
+			continue;
+		}
+		if (token->isSecondaryTiedNote()) {
+			continue;
+		}
+
+		base7 = Convert::kernToBase7(token);
+		accid = Convert::kernToAccidentalCount(token);
+		haseditQ = false;
+		removeQ = false;
+
+		// Hard-wired to "i" as editorial accidental marker
+		if (token->find("ni") != string::npos) {
+			haseditQ = true;
+		} else if (token->find("-i") != string::npos) {
+			haseditQ = true;
+		} else if (token->find("#i") != string::npos) {
+			haseditQ = true;
+		} else if (token->find("nXi") != string::npos) {
+			haseditQ = true;
+			removeQ = true;
+		} else if (token->find("-Xi") != string::npos) {
+			haseditQ = true;
+			removeQ = true;
+		} else if (token->find("#Xi") != string::npos) {
+			haseditQ = true;
+			removeQ = true;
+		}
+
+		if (removeQ) {
+			string temp = *token;
+			hre.replaceDestructive(temp, "", "X");
+			token->setText(temp);
+		}
+
+		bool explicitQ = false;
+		if (token->find("#X") != string::npos) {
+			explicitQ = true;
+		} else if (token->find("-X") != string::npos) {
+			explicitQ = true;
+		} else if (token->find("nX") != string::npos) {
+			explicitQ = true;
+		} else if (token->find("n") != string::npos) {
+			// add an explicit accidental marker
+			explicitQ = true;
+			string text = *token;
+			hre.replaceDestructive(text, "nX", "n");
+			token->setText(text);
+		}
+
+		if (haseditQ) {
+			// Store new editorial pitch state.
+			m_estates.at(track).at(base7) = true;
+			m_pstates.at(track).at(base7) = accid;
+			continue;
+		}
+
+		if (explicitQ) {
+			// No need to make editorial since it is visible.
+			m_estates.at(track).at(base7) = false;
+			m_pstates.at(track).at(base7) = accid;
+			continue;
+		}
+
+		if (accid == m_kstates.at(track).at(base7)) {
+			// 	!m_estates.at(track).at(base7)) {
+			// add !m_estates.at(track).at(base) as a condition if
+			// you want editorial accidentals to be added to return the
+			// note to the accidental in the key.
+			//
+			// The accidental matches the key-signature state,
+			// so it should not be made editorial eventhough
+			// it is not visible.
+			m_pstates.at(track).at(base7) = accid;
+
+			// Add a "y" marker of there is an interpreted accidental
+			// state (flat or sharp) that is part of the key signature.
+			int hasaccid = false;
+			if (token->find("#") != std::string::npos) {
+				hasaccid = true;
+			} else if (token->find("-") != std::string::npos) {
+				hasaccid = true;
+			}
+			int hashide = false;
+			if (token->find("-y") != std::string::npos) {
+				hashide = true;
+			}
+			else if (token->find("#y") != std::string::npos) {
+				hashide = true;
+			}
+			if (hasaccid && !hashide) {
+				string text = *token;
+				hre.replaceDestructive(text, "#y", "#");
+				hre.replaceDestructive(text, "-y", "-");
+				token->setText(text);
+			}
+
+			continue;
+		}
+
+		// At this point the previous note with this pitch class
+		// had an editorial accidental, and this note also has the
+		// same accidental, or there was a previous visual accidental
+		// outside of the key signature that will cause this note to have
+		// an editorial accidental mark applied (Sibelius will drop
+		// secondary editorial accidentals in a measure when exporting,
+		// MusicXML, which is why this function is needed).
+
+		m_estates[track][base7] = true;
+		m_pstates[track][base7] = accid;
+
+		string text = token->getText();
+		string output = "";
+		bool foundQ = false;
+		for (int j=0; j<(int)text.size(); j++) {
+			if (text[j] == 'n') {
+				output += "ni";
+				foundQ = true;
+			} else if (text[j] == '#') {
+				output += "#i";
+				foundQ = true;
+			} else if (text[j] == '-') {
+				output += "-i";
+				foundQ = true;
+			} else {
+				output += text[j];
+			}
+		}
+
+		if (foundQ) {
+			token->setText(output);
+			continue;
+		}
+
+		// The note is natural, but has no natural sign.
+		// add the natural sign and editorial mark.
+		for (int j=(int)output.size()-1; j>=0; j--) {
+			if ((tolower(output[j]) >= 'a') && (tolower(output[j]) <= 'g')) {
+				output.insert(j+1, "ni");
+				break;
+			}
+		}
+		token->setText(output);
+	}
+}
+
+
+
+////////////////////////////////
+//
+// Tool_1520ify::updateKeySignatures -- Fill in the accidental
+//    states for each diatonic pitch.
+//
+
+void Tool_1520ify::updateKeySignatures(HumdrumFile& infile, int lineindex) {
+	HumdrumLine& line = infile[lineindex];
+	int track;
+	for (int i=0; i<line.getFieldCount(); i++) {
+		if (!line.token(i)->isKeySignature()) {
+			continue;
+		}
+		HTp token = line.token(i);
+		track = token->getTrack();
+		string text = token->getText();
+		fill(m_kstates[track].begin(), m_kstates[track].end(), 0);
+		for (int j=3; j<(int)text.size()-1; j++) {
+			if (text[j] == ']') {
+				break;
+			}
+			switch (text[j]) {
+				case 'a': case 'A':
+					switch (text[j+1]) {
+						case '#': m_kstates[track][5] = +1;
+						break;
+						case '-': m_kstates[track][5] = -1;
+						break;
+					}
+					break;
+
+				case 'b': case 'B':
+					switch (text[j+1]) {
+						case '#': m_kstates[track][6] = +1;
+						break;
+						case '-': m_kstates[track][6] = -1;
+						break;
+					}
+					break;
+
+				case 'c': case 'C':
+					switch (text[j+1]) {
+						case '#': m_kstates[track][0] = +1;
+						break;
+						case '-': m_kstates[track][0] = -1;
+						break;
+					}
+					break;
+
+				case 'd': case 'D':
+					switch (text[j+1]) {
+						case '#': m_kstates[track][1] = +1;
+						break;
+						case '-': m_kstates[track][1] = -1;
+						break;
+					}
+					break;
+
+				case 'e': case 'E':
+					switch (text[j+1]) {
+						case '#': m_kstates[track][2] = +1;
+						break;
+						case '-': m_kstates[track][2] = -1;
+						break;
+					}
+					break;
+
+				case 'f': case 'F':
+					switch (text[j+1]) {
+						case '#': m_kstates[track][3] = +1;
+						break;
+						case '-': m_kstates[track][3] = -1;
+						break;
+					}
+					break;
+
+				case 'g': case 'G':
+					switch (text[j+1]) {
+						case '#': m_kstates[track][4] = +1;
+						break;
+						case '-': m_kstates[track][4] = -1;
+						break;
+					}
+					break;
+			}
+			for (int j=0; j<7; j++) {
+				if (m_kstates[track][j] == 0) {
+					continue;
+				}
+				for (int k=1; k<10; k++) {
+					m_kstates[track][j+k*7] = m_kstates[track][j];
+				}
+			}
+		}
+	}
+
+	// initialize m_pstates with contents of m_kstates
+	for (int i=0; i<(int)m_kstates.size(); i++) {
+		for (int j=0; j<(int)m_kstates[i].size(); j++) {
+			m_pstates[i][j] = m_kstates[i][j];
+		}
+	}
+
+}
+
+
+
+////////////////////////////////
+//
+// Tool_1520ify::clearStates --
+//
+
+void Tool_1520ify::clearStates(void) {
+	for (int i=0; i<(int)m_pstates.size(); i++) {
+		fill(m_pstates[i].begin(), m_pstates[i].end(), 0);
+	}
+	for (int i=0; i<(int)m_estates.size(); i++) {
+		fill(m_estates[i].begin(), m_estates[i].end(), false);
+	}
+}
+
+
+//////////////////////////////
+//
+// Tool_1520ify::getDate --
+//
+
+string Tool_1520ify::getDate(void) {
+	auto now = std::chrono::system_clock::now();
+	std::time_t now_time = std::chrono::system_clock::to_time_t(now);
+	std::tm* local_time = std::localtime(&now_time);
+	int year = local_time->tm_year + 1900;
+	int month = local_time->tm_mon + 1;
+	int day = local_time->tm_mday;
+	stringstream ss;
+	ss << year << "/";
+	ss << std::setw(2) << std::setfill('0') << month << "/";
+	ss << std::setw(2) << std::setfill('0') << day;
+	return ss.str();
+}
+
+
+
+//////////////////////////////
+//
+// Tool_1520ify::getYear --
+//
+
+int Tool_1520ify::getYear(void) {
+	auto now = std::chrono::system_clock::now();
+	std::time_t now_time = std::chrono::system_clock::to_time_t(now);
+	std::tm* local_time = std::localtime(&now_time);
+	int year = local_time->tm_year + 1900;
+	return year;
+}
+
+
+
+// END_MERGE
+
+} // end namespace hum
+
+STREAM_INTERFACE(Tool_1520ify)

--- a/include/tool-1520ify.h
+++ b/include/tool-1520ify.h
@@ -45,6 +45,9 @@ class Tool_1520ify : public HumTool {
 		void        fixEditorialAccidentals(HumdrumFile& infile);
 		void        fixInstrumentAbbreviations(HumdrumFile& infile);
 		void        addTerminalLongs   (HumdrumFile& infile);
+		bool        isInternalSectionBoundary(HumdrumFile& infile, int lineindex);
+		bool        markPreviousNoteAsLong(HTp token, bool stopAtRest);
+		std::string getVoicesReference(HumdrumFile& infile);
 		void        deleteDummyTranspositions(HumdrumFile& infile);
 		std::string getDate            (void);
 		int         getYear            (void);
@@ -62,6 +65,5 @@ class Tool_1520ify : public HumTool {
 } // end namespace hum
 
 #endif /* _TOOL_1520IFY_H_INCLUDED */
-
 
 

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Sun Jun 14 23:22:55 PDT 2026
+// Last Modified: Tue Jun 30 10:40:09 CEST 2026
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -56903,6 +56903,417 @@ ostream& operator<<(ostream& out, PixelColor apixel) {
 
 
 
+static void splitEncoderDate(HumdrumFile& infile) {
+	HumRegex hre;
+	int encLine = -1;
+	int endLine = -1;
+	std::string encoder;
+	std::string endDate;
+
+	for (int i=0; i<infile.getLineCount(); ++i) {
+		if (!infile[i].isReference()) {
+			continue;
+		}
+		HTp tok = infile.token(i, 0);
+		if (!tok) {
+			continue;
+		}
+		if ((encLine < 0) && (tok->compare(0, 7, "!!!ENC:") == 0)) {
+			std::string text = tok->getText().substr(7);
+			while (!text.empty() && std::isspace(static_cast<unsigned char>(text.front()))) {
+				text.erase(text.begin());
+			}
+			while (!text.empty() && std::isspace(static_cast<unsigned char>(text.back()))) {
+				text.pop_back();
+			}
+			if (hre.search(text, "^(.+?)\\s+((?:\\d{4}/\\d{1,2}/\\d{1,2})|(?:\\d{1,2}-\\d{1,2}-\\d{4}))/?$")) {
+				encoder = hre.getMatch(1);
+				endDate = hre.getMatch(2);
+				encLine = i;
+			}
+		} else if ((endLine < 0) && (tok->compare(0, 7, "!!!END:") == 0)) {
+			endLine = i;
+		}
+	}
+
+	if (encLine < 0) {
+		return;
+	}
+
+	while (!encoder.empty() && std::isspace(static_cast<unsigned char>(encoder.back()))) {
+		encoder.pop_back();
+	}
+	infile.token(encLine, 0)->setText("!!!ENC: " + encoder);
+
+	if (endLine >= 0) {
+		HTp tok = infile.token(endLine, 0);
+		std::string text = tok ? tok->getText() : "";
+		size_t colon = text.find(':');
+		bool hasContent = false;
+		if (colon != std::string::npos) {
+			for (size_t p=colon + 1; p<text.size(); ++p) {
+				if (!std::isspace(static_cast<unsigned char>(text[p]))) {
+					hasContent = true;
+					break;
+				}
+			}
+		}
+		if (!hasContent && tok) {
+			tok->setText("!!!END: " + endDate);
+		}
+	} else {
+		infile.insertLine(encLine + 1, "!!!END: " + endDate);
+	}
+}
+
+
+static std::string getMetForMensurationLabel(const std::string& text) {
+	static const std::vector<std::pair<std::string, std::string>> mappings = {
+		{"MenCircleOver3", "*met(O/3)"},
+		{"MenCutCircle3", "*met(O|3)"},
+		{"MenCircleDot", "*met(O.)"},
+		{"MenCutCDot", "*met(C.|)"},
+		{"MenReverseC", "*met(Cr)"},
+		{"Men3Over2", "*met(3/2)"},
+		{"MenCutCircle", "*met(O|)"},
+		{"MenCutC3", "*met(C|3)"},
+		{"MenCutC2", "*met(C|2)"},
+		{"MenCircle3", "*met(O3)"},
+		{"MenCircle2", "*met(O2)"},
+		{"MenCutC", "*met(C|)"},
+		{"MenCDot", "*met(C.)"},
+		{"MenC3", "*met(C3)"},
+		{"MenC2", "*met(C2)"},
+		{"MenCircle", "*met(O)"},
+		{"MenC", "*met(C)"},
+		{"Men3", "*met(3)"},
+		{"Men2", "*met(2)"}
+	};
+
+	for (const auto& mapping : mappings) {
+		size_t pos = text.find(mapping.first);
+		if (pos == std::string::npos) {
+			continue;
+		}
+		size_t end = pos + mapping.first.size();
+		if ((end < text.size()) && std::isalnum(static_cast<unsigned char>(text[end]))) {
+			continue;
+		}
+		return mapping.second;
+	}
+
+	return "";
+}
+
+
+static std::string getNearbyMensurationLabelMet(HumdrumFile& infile, int mensline) {
+	for (int i=mensline + 1; i<infile.getLineCount(); ++i) {
+		if (infile[i].isData() || infile[i].isBarline() || infile[i].isTerminator()) {
+			break;
+		}
+		if (infile[i].isInterpretation()) {
+			continue;
+		}
+		if (!infile[i].isLocalComment() && !infile[i].isGlobalComment()) {
+			continue;
+		}
+		for (int j=0; j<infile[i].getFieldCount(); ++j) {
+			HTp tok = infile.token(i, j);
+			if (!tok) {
+				continue;
+			}
+			std::string met = getMetForMensurationLabel(tok->getText());
+			if (!met.empty()) {
+				return met;
+			}
+		}
+	}
+
+	return "";
+}
+
+
+static void deleteNearbyMensurationLabel(HumdrumFile& infile, int mensline) {
+	for (int i=mensline + 1; i<infile.getLineCount(); ++i) {
+		if (infile[i].isData() || infile[i].isBarline() || infile[i].isTerminator()) {
+			break;
+		}
+		if (infile[i].isInterpretation()) {
+			continue;
+		}
+		if (!infile[i].isLocalComment() && !infile[i].isGlobalComment()) {
+			continue;
+		}
+
+		bool changed = false;
+		for (int j=0; j<infile[i].getFieldCount(); ++j) {
+			HTp tok = infile.token(i, j);
+			if (!tok) {
+				continue;
+			}
+			if (getMetForMensurationLabel(tok->getText()).empty()) {
+				continue;
+			}
+			if (infile[i].isGlobalComment()) {
+				infile.deleteLine(i);
+				return;
+			}
+			tok->setText("!");
+			changed = true;
+		}
+
+		if (!changed) {
+			continue;
+		}
+
+		bool empty = true;
+		for (int j=0; j<infile[i].getFieldCount(); ++j) {
+			HTp tok = infile.token(i, j);
+			if (tok && (*tok != "!")) {
+				empty = false;
+				break;
+			}
+		}
+		if (empty) {
+			infile.deleteLine(i);
+		}
+		return;
+	}
+}
+
+
+static void applyMensurationLabelMetOverrides(HumdrumFile& infile) {
+	for (int i=0; i<infile.getLineCount(); ++i) {
+		if (!infile[i].isInterpretation()) {
+			continue;
+		}
+
+		bool hasMens = false;
+		for (int j=0; j<infile[i].getFieldCount(); ++j) {
+			HTp tok = infile.token(i, j);
+			if (tok && (tok->compare(0, 2, "*M") == 0)) {
+				hasMens = true;
+				break;
+			}
+		}
+		if (!hasMens) {
+			continue;
+		}
+
+		std::string labelMet = getNearbyMensurationLabelMet(infile, i);
+		if (labelMet.empty()) {
+			continue;
+		}
+
+		for (int j=i + 1; j<infile.getLineCount(); ++j) {
+			if (infile[j].isData() || infile[j].isBarline() || infile[j].isTerminator()) {
+				break;
+			}
+			if (!infile[j].isInterpretation()) {
+				continue;
+			}
+
+			bool hasMet = false;
+			for (int k=0; k<infile[j].getFieldCount(); ++k) {
+				HTp tok = infile.token(j, k);
+				if (tok && (tok->compare(0, 5, "*met(") == 0)) {
+					hasMet = true;
+					break;
+				}
+			}
+			if (!hasMet) {
+				continue;
+			}
+
+			for (int k=0; k<infile[j].getFieldCount(); ++k) {
+				HTp tok = infile.token(j, k);
+				if (tok && !tok->isNull()) {
+					tok->setText(labelMet);
+				}
+			}
+			deleteNearbyMensurationLabel(infile, i);
+			break;
+		}
+	}
+}
+
+
+static std::string addMeasureNumberToBarlineToken(const std::string& text, int number) {
+	std::string output;
+	for (int i=0; i<(int)text.size(); ++i) {
+		if ((text[i] == '=') && ((i + 1 >= (int)text.size()) || (text[i + 1] != '='))) {
+			output += '=';
+			output += std::to_string(number);
+		} else if (!std::isdigit(static_cast<unsigned char>(text[i]))) {
+			output += text[i];
+		}
+	}
+	return output;
+}
+
+
+static void addAllMeasureNumbers(HumdrumFile& infile) {
+	int number = 1;
+	for (int i=0; i<infile.getLineCount(); ++i) {
+		if (!infile[i].isBarline()) {
+			continue;
+		}
+
+		bool finalQ = false;
+		for (int j=0; j<infile[i].getFieldCount(); ++j) {
+			HTp tok = infile.token(i, j);
+			if (tok && (tok->find("==") != std::string::npos)) {
+				finalQ = true;
+				break;
+			}
+		}
+		if (finalQ) {
+			continue;
+		}
+
+		for (int j=0; j<infile[i].getFieldCount(); ++j) {
+			HTp tok = infile.token(i, j);
+			if (tok) {
+				tok->setText(addMeasureNumberToBarlineToken(tok->getText(), number));
+			}
+		}
+		number++;
+	}
+}
+
+
+static std::string getDefaultMetForMensuration(HTp token) {
+	if (!token || token->isNull()) {
+		return "";
+	}
+	if (*token == "*M2/1") {
+		return "*met(C|)";
+	}
+	if (*token == "*M3/1") {
+		return "*met(O)";
+	}
+	if (*token == "*M6/2") {
+		return "*met(C.)";
+	}
+	if (*token == "*M9/2") {
+		return "*met(O.)";
+	}
+	return "";
+}
+
+
+static bool hasNonemptyReference(HumdrumFile& infile, const std::string& key) {
+	std::string prefix = "!!!" + key + ":";
+	for (int i=0; i<infile.getLineCount(); ++i) {
+		if (!infile[i].isReference()) {
+			continue;
+		}
+		HTp tok = infile.token(i, 0);
+		if (!tok || (tok->compare(0, prefix.size(), prefix) != 0)) {
+			continue;
+		}
+		std::string text = tok->getText();
+		size_t colon = text.find(':');
+		if (colon == std::string::npos) {
+			return false;
+		}
+		for (size_t p=colon + 1; p<text.size(); ++p) {
+			if (!std::isspace(static_cast<unsigned char>(text[p]))) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	return false;
+}
+
+
+static bool hasMuse2psRecord(HumdrumFile& infile) {
+	for (int i=0; i<infile.getLineCount(); ++i) {
+		if (!infile[i].isGlobalComment()) {
+			continue;
+		}
+		HTp tok = infile.token(i, 0);
+		if (tok && (tok->compare(0, 10, "!!muse2ps:") == 0)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+
+static bool hasTextSpines(HumdrumFile& infile) {
+	for (int i=0; i<infile.getLineCount(); ++i) {
+		if (!infile[i].isExclusive()) {
+			continue;
+		}
+		for (int j=0; j<infile[i].getFieldCount(); ++j) {
+			HTp tok = infile.token(i, j);
+			if (tok && (*tok == "**text")) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+
+static std::string getMuse2psSpacing(int voices, bool texted) {
+	if (texted) {
+		if (voices == 3) {
+			return "i2I150v90,90,120c122z18l2700t130";
+		}
+		if (voices == 4) {
+			return "i2I150v90,90,90,120c122z18l2700t130";
+		}
+		if (voices == 5) {
+			return "i2I150v75,75,75,75,110c122z18l2780t100";
+		}
+		if (voices == 6) {
+			return "i2I150v85,85,85,85,85,100z18l2550t200c122";
+		}
+		return "";
+	}
+
+	if (voices == 3) {
+		return "i2I150v90,90,120c120z18l2770t130";
+	}
+	if (voices == 4) {
+		return "i2I150v90,90,90,120c120z18l2770t130";
+	}
+	if (voices == 5) {
+		return "i2I150v90,90,90,90,120c120z18l2770t130";
+	}
+	if (voices == 6) {
+		return "i2I150v85,85,85,85,85,100z18l2550t200c122";
+	}
+
+	return "";
+}
+
+
+static void addMuse2psRecord(HumdrumFile& infile) {
+	if (hasMuse2psRecord(infile)) {
+		return;
+	}
+
+	int voices = (int)infile.getKernSpineStartList().size();
+	std::string spacing = getMuse2psSpacing(voices, hasTextSpines(infile));
+	if (spacing.empty()) {
+		return;
+	}
+
+	std::string prefix = "C^@{COM}^";
+	if (hasNonemptyReference(infile, "OPR")) {
+		prefix = "T^@{OPR}^u^@{ONM}{. }@{OTL}^C^@{COM}^";
+	}
+
+	infile.appendLine("!!muse2ps: " + prefix + spacing);
+}
+
 
 /////////////////////////////////
 //
@@ -57109,29 +57520,31 @@ void Tool_1520ify::processFile(HumdrumFile& infile) {
 		// If there is a mensuration line just above, use it to decide canonical *met(...)
 		int mensLine = i - 1;
 		if (mensLine >= 0 && infile[mensLine].isInterpretation()) {
+			std::string labelMet = getNearbyMensurationLabelMet(infile, mensLine);
 			for (int j = 0; j < infile[i].getFieldCount(); ++j) {
 				HTp metTok  = infile.token(i, j);
 				HTp mensTok = infile.token(mensLine, j);
 
-				// Default: leave non-*met tokens alone on this line
+				// Default: leave non-*met tokens alone on this line unless a
+				// mensuration label applies to the whole mensuration block.
 				if (!metTok || metTok->isNull()) {
 				    continue;
 				}
 
-				if (metTok->compare(0, 5, "*met(") != 0) {
+				if (labelMet.empty() && (metTok->compare(0, 5, "*met(") != 0)) {
 				    continue;
 				}
 
 				// Decide canonical met from the mensuration just above
 				const char* repl = "*";   // if we can’t decide, blank it
 
-				if (mensTok && !mensTok->isNull()) {
-				    if (*mensTok == "*M2/1") {
-				        repl = "*met(C|)";
-				    }
-				    else if (*mensTok == "*M3/1") {
-				        repl = "*met(O)";
-				    }
+				if (!labelMet.empty()) {
+					repl = labelMet.c_str();
+				} else {
+					std::string defaultMet = getDefaultMetForMensuration(mensTok);
+					if (!defaultMet.empty()) {
+						repl = defaultMet.c_str();
+					}
 				}
 				metTok->setText(repl);
 			}
@@ -57202,21 +57615,24 @@ void Tool_1520ify::processFile(HumdrumFile& infile) {
 			}
 		}
 
-		// Build a *met(...) line (post-normalization we only need to check *M2/1 and *M3/1)
+		// Build a *met(...) line for recognized mensuration signs.
 		std::string newline;
 		bool willInsert = false;
+		std::string labelMet = getNearbyMensurationLabelMet(infile, i);
 
 		for (int j = 0; j < infile[i].getFieldCount(); ++j) {
 			HTp tok = infile.token(i, j);
-			const char* out = "*";
+			std::string out = "*";
 			if (tok && !tok->isNull()) {
-				if (*tok == "*M2/1") { 
-					out = "*met(C|)"; 
+				if (!labelMet.empty() && (tok->compare(0, 2, "*M") == 0)) {
+					out = labelMet;
 					willInsert = true; 
-				}
-				else if (*tok == "*M3/1") { 
-					out = "*met(O)"; 
-					willInsert = true; 
+				} else {
+					std::string defaultMet = getDefaultMetForMensuration(tok);
+					if (!defaultMet.empty()) {
+						out = defaultMet;
+						willInsert = true;
+					}
 				}
 			}
 			newline += out;
@@ -57230,6 +57646,8 @@ void Tool_1520ify::processFile(HumdrumFile& infile) {
 			i++;  // skip the line we just inserted
 		}
 	}
+
+	applyMensurationLabelMetOverrides(infile);
 
 	// Convert LO:TX Section lines in-place to !!section and !!!OMD
 	for (int i = 0; i < infile.getLineCount(); ++i) {
@@ -57280,6 +57698,48 @@ void Tool_1520ify::processFile(HumdrumFile& infile) {
 		i += 1;
 	}
 
+	// Refresh token/line relationships after structural edits so section-based
+	// voice counting sees correct line indexes.
+	infile.createLinesFromTokens();
+
+	// Populate !!!voices after labelled section comments have been created.
+	{
+		std::string voiceText = getVoicesReference(infile);
+
+		if (!voiceText.empty()) {
+			for (int li = 0; li < infile.getLineCount(); ++li) {
+				if (!infile[li].isReference()) {
+					continue;
+				}
+				HTp tok = infile.token(li, 0);
+				if (!tok) {
+					continue;
+				}
+				if (tok->compare(0, 10, "!!!voices:") != 0) {
+					continue;
+				}
+
+				std::string cur = tok->getText();
+				size_t colon = cur.find(':');
+				bool hasContent = false;
+				if (colon != std::string::npos) {
+					for (size_t p = colon + 1; p < cur.size(); ++p) {
+						if (!std::isspace(static_cast<unsigned char>(cur[p]))) {
+							hasContent = true;
+							break;
+						}
+					}
+				}
+
+				bool overwriteQ = (voiceText.find('-') != std::string::npos);
+				if (!hasContent || overwriteQ) {
+					tok->setText("!!!voices: " + voiceText);
+				}
+				break;
+			}
+		}
+	}
+
 	// Input lyrics may contain "=" signs which are to be converted into
 	// spaces in **text data, and into elisions when displaying with verovio.
 	Tool_shed shed;
@@ -57291,6 +57751,8 @@ void Tool_1520ify::processFile(HumdrumFile& infile) {
 	argv.push_back("s/=/ /g");
 	shed.process(argv);
 	shed.run(infile);
+
+	addAllMeasureNumbers(infile);
 }
 
 
@@ -57426,6 +57888,22 @@ void Tool_1520ify::fixEditorialAccidentals(HumdrumFile& infile) {
 //
 
 void Tool_1520ify::addTerminalLongs(HumdrumFile& infile) {
+	for (int i=0; i<infile.getLineCount(); ++i) {
+		if (!isInternalSectionBoundary(infile, i)) {
+			continue;
+		}
+		for (int j=0; j<infile[i].getFieldCount(); ++j) {
+			HTp token = infile.token(i, j);
+			if (!token || !token->isKern()) {
+				continue;
+			}
+			if (token->find("||") == string::npos) {
+				continue;
+			}
+			markPreviousNoteAsLong(token, true);
+		}
+	}
+
 	int scount = infile.getStrandCount();
 	for (int i=0; i<scount; i++) {
 		HTp cur = infile.getStrandEnd(i);
@@ -57435,34 +57913,273 @@ void Tool_1520ify::addTerminalLongs(HumdrumFile& infile) {
 		if (!cur->isKern()) {
 			continue;
 		}
-		while (cur) {
-			if (!cur->isData()) {
-				cur = cur->getPreviousToken();
-				continue;
-			}
-			if (cur->isNull()) {
-				cur = cur->getPreviousToken();
-				continue;
-			}
-			if (cur->isRest()) {
-				cur = cur->getPreviousToken();
-				continue;
-			}
-			if (cur->isSecondaryTiedNote()) {
-				cur = cur->getPreviousToken();
-				continue;
-			}
-			if (cur->find("l") != std::string::npos) {
-				// already marked so do not do it again
-				break;
-			}
-			// mark this note with "l"
-			string newtext = *cur;
-			newtext += "l";
-			cur->setText(newtext);
+		markPreviousNoteAsLong(cur, false);
+	}
+}
+
+
+
+//////////////////////////////
+//
+// Tool_1520ify::isInternalSectionBoundary -- Identify internal double barlines
+//    that are followed by a new section rather than score termination.
+//
+
+bool Tool_1520ify::isInternalSectionBoundary(HumdrumFile& infile, int lineindex) {
+	if ((lineindex < 0) || (lineindex >= infile.getLineCount())) {
+		return false;
+	}
+	if (!infile[lineindex].isBarline()) {
+		return false;
+	}
+
+	bool doubleQ = false;
+	for (int j=0; j<infile[lineindex].getFieldCount(); ++j) {
+		HTp token = infile.token(lineindex, j);
+		if (token && token->find("||") != string::npos) {
+			doubleQ = true;
 			break;
 		}
 	}
+	if (!doubleQ) {
+		return false;
+	}
+
+	bool restartQ = false;
+	for (int i=lineindex + 1; i<infile.getLineCount(); ++i) {
+		if (infile[i].isTerminator()) {
+			return false;
+		}
+		if (infile[i].isBarline()) {
+			return false;
+		}
+		if (infile[i].isGlobalComment()) {
+			HTp token = infile.token(i, 0);
+			if (!token) {
+				continue;
+			}
+			if ((token->compare(0, 10, "!!section:") == 0) ||
+			    (token->compare(0, 7, "!!!OMD:") == 0)) {
+				restartQ = true;
+			}
+			continue;
+		}
+		if (infile[i].isLocalComment() || infile[i].isReference() || infile[i].isEmpty()) {
+			continue;
+		}
+		if (infile[i].isInterpretation()) {
+			for (int j=0; j<infile[i].getFieldCount(); ++j) {
+				HTp token = infile.token(i, j);
+				if (!token || token->isNull()) {
+					continue;
+				}
+				if ((token->compare(0, 2, "*M") == 0) ||
+				    (token->compare(0, 5, "*met(") == 0)) {
+					restartQ = true;
+				}
+			}
+			continue;
+		}
+		if (infile[i].isData()) {
+			return restartQ;
+		}
+	}
+
+	return false;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_1520ify::markPreviousNoteAsLong -- Walk backwards within a strand
+//    and mark the last note attack as a long.  For internal boundaries,
+//    stopAtRest prevents adding a long when the voice has already dropped
+//    out into rests before the section break.
+//
+
+bool Tool_1520ify::markPreviousNoteAsLong(HTp token, bool stopAtRest) {
+	if (!token) {
+		return false;
+	}
+
+	HTp cur = token->getPreviousToken();
+	while (cur) {
+		if (!cur->isData()) {
+			cur = cur->getPreviousToken();
+			continue;
+		}
+		if (cur->isNull()) {
+			cur = cur->getPreviousToken();
+			continue;
+		}
+		if (cur->isRest()) {
+			if (stopAtRest) {
+				return false;
+			}
+			cur = cur->getPreviousToken();
+			continue;
+		}
+		if (cur->isSecondaryTiedNote()) {
+			cur = cur->getPreviousToken();
+			continue;
+		}
+		if (cur->find("l") != std::string::npos) {
+			return true;
+		}
+
+		string newtext = *cur;
+		newtext += "l";
+		cur->setText(newtext);
+		return true;
+	}
+
+	return false;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_1520ify::getVoicesReference -- Return a voice-count reference string
+//    based on active voices in labelled internal sections.  If sections
+//    differ in active voice counts, report a range such as "2-4".
+//
+
+std::string Tool_1520ify::getVoicesReference(HumdrumFile& infile) {
+	std::vector<HTp> kerns = infile.getKernSpineStartList();
+	if (kerns.empty()) {
+		return "";
+	}
+
+	auto isLabeledSectionBoundary = [&](int lineindex) -> bool {
+		if ((lineindex < 0) || (lineindex >= infile.getLineCount())) {
+			return false;
+		}
+		if (!infile[lineindex].isBarline()) {
+			return false;
+		}
+
+		bool doubleQ = false;
+		for (int j=0; j<infile[lineindex].getFieldCount(); ++j) {
+			HTp token = infile.token(lineindex, j);
+			if (token && token->find("||") != string::npos) {
+				doubleQ = true;
+				break;
+			}
+		}
+		if (!doubleQ) {
+			return false;
+		}
+
+		for (int i=lineindex + 1; i<infile.getLineCount(); ++i) {
+			if (infile[i].isTerminator()) {
+				return false;
+			}
+			if (infile[i].isBarline()) {
+				return false;
+			}
+			if (infile[i].isGlobalComment()) {
+				HTp token = infile.token(i, 0);
+				if (!token) {
+					continue;
+				}
+				if ((token->compare(0, 10, "!!section:") == 0) ||
+				    (token->compare(0, 7, "!!!OMD:") == 0)) {
+					return true;
+				}
+				continue;
+			}
+			if (infile[i].isLocalComment() || infile[i].isReference() ||
+			    infile[i].isInterpretation() || infile[i].isEmpty()) {
+				continue;
+			}
+			if (infile[i].isData()) {
+				return false;
+			}
+		}
+		return false;
+	};
+
+	std::vector<std::pair<int, int>> sections;
+	int startline = -1;
+	for (int i=0; i<infile.getLineCount(); ++i) {
+		if (infile[i].isData()) {
+			startline = i;
+			break;
+		}
+	}
+	if (startline < 0) {
+		return "";
+	}
+
+	for (int i=0; i<infile.getLineCount(); ++i) {
+		if (!isLabeledSectionBoundary(i)) {
+			continue;
+		}
+		sections.push_back(std::make_pair(startline, i));
+		for (int j=i + 1; j<infile.getLineCount(); ++j) {
+			if (infile[j].isData()) {
+				startline = j;
+				break;
+			}
+		}
+	}
+
+	int endline = -1;
+	for (int i=infile.getLineCount() - 1; i>=0; --i) {
+		if (infile[i].isData()) {
+			endline = i;
+			break;
+		}
+	}
+	if ((startline >= 0) && (endline >= startline)) {
+		sections.push_back(std::make_pair(startline, endline));
+	}
+
+	if (sections.empty()) {
+		return std::to_string((int)kerns.size());
+	}
+
+	int minVoices = (int)kerns.size();
+	int maxVoices = 0;
+
+	for (int i=0; i<(int)sections.size(); ++i) {
+		std::vector<bool> active(kerns.size(), false);
+		for (int line=sections[i].first; line<=sections[i].second; ++line) {
+			if (!infile[line].isData()) {
+				continue;
+			}
+			int kindex = 0;
+			for (int field=0; field<infile[line].getFieldCount(); ++field) {
+				HTp tok = infile.token(line, field);
+				if (!tok || !tok->isKern()) {
+					continue;
+				}
+				if (kindex >= (int)active.size()) {
+					break;
+				}
+				if (!tok->isNull() && !tok->isRest() && !tok->isSecondaryTiedNote()) {
+					active[kindex] = true;
+				}
+				kindex++;
+			}
+		}
+
+		int activeCount = 0;
+		for (int j=0; j<(int)active.size(); ++j) {
+			if (active[j]) {
+				activeCount++;
+			}
+		}
+		minVoices = std::min(minVoices, activeCount);
+		maxVoices = std::max(maxVoices, activeCount);
+	}
+
+	if (minVoices == maxVoices) {
+		return std::to_string(minVoices);
+	}
+	return std::to_string(minVoices) + "-" + std::to_string(maxVoices);
 }
 
 
@@ -57768,6 +58485,17 @@ void Tool_1520ify::addBibliographicRecords(HumdrumFile& infile) {
 		}
 	}
 
+	if (!basename.empty()) {
+		size_t dot = basename.find_last_of('.');
+		if ((dot != std::string::npos) && (basename.substr(dot) == ".krn")) {
+			// already in the desired form
+		} else if (dot != std::string::npos) {
+			basename = basename.substr(0, dot) + ".krn";
+		} else {
+			basename += ".krn";
+		}
+	}
+
 	// Build the segment line
 	std::string segmentLine = "!!!!SEGMENT: " + basename;
 
@@ -57961,51 +58689,6 @@ void Tool_1520ify::addBibliographicRecords(HumdrumFile& infile) {
 	} else if (foundOPR) {
 	    infile.deleteLine(oprLine);
 	}
-
-	// --- Populate voices from number of **kern spines ---
-	{
-		// Count **kern spines
-		std::vector<HTp> kerns = infile.getKernSpineStartList();
-		int voiceCount = static_cast<int>(kerns.size());
-
-		if (voiceCount > 0) {
-			for (int li = 0; li < infile.getLineCount(); ++li) {
-				if (!infile[li].isReference()) {
-					continue;
-				}
-				HTp tok = infile.token(li, 0);
-				if (!tok) {
-					continue;
-				}
-
-				// Find the !!!voices: line
-				if (tok->compare(0, 10, "!!!voices:") != 0){
-					continue;
-				}
-
-				std::string cur = tok->getText();
-
-				// Check if there is already non-whitespace content after the colon
-				size_t colon = cur.find(':');
-				bool hasContent = false;
-				if (colon != std::string::npos) {
-					for (size_t p = colon + 1; p < cur.size(); ++p) {
-						if (!std::isspace(static_cast<unsigned char>(cur[p]))) {
-							hasContent = true;
-							break;
-						}
-					}
-				}
-
-				// Only auto-fill if it was effectively empty
-				if (!hasContent) {
-					tok->setText("!!!voices: " + std::to_string(voiceCount));
-				}
-				break; // done with voices
-			}
-		}
-	}
-
 
 	// --- Auto-fill AGN (genre + optional movement name) based on numeric id ---
 	
@@ -58273,6 +58956,8 @@ void Tool_1520ify::addBibliographicRecords(HumdrumFile& infile) {
 		infile.appendLine(line);
 	}
 
+	splitEncoderDate(infile);
+
 	// --- Remove !!!SMS: if it contains no content ---
 	{
 	    for (int li = 0; li < infile.getLineCount(); ++li) {
@@ -58309,6 +58994,8 @@ void Tool_1520ify::addBibliographicRecords(HumdrumFile& infile) {
 	        }
 	    }
 	}
+
+	addMuse2psRecord(infile);
 }
 
 

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Sun Jun 14 23:22:55 PDT 2026
+// Last Modified: Tue Jun 30 10:40:09 CEST 2026
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11
@@ -5936,6 +5936,9 @@ class Tool_1520ify : public HumTool {
 		void        fixEditorialAccidentals(HumdrumFile& infile);
 		void        fixInstrumentAbbreviations(HumdrumFile& infile);
 		void        addTerminalLongs   (HumdrumFile& infile);
+		bool        isInternalSectionBoundary(HumdrumFile& infile, int lineindex);
+		bool        markPreviousNoteAsLong(HTp token, bool stopAtRest);
+		std::string getVoicesReference(HumdrumFile& infile);
 		void        deleteDummyTranspositions(HumdrumFile& infile);
 		std::string getDate            (void);
 		int         getYear            (void);

--- a/src/tool-1520ify.cpp
+++ b/src/tool-1520ify.cpp
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <chrono>
 #include <iomanip>
+#include <sstream>
 
 // include filesystem for grabbing the filename
 #include <filesystem>
@@ -31,6 +32,417 @@ using namespace std;
 namespace hum {
 
 // START_MERGE
+
+static void splitEncoderDate(HumdrumFile& infile) {
+	HumRegex hre;
+	int encLine = -1;
+	int endLine = -1;
+	std::string encoder;
+	std::string endDate;
+
+	for (int i=0; i<infile.getLineCount(); ++i) {
+		if (!infile[i].isReference()) {
+			continue;
+		}
+		HTp tok = infile.token(i, 0);
+		if (!tok) {
+			continue;
+		}
+		if ((encLine < 0) && (tok->compare(0, 7, "!!!ENC:") == 0)) {
+			std::string text = tok->getText().substr(7);
+			while (!text.empty() && std::isspace(static_cast<unsigned char>(text.front()))) {
+				text.erase(text.begin());
+			}
+			while (!text.empty() && std::isspace(static_cast<unsigned char>(text.back()))) {
+				text.pop_back();
+			}
+			if (hre.search(text, "^(.+?)\\s+((?:\\d{4}/\\d{1,2}/\\d{1,2})|(?:\\d{1,2}-\\d{1,2}-\\d{4}))/?$")) {
+				encoder = hre.getMatch(1);
+				endDate = hre.getMatch(2);
+				encLine = i;
+			}
+		} else if ((endLine < 0) && (tok->compare(0, 7, "!!!END:") == 0)) {
+			endLine = i;
+		}
+	}
+
+	if (encLine < 0) {
+		return;
+	}
+
+	while (!encoder.empty() && std::isspace(static_cast<unsigned char>(encoder.back()))) {
+		encoder.pop_back();
+	}
+	infile.token(encLine, 0)->setText("!!!ENC: " + encoder);
+
+	if (endLine >= 0) {
+		HTp tok = infile.token(endLine, 0);
+		std::string text = tok ? tok->getText() : "";
+		size_t colon = text.find(':');
+		bool hasContent = false;
+		if (colon != std::string::npos) {
+			for (size_t p=colon + 1; p<text.size(); ++p) {
+				if (!std::isspace(static_cast<unsigned char>(text[p]))) {
+					hasContent = true;
+					break;
+				}
+			}
+		}
+		if (!hasContent && tok) {
+			tok->setText("!!!END: " + endDate);
+		}
+	} else {
+		infile.insertLine(encLine + 1, "!!!END: " + endDate);
+	}
+}
+
+
+static std::string getMetForMensurationLabel(const std::string& text) {
+	static const std::vector<std::pair<std::string, std::string>> mappings = {
+		{"MenCircleOver3", "*met(O/3)"},
+		{"MenCutCircle3", "*met(O|3)"},
+		{"MenCircleDot", "*met(O.)"},
+		{"MenCutCDot", "*met(C.|)"},
+		{"MenReverseC", "*met(Cr)"},
+		{"Men3Over2", "*met(3/2)"},
+		{"MenCutCircle", "*met(O|)"},
+		{"MenCutC3", "*met(C|3)"},
+		{"MenCutC2", "*met(C|2)"},
+		{"MenCircle3", "*met(O3)"},
+		{"MenCircle2", "*met(O2)"},
+		{"MenCutC", "*met(C|)"},
+		{"MenCDot", "*met(C.)"},
+		{"MenC3", "*met(C3)"},
+		{"MenC2", "*met(C2)"},
+		{"MenCircle", "*met(O)"},
+		{"MenC", "*met(C)"},
+		{"Men3", "*met(3)"},
+		{"Men2", "*met(2)"}
+	};
+
+	for (const auto& mapping : mappings) {
+		size_t pos = text.find(mapping.first);
+		if (pos == std::string::npos) {
+			continue;
+		}
+		size_t end = pos + mapping.first.size();
+		if ((end < text.size()) && std::isalnum(static_cast<unsigned char>(text[end]))) {
+			continue;
+		}
+		return mapping.second;
+	}
+
+	return "";
+}
+
+
+static std::string getNearbyMensurationLabelMet(HumdrumFile& infile, int mensline) {
+	for (int i=mensline + 1; i<infile.getLineCount(); ++i) {
+		if (infile[i].isData() || infile[i].isBarline() || infile[i].isTerminator()) {
+			break;
+		}
+		if (infile[i].isInterpretation()) {
+			continue;
+		}
+		if (!infile[i].isLocalComment() && !infile[i].isGlobalComment()) {
+			continue;
+		}
+		for (int j=0; j<infile[i].getFieldCount(); ++j) {
+			HTp tok = infile.token(i, j);
+			if (!tok) {
+				continue;
+			}
+			std::string met = getMetForMensurationLabel(tok->getText());
+			if (!met.empty()) {
+				return met;
+			}
+		}
+	}
+
+	return "";
+}
+
+
+static void deleteNearbyMensurationLabel(HumdrumFile& infile, int mensline) {
+	for (int i=mensline + 1; i<infile.getLineCount(); ++i) {
+		if (infile[i].isData() || infile[i].isBarline() || infile[i].isTerminator()) {
+			break;
+		}
+		if (infile[i].isInterpretation()) {
+			continue;
+		}
+		if (!infile[i].isLocalComment() && !infile[i].isGlobalComment()) {
+			continue;
+		}
+
+		bool changed = false;
+		for (int j=0; j<infile[i].getFieldCount(); ++j) {
+			HTp tok = infile.token(i, j);
+			if (!tok) {
+				continue;
+			}
+			if (getMetForMensurationLabel(tok->getText()).empty()) {
+				continue;
+			}
+			if (infile[i].isGlobalComment()) {
+				infile.deleteLine(i);
+				return;
+			}
+			tok->setText("!");
+			changed = true;
+		}
+
+		if (!changed) {
+			continue;
+		}
+
+		bool empty = true;
+		for (int j=0; j<infile[i].getFieldCount(); ++j) {
+			HTp tok = infile.token(i, j);
+			if (tok && (*tok != "!")) {
+				empty = false;
+				break;
+			}
+		}
+		if (empty) {
+			infile.deleteLine(i);
+		}
+		return;
+	}
+}
+
+
+static void applyMensurationLabelMetOverrides(HumdrumFile& infile) {
+	for (int i=0; i<infile.getLineCount(); ++i) {
+		if (!infile[i].isInterpretation()) {
+			continue;
+		}
+
+		bool hasMens = false;
+		for (int j=0; j<infile[i].getFieldCount(); ++j) {
+			HTp tok = infile.token(i, j);
+			if (tok && (tok->compare(0, 2, "*M") == 0)) {
+				hasMens = true;
+				break;
+			}
+		}
+		if (!hasMens) {
+			continue;
+		}
+
+		std::string labelMet = getNearbyMensurationLabelMet(infile, i);
+		if (labelMet.empty()) {
+			continue;
+		}
+
+		for (int j=i + 1; j<infile.getLineCount(); ++j) {
+			if (infile[j].isData() || infile[j].isBarline() || infile[j].isTerminator()) {
+				break;
+			}
+			if (!infile[j].isInterpretation()) {
+				continue;
+			}
+
+			bool hasMet = false;
+			for (int k=0; k<infile[j].getFieldCount(); ++k) {
+				HTp tok = infile.token(j, k);
+				if (tok && (tok->compare(0, 5, "*met(") == 0)) {
+					hasMet = true;
+					break;
+				}
+			}
+			if (!hasMet) {
+				continue;
+			}
+
+			for (int k=0; k<infile[j].getFieldCount(); ++k) {
+				HTp tok = infile.token(j, k);
+				if (tok && !tok->isNull()) {
+					tok->setText(labelMet);
+				}
+			}
+			deleteNearbyMensurationLabel(infile, i);
+			break;
+		}
+	}
+}
+
+
+static std::string addMeasureNumberToBarlineToken(const std::string& text, int number) {
+	std::string output;
+	for (int i=0; i<(int)text.size(); ++i) {
+		if ((text[i] == '=') && ((i + 1 >= (int)text.size()) || (text[i + 1] != '='))) {
+			output += '=';
+			output += std::to_string(number);
+		} else if (!std::isdigit(static_cast<unsigned char>(text[i]))) {
+			output += text[i];
+		}
+	}
+	return output;
+}
+
+
+static void addAllMeasureNumbers(HumdrumFile& infile) {
+	int number = 1;
+	for (int i=0; i<infile.getLineCount(); ++i) {
+		if (!infile[i].isBarline()) {
+			continue;
+		}
+
+		bool finalQ = false;
+		for (int j=0; j<infile[i].getFieldCount(); ++j) {
+			HTp tok = infile.token(i, j);
+			if (tok && (tok->find("==") != std::string::npos)) {
+				finalQ = true;
+				break;
+			}
+		}
+		if (finalQ) {
+			continue;
+		}
+
+		for (int j=0; j<infile[i].getFieldCount(); ++j) {
+			HTp tok = infile.token(i, j);
+			if (tok) {
+				tok->setText(addMeasureNumberToBarlineToken(tok->getText(), number));
+			}
+		}
+		number++;
+	}
+}
+
+
+static std::string getDefaultMetForMensuration(HTp token) {
+	if (!token || token->isNull()) {
+		return "";
+	}
+	if (*token == "*M2/1") {
+		return "*met(C|)";
+	}
+	if (*token == "*M3/1") {
+		return "*met(O)";
+	}
+	if (*token == "*M6/2") {
+		return "*met(C.)";
+	}
+	if (*token == "*M9/2") {
+		return "*met(O.)";
+	}
+	return "";
+}
+
+
+static bool hasNonemptyReference(HumdrumFile& infile, const std::string& key) {
+	std::string prefix = "!!!" + key + ":";
+	for (int i=0; i<infile.getLineCount(); ++i) {
+		if (!infile[i].isReference()) {
+			continue;
+		}
+		HTp tok = infile.token(i, 0);
+		if (!tok || (tok->compare(0, prefix.size(), prefix) != 0)) {
+			continue;
+		}
+		std::string text = tok->getText();
+		size_t colon = text.find(':');
+		if (colon == std::string::npos) {
+			return false;
+		}
+		for (size_t p=colon + 1; p<text.size(); ++p) {
+			if (!std::isspace(static_cast<unsigned char>(text[p]))) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	return false;
+}
+
+
+static bool hasMuse2psRecord(HumdrumFile& infile) {
+	for (int i=0; i<infile.getLineCount(); ++i) {
+		if (!infile[i].isGlobalComment()) {
+			continue;
+		}
+		HTp tok = infile.token(i, 0);
+		if (tok && (tok->compare(0, 10, "!!muse2ps:") == 0)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+
+static bool hasTextSpines(HumdrumFile& infile) {
+	for (int i=0; i<infile.getLineCount(); ++i) {
+		if (!infile[i].isExclusive()) {
+			continue;
+		}
+		for (int j=0; j<infile[i].getFieldCount(); ++j) {
+			HTp tok = infile.token(i, j);
+			if (tok && (*tok == "**text")) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+
+static std::string getMuse2psSpacing(int voices, bool texted) {
+	if (texted) {
+		if (voices == 3) {
+			return "i2I150v90,90,120c122z18l2700t130";
+		}
+		if (voices == 4) {
+			return "i2I150v90,90,90,120c122z18l2700t130";
+		}
+		if (voices == 5) {
+			return "i2I150v75,75,75,75,110c122z18l2780t100";
+		}
+		if (voices == 6) {
+			return "i2I150v85,85,85,85,85,100z18l2550t200c122";
+		}
+		return "";
+	}
+
+	if (voices == 3) {
+		return "i2I150v90,90,120c120z18l2770t130";
+	}
+	if (voices == 4) {
+		return "i2I150v90,90,90,120c120z18l2770t130";
+	}
+	if (voices == 5) {
+		return "i2I150v90,90,90,90,120c120z18l2770t130";
+	}
+	if (voices == 6) {
+		return "i2I150v85,85,85,85,85,100z18l2550t200c122";
+	}
+
+	return "";
+}
+
+
+static void addMuse2psRecord(HumdrumFile& infile) {
+	if (hasMuse2psRecord(infile)) {
+		return;
+	}
+
+	int voices = (int)infile.getKernSpineStartList().size();
+	std::string spacing = getMuse2psSpacing(voices, hasTextSpines(infile));
+	if (spacing.empty()) {
+		return;
+	}
+
+	std::string prefix = "C^@{COM}^";
+	if (hasNonemptyReference(infile, "OPR")) {
+		prefix = "T^@{OPR}^u^@{ONM}{. }@{OTL}^C^@{COM}^";
+	}
+
+	infile.appendLine("!!muse2ps: " + prefix + spacing);
+}
 
 
 /////////////////////////////////
@@ -238,29 +650,31 @@ void Tool_1520ify::processFile(HumdrumFile& infile) {
 		// If there is a mensuration line just above, use it to decide canonical *met(...)
 		int mensLine = i - 1;
 		if (mensLine >= 0 && infile[mensLine].isInterpretation()) {
+			std::string labelMet = getNearbyMensurationLabelMet(infile, mensLine);
 			for (int j = 0; j < infile[i].getFieldCount(); ++j) {
 				HTp metTok  = infile.token(i, j);
 				HTp mensTok = infile.token(mensLine, j);
 
-				// Default: leave non-*met tokens alone on this line
+				// Default: leave non-*met tokens alone on this line unless a
+				// mensuration label applies to the whole mensuration block.
 				if (!metTok || metTok->isNull()) {
 				    continue;
 				}
 
-				if (metTok->compare(0, 5, "*met(") != 0) {
+				if (labelMet.empty() && (metTok->compare(0, 5, "*met(") != 0)) {
 				    continue;
 				}
 
 				// Decide canonical met from the mensuration just above
 				const char* repl = "*";   // if we can’t decide, blank it
 
-				if (mensTok && !mensTok->isNull()) {
-				    if (*mensTok == "*M2/1") {
-				        repl = "*met(C|)";
-				    }
-				    else if (*mensTok == "*M3/1") {
-				        repl = "*met(O)";
-				    }
+				if (!labelMet.empty()) {
+					repl = labelMet.c_str();
+				} else {
+					std::string defaultMet = getDefaultMetForMensuration(mensTok);
+					if (!defaultMet.empty()) {
+						repl = defaultMet.c_str();
+					}
 				}
 				metTok->setText(repl);
 			}
@@ -331,21 +745,24 @@ void Tool_1520ify::processFile(HumdrumFile& infile) {
 			}
 		}
 
-		// Build a *met(...) line (post-normalization we only need to check *M2/1 and *M3/1)
+		// Build a *met(...) line for recognized mensuration signs.
 		std::string newline;
 		bool willInsert = false;
+		std::string labelMet = getNearbyMensurationLabelMet(infile, i);
 
 		for (int j = 0; j < infile[i].getFieldCount(); ++j) {
 			HTp tok = infile.token(i, j);
-			const char* out = "*";
+			std::string out = "*";
 			if (tok && !tok->isNull()) {
-				if (*tok == "*M2/1") { 
-					out = "*met(C|)"; 
+				if (!labelMet.empty() && (tok->compare(0, 2, "*M") == 0)) {
+					out = labelMet;
 					willInsert = true; 
-				}
-				else if (*tok == "*M3/1") { 
-					out = "*met(O)"; 
-					willInsert = true; 
+				} else {
+					std::string defaultMet = getDefaultMetForMensuration(tok);
+					if (!defaultMet.empty()) {
+						out = defaultMet;
+						willInsert = true;
+					}
 				}
 			}
 			newline += out;
@@ -359,6 +776,8 @@ void Tool_1520ify::processFile(HumdrumFile& infile) {
 			i++;  // skip the line we just inserted
 		}
 	}
+
+	applyMensurationLabelMetOverrides(infile);
 
 	// Convert LO:TX Section lines in-place to !!section and !!!OMD
 	for (int i = 0; i < infile.getLineCount(); ++i) {
@@ -409,6 +828,48 @@ void Tool_1520ify::processFile(HumdrumFile& infile) {
 		i += 1;
 	}
 
+	// Refresh token/line relationships after structural edits so section-based
+	// voice counting sees correct line indexes.
+	infile.createLinesFromTokens();
+
+	// Populate !!!voices after labelled section comments have been created.
+	{
+		std::string voiceText = getVoicesReference(infile);
+
+		if (!voiceText.empty()) {
+			for (int li = 0; li < infile.getLineCount(); ++li) {
+				if (!infile[li].isReference()) {
+					continue;
+				}
+				HTp tok = infile.token(li, 0);
+				if (!tok) {
+					continue;
+				}
+				if (tok->compare(0, 10, "!!!voices:") != 0) {
+					continue;
+				}
+
+				std::string cur = tok->getText();
+				size_t colon = cur.find(':');
+				bool hasContent = false;
+				if (colon != std::string::npos) {
+					for (size_t p = colon + 1; p < cur.size(); ++p) {
+						if (!std::isspace(static_cast<unsigned char>(cur[p]))) {
+							hasContent = true;
+							break;
+						}
+					}
+				}
+
+				bool overwriteQ = (voiceText.find('-') != std::string::npos);
+				if (!hasContent || overwriteQ) {
+					tok->setText("!!!voices: " + voiceText);
+				}
+				break;
+			}
+		}
+	}
+
 	// Input lyrics may contain "=" signs which are to be converted into
 	// spaces in **text data, and into elisions when displaying with verovio.
 	Tool_shed shed;
@@ -420,6 +881,8 @@ void Tool_1520ify::processFile(HumdrumFile& infile) {
 	argv.push_back("s/=/ /g");
 	shed.process(argv);
 	shed.run(infile);
+
+	addAllMeasureNumbers(infile);
 }
 
 
@@ -555,6 +1018,22 @@ void Tool_1520ify::fixEditorialAccidentals(HumdrumFile& infile) {
 //
 
 void Tool_1520ify::addTerminalLongs(HumdrumFile& infile) {
+	for (int i=0; i<infile.getLineCount(); ++i) {
+		if (!isInternalSectionBoundary(infile, i)) {
+			continue;
+		}
+		for (int j=0; j<infile[i].getFieldCount(); ++j) {
+			HTp token = infile.token(i, j);
+			if (!token || !token->isKern()) {
+				continue;
+			}
+			if (token->find("||") == string::npos) {
+				continue;
+			}
+			markPreviousNoteAsLong(token, true);
+		}
+	}
+
 	int scount = infile.getStrandCount();
 	for (int i=0; i<scount; i++) {
 		HTp cur = infile.getStrandEnd(i);
@@ -564,34 +1043,273 @@ void Tool_1520ify::addTerminalLongs(HumdrumFile& infile) {
 		if (!cur->isKern()) {
 			continue;
 		}
-		while (cur) {
-			if (!cur->isData()) {
-				cur = cur->getPreviousToken();
-				continue;
-			}
-			if (cur->isNull()) {
-				cur = cur->getPreviousToken();
-				continue;
-			}
-			if (cur->isRest()) {
-				cur = cur->getPreviousToken();
-				continue;
-			}
-			if (cur->isSecondaryTiedNote()) {
-				cur = cur->getPreviousToken();
-				continue;
-			}
-			if (cur->find("l") != std::string::npos) {
-				// already marked so do not do it again
-				break;
-			}
-			// mark this note with "l"
-			string newtext = *cur;
-			newtext += "l";
-			cur->setText(newtext);
+		markPreviousNoteAsLong(cur, false);
+	}
+}
+
+
+
+//////////////////////////////
+//
+// Tool_1520ify::isInternalSectionBoundary -- Identify internal double barlines
+//    that are followed by a new section rather than score termination.
+//
+
+bool Tool_1520ify::isInternalSectionBoundary(HumdrumFile& infile, int lineindex) {
+	if ((lineindex < 0) || (lineindex >= infile.getLineCount())) {
+		return false;
+	}
+	if (!infile[lineindex].isBarline()) {
+		return false;
+	}
+
+	bool doubleQ = false;
+	for (int j=0; j<infile[lineindex].getFieldCount(); ++j) {
+		HTp token = infile.token(lineindex, j);
+		if (token && token->find("||") != string::npos) {
+			doubleQ = true;
 			break;
 		}
 	}
+	if (!doubleQ) {
+		return false;
+	}
+
+	bool restartQ = false;
+	for (int i=lineindex + 1; i<infile.getLineCount(); ++i) {
+		if (infile[i].isTerminator()) {
+			return false;
+		}
+		if (infile[i].isBarline()) {
+			return false;
+		}
+		if (infile[i].isGlobalComment()) {
+			HTp token = infile.token(i, 0);
+			if (!token) {
+				continue;
+			}
+			if ((token->compare(0, 10, "!!section:") == 0) ||
+			    (token->compare(0, 7, "!!!OMD:") == 0)) {
+				restartQ = true;
+			}
+			continue;
+		}
+		if (infile[i].isLocalComment() || infile[i].isReference() || infile[i].isEmpty()) {
+			continue;
+		}
+		if (infile[i].isInterpretation()) {
+			for (int j=0; j<infile[i].getFieldCount(); ++j) {
+				HTp token = infile.token(i, j);
+				if (!token || token->isNull()) {
+					continue;
+				}
+				if ((token->compare(0, 2, "*M") == 0) ||
+				    (token->compare(0, 5, "*met(") == 0)) {
+					restartQ = true;
+				}
+			}
+			continue;
+		}
+		if (infile[i].isData()) {
+			return restartQ;
+		}
+	}
+
+	return false;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_1520ify::markPreviousNoteAsLong -- Walk backwards within a strand
+//    and mark the last note attack as a long.  For internal boundaries,
+//    stopAtRest prevents adding a long when the voice has already dropped
+//    out into rests before the section break.
+//
+
+bool Tool_1520ify::markPreviousNoteAsLong(HTp token, bool stopAtRest) {
+	if (!token) {
+		return false;
+	}
+
+	HTp cur = token->getPreviousToken();
+	while (cur) {
+		if (!cur->isData()) {
+			cur = cur->getPreviousToken();
+			continue;
+		}
+		if (cur->isNull()) {
+			cur = cur->getPreviousToken();
+			continue;
+		}
+		if (cur->isRest()) {
+			if (stopAtRest) {
+				return false;
+			}
+			cur = cur->getPreviousToken();
+			continue;
+		}
+		if (cur->isSecondaryTiedNote()) {
+			cur = cur->getPreviousToken();
+			continue;
+		}
+		if (cur->find("l") != std::string::npos) {
+			return true;
+		}
+
+		string newtext = *cur;
+		newtext += "l";
+		cur->setText(newtext);
+		return true;
+	}
+
+	return false;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_1520ify::getVoicesReference -- Return a voice-count reference string
+//    based on active voices in labelled internal sections.  If sections
+//    differ in active voice counts, report a range such as "2-4".
+//
+
+std::string Tool_1520ify::getVoicesReference(HumdrumFile& infile) {
+	std::vector<HTp> kerns = infile.getKernSpineStartList();
+	if (kerns.empty()) {
+		return "";
+	}
+
+	auto isLabeledSectionBoundary = [&](int lineindex) -> bool {
+		if ((lineindex < 0) || (lineindex >= infile.getLineCount())) {
+			return false;
+		}
+		if (!infile[lineindex].isBarline()) {
+			return false;
+		}
+
+		bool doubleQ = false;
+		for (int j=0; j<infile[lineindex].getFieldCount(); ++j) {
+			HTp token = infile.token(lineindex, j);
+			if (token && token->find("||") != string::npos) {
+				doubleQ = true;
+				break;
+			}
+		}
+		if (!doubleQ) {
+			return false;
+		}
+
+		for (int i=lineindex + 1; i<infile.getLineCount(); ++i) {
+			if (infile[i].isTerminator()) {
+				return false;
+			}
+			if (infile[i].isBarline()) {
+				return false;
+			}
+			if (infile[i].isGlobalComment()) {
+				HTp token = infile.token(i, 0);
+				if (!token) {
+					continue;
+				}
+				if ((token->compare(0, 10, "!!section:") == 0) ||
+				    (token->compare(0, 7, "!!!OMD:") == 0)) {
+					return true;
+				}
+				continue;
+			}
+			if (infile[i].isLocalComment() || infile[i].isReference() ||
+			    infile[i].isInterpretation() || infile[i].isEmpty()) {
+				continue;
+			}
+			if (infile[i].isData()) {
+				return false;
+			}
+		}
+		return false;
+	};
+
+	std::vector<std::pair<int, int>> sections;
+	int startline = -1;
+	for (int i=0; i<infile.getLineCount(); ++i) {
+		if (infile[i].isData()) {
+			startline = i;
+			break;
+		}
+	}
+	if (startline < 0) {
+		return "";
+	}
+
+	for (int i=0; i<infile.getLineCount(); ++i) {
+		if (!isLabeledSectionBoundary(i)) {
+			continue;
+		}
+		sections.push_back(std::make_pair(startline, i));
+		for (int j=i + 1; j<infile.getLineCount(); ++j) {
+			if (infile[j].isData()) {
+				startline = j;
+				break;
+			}
+		}
+	}
+
+	int endline = -1;
+	for (int i=infile.getLineCount() - 1; i>=0; --i) {
+		if (infile[i].isData()) {
+			endline = i;
+			break;
+		}
+	}
+	if ((startline >= 0) && (endline >= startline)) {
+		sections.push_back(std::make_pair(startline, endline));
+	}
+
+	if (sections.empty()) {
+		return std::to_string((int)kerns.size());
+	}
+
+	int minVoices = (int)kerns.size();
+	int maxVoices = 0;
+
+	for (int i=0; i<(int)sections.size(); ++i) {
+		std::vector<bool> active(kerns.size(), false);
+		for (int line=sections[i].first; line<=sections[i].second; ++line) {
+			if (!infile[line].isData()) {
+				continue;
+			}
+			int kindex = 0;
+			for (int field=0; field<infile[line].getFieldCount(); ++field) {
+				HTp tok = infile.token(line, field);
+				if (!tok || !tok->isKern()) {
+					continue;
+				}
+				if (kindex >= (int)active.size()) {
+					break;
+				}
+				if (!tok->isNull() && !tok->isRest() && !tok->isSecondaryTiedNote()) {
+					active[kindex] = true;
+				}
+				kindex++;
+			}
+		}
+
+		int activeCount = 0;
+		for (int j=0; j<(int)active.size(); ++j) {
+			if (active[j]) {
+				activeCount++;
+			}
+		}
+		minVoices = std::min(minVoices, activeCount);
+		maxVoices = std::max(maxVoices, activeCount);
+	}
+
+	if (minVoices == maxVoices) {
+		return std::to_string(minVoices);
+	}
+	return std::to_string(minVoices) + "-" + std::to_string(maxVoices);
 }
 
 
@@ -897,6 +1615,17 @@ void Tool_1520ify::addBibliographicRecords(HumdrumFile& infile) {
 		}
 	}
 
+	if (!basename.empty()) {
+		size_t dot = basename.find_last_of('.');
+		if ((dot != std::string::npos) && (basename.substr(dot) == ".krn")) {
+			// already in the desired form
+		} else if (dot != std::string::npos) {
+			basename = basename.substr(0, dot) + ".krn";
+		} else {
+			basename += ".krn";
+		}
+	}
+
 	// Build the segment line
 	std::string segmentLine = "!!!!SEGMENT: " + basename;
 
@@ -1090,51 +1819,6 @@ void Tool_1520ify::addBibliographicRecords(HumdrumFile& infile) {
 	} else if (foundOPR) {
 	    infile.deleteLine(oprLine);
 	}
-
-	// --- Populate voices from number of **kern spines ---
-	{
-		// Count **kern spines
-		std::vector<HTp> kerns = infile.getKernSpineStartList();
-		int voiceCount = static_cast<int>(kerns.size());
-
-		if (voiceCount > 0) {
-			for (int li = 0; li < infile.getLineCount(); ++li) {
-				if (!infile[li].isReference()) {
-					continue;
-				}
-				HTp tok = infile.token(li, 0);
-				if (!tok) {
-					continue;
-				}
-
-				// Find the !!!voices: line
-				if (tok->compare(0, 10, "!!!voices:") != 0){
-					continue;
-				}
-
-				std::string cur = tok->getText();
-
-				// Check if there is already non-whitespace content after the colon
-				size_t colon = cur.find(':');
-				bool hasContent = false;
-				if (colon != std::string::npos) {
-					for (size_t p = colon + 1; p < cur.size(); ++p) {
-						if (!std::isspace(static_cast<unsigned char>(cur[p]))) {
-							hasContent = true;
-							break;
-						}
-					}
-				}
-
-				// Only auto-fill if it was effectively empty
-				if (!hasContent) {
-					tok->setText("!!!voices: " + std::to_string(voiceCount));
-				}
-				break; // done with voices
-			}
-		}
-	}
-
 
 	// --- Auto-fill AGN (genre + optional movement name) based on numeric id ---
 	
@@ -1402,6 +2086,8 @@ void Tool_1520ify::addBibliographicRecords(HumdrumFile& infile) {
 		infile.appendLine(line);
 	}
 
+	splitEncoderDate(infile);
+
 	// --- Remove !!!SMS: if it contains no content ---
 	{
 	    for (int li = 0; li < infile.getLineCount(); ++li) {
@@ -1438,6 +2124,8 @@ void Tool_1520ify::addBibliographicRecords(HumdrumFile& infile) {
 	        }
 	    }
 	}
+
+	addMuse2psRecord(infile);
 }
 
 


### PR DESCRIPTION
This updates the `1520ify` filter with the remaining cleanup needed for 1520s Project conversion output.

Main changes:

- handles mensuration labels from text and converts them into the appropriate `*met(...)` interpretations
- supports additional default mensuration-to-`*met(...)` mappings, including `*M6/2` and `*M9/2`
- incorporates `barnum -a`-style numbering for ordinary barlines, leaving final barlines unchanged
- improves terminal long handling, including internal section boundaries
- computes `!!!voices:` from active voices by section, allowing ranges such as `2-4` when sections differ
- normalizes `!!!!SEGMENT:` filenames to `.krn`
- splits encoder/date information from `!!!ENC:` into `!!!ENC:` and `!!!END:` where applicable
- adds `!!muse2ps:` spacing defaults when absent
- updates the generated `min/humlib.*` files to match the source/header changes