### PR TITLE
Fix STREAM_INTERFACE for older tools

### DIFF
--- a/include/HumTool.h
+++ b/include/HumTool.h
@@ -179,6 +179,22 @@ int main(int argc, char** argv) {                                          \
 	bool status = true;                                                     \
 	while (instream.readSingleSegment(infiles)) {                           \
 		status &= interface.run(infiles);                                    \
+		if (interface.hasWarning()) {                                       \
+			interface.getWarning(std::cerr);                                \
+		}                                                                   \
+		if (interface.hasAnyText()) {                                       \
+		   interface.getAllText(std::cout);                                 \
+		}                                                                   \
+		if (interface.hasError()) {                                         \
+			interface.getError(std::cerr);                                  \
+	        return -1;                                                      \
+		}                                                                   \
+		if (!interface.hasAnyText()) {                                      \
+			for (int i=0; i<infiles.getCount(); i++) {                      \
+				cout << infiles[i];                                         \
+			}                                                               \
+		}                                                                   \
+		interface.clearOutput();                                            \
 	}                                                                       \
 	interface.finally();                                                    \
 	if (interface.hasWarning()) {                                           \
@@ -190,11 +206,6 @@ int main(int argc, char** argv) {                                          \
 	if (interface.hasError()) {                                             \
 		interface.getError(std::cerr);                                       \
         return -1;                                                         \
-	}                                                                       \
-	if (!interface.hasAnyText()) {                                          \
-		for (int i=0; i<infiles.getCount(); i++) {                           \
-			cout << infiles[i];                                               \
-		}                                                                    \
 	}                                                                       \
 	interface.clearOutput();                                                \
 	return !status;                                                         \

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Sa. 11 Juli 2026 22:39:12 CEST
+// Last Modified: Fr. 17 Juli 2026 00:18:17 CEST
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Sa. 11 Juli 2026 22:39:12 CEST
+// Last Modified: Fr. 17 Juli 2026 00:18:17 CEST
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11
@@ -5732,6 +5732,22 @@ int main(int argc, char** argv) {                                          \
 	bool status = true;                                                     \
 	while (instream.readSingleSegment(infiles)) {                           \
 		status &= interface.run(infiles);                                    \
+		if (interface.hasWarning()) {                                       \
+			interface.getWarning(std::cerr);                                \
+		}                                                                   \
+		if (interface.hasAnyText()) {                                       \
+		   interface.getAllText(std::cout);                                 \
+		}                                                                   \
+		if (interface.hasError()) {                                         \
+			interface.getError(std::cerr);                                  \
+	        return -1;                                                      \
+		}                                                                   \
+		if (!interface.hasAnyText()) {                                      \
+			for (int i=0; i<infiles.getCount(); i++) {                      \
+				cout << infiles[i];                                         \
+			}                                                               \
+		}                                                                   \
+		interface.clearOutput();                                            \
 	}                                                                       \
 	interface.finally();                                                    \
 	if (interface.hasWarning()) {                                           \
@@ -5743,11 +5759,6 @@ int main(int argc, char** argv) {                                          \
 	if (interface.hasError()) {                                             \
 		interface.getError(std::cerr);                                       \
         return -1;                                                         \
-	}                                                                       \
-	if (!interface.hasAnyText()) {                                          \
-		for (int i=0; i<infiles.getCount(); i++) {                           \
-			cout << infiles[i];                                               \
-		}                                                                    \
 	}                                                                       \
 	interface.clearOutput();                                                \
 	return !status;                                                         \


### PR DESCRIPTION
Working on a new tool `metweight` (name tbd) that adds a spine with information about strong and weak beats, I wanted to see if I can use the existing `metlev` tool for my scenario. I discovered that older tools like `metlev` and `recip` currently do not have any output. So I tried to fix this with this PR. I'm not entirely sure about the impact of this change. Will this potentially break other tools?

We should check this for tools that use `interface.finally()` and tools that use `m_humdrum_text`.

Do you have any concerns about this change?