### PR TITLE
Improve mintx

### DIFF
--- a/include/tool-mint.h
+++ b/include/tool-mint.h
@@ -36,14 +36,13 @@ class Tool_mint : public HumTool {
 		bool run     (HumdrumFile& infile, std::ostream& out);
 
 	protected:
-		void        initialize             (void);
-		void        processFile            (HumdrumFile& infile);
-		void        analyzeLine            (HumdrumFile& infile, int line);
-		int         processKernSpines      (HumdrumFile& infile, int line, int start);
-		std::string getIntervalToken       (HTp token);
-		std::string getIntervalQuality     (int base40interval);
-		HTp         getPreviousAttackToken (HTp token);
-		int         getRepresentativeBase40Pitch(HTp token);
+		void                     initialize             (void);
+		void                     processFile            (HumdrumFile& infile);
+		std::vector<std::string> getTrackData           (HTp kernstart, int lineCount);
+		std::string              getIntervalToken       (HTp token);
+		std::string              getIntervalQuality     (int base40interval);
+		HTp                      getPreviousAttackToken (HTp token);
+		int                      getRepresentativeBase40Pitch(HTp token);
 
 	private:
 		bool m_absoluteQ = false; // -a option: hide direction of the interval

--- a/include/tool-mint.h
+++ b/include/tool-mint.h
@@ -52,8 +52,8 @@ class Tool_mint : public HumTool {
 		bool m_lowestQ   = false; // -l option: use lowest note of a chord instead of the highest
 		bool m_cdataQ    = false; // -x option: label the spine **cdata-mint instead of **mint
 
-		std::string       m_kernTracks  = ""; // used with -k option
-		std::string       m_spineTracks = ""; // used with -s option
+		std::string       m_kernTracks    = ""; // used with -k option
+		std::string       m_spines        = ""; // used with -s option
 		std::vector<bool> m_selectedKernSpines; // used with -k and -s option
 
 };

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Sa. 11 Juli 2026 22:39:12 CEST
+// Last Modified: Fr. 24 Juli 2026 09:49:05 CEST
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -111493,7 +111493,7 @@ Tool_mint::Tool_mint(void) {
 	define("l|lowest=b",       "use the lowest note of a chord instead of the highest note");
 	define("x|cdata=b",        "label the spine **cdata-mint instead of **mint");
 	define("k|kern-tracks=s",  "process only the specified kern spines");
-	define("s|spine-tracks|spine|spines|track|tracks=s", "process only the specified spines");
+	define("s|spine|spines=s", "process only the specified spines");
 }
 
 
@@ -111552,8 +111552,8 @@ void Tool_mint::initialize(void) {
 	m_lowestQ   = getBoolean("lowest");
 	m_cdataQ    = getBoolean("cdata");
 
-	if (getBoolean("spine-tracks")) {
-		m_spineTracks = getString("spine-tracks");
+	if (getBoolean("spines")) {
+		m_spines = getString("spines");
 	} else if (getBoolean("kern-tracks")) {
 		m_kernTracks = getString("kern-tracks");
 	}
@@ -111587,9 +111587,9 @@ void Tool_mint::processFile(HumdrumFile& infile) {
 			int track = kernspines.at(index)->getTrack();
 			m_selectedKernSpines.at(track) = true;
 		}
-	} else if (!m_spineTracks.empty()) {
+	} else if (!m_spines.empty()) {
 		fill(m_selectedKernSpines.begin(), m_selectedKernSpines.end(), false);
-		infile.makeBooleanTrackList(m_selectedKernSpines, m_spineTracks);
+		infile.makeBooleanTrackList(m_selectedKernSpines, m_spines);
 	}
 
 	for (int i = 0; i < infile.getLineCount(); i++) {

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Fr. 24 Juli 2026 09:49:05 CEST
+// Last Modified: Fr. 24 Juli 2026 09:50:23 CEST
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -111574,9 +111574,10 @@ void Tool_mint::processFile(HumdrumFile& infile) {
 	m_selectedKernSpines.resize(maxTrack + 1); // +1 since track=0 is not used
 	fill(m_selectedKernSpines.begin(), m_selectedKernSpines.end(), true);
 
+	vector<HTp> kernspines = infile.getKernSpineStartList();
+
 	// Calculate which input spines to process based on -k or -s option:
 	if (!m_kernTracks.empty()) {
-		vector<HTp> kernspines = infile.getKernSpineStartList();
 		vector<int> ktracks = Convert::extractIntegerList(m_kernTracks, maxTrack);
 		fill(m_selectedKernSpines.begin(), m_selectedKernSpines.end(), false);
 		for (int i = 0; i < (int)ktracks.size(); i++) {
@@ -111592,109 +111593,46 @@ void Tool_mint::processFile(HumdrumFile& infile) {
 		infile.makeBooleanTrackList(m_selectedKernSpines, m_spines);
 	}
 
-	for (int i = 0; i < infile.getLineCount(); i++) {
-		analyzeLine(infile, i);
+	string exinterp = m_cdataQ ? "**cdata-mint" : "**mint";
+	int lineCount = infile.getLineCount();
+
+	for (int i = 0; i < (int)kernspines.size(); i++) {
+		if (!m_selectedKernSpines.at(kernspines[i]->getTrack())) {
+			continue;
+		}
+		vector<string> trackData = getTrackData(kernspines[i], lineCount);
+		if (i + 1 < (int)kernspines.size()) {
+			int nextTrack = kernspines[i + 1]->getTrack();
+			infile.insertDataSpineBefore(nextTrack, trackData, ".", exinterp);
+		} else {
+			infile.appendDataSpine(trackData, ".", exinterp);
+		}
 	}
+
+	// Enables usage in verovio (`!!!filter: mint`)
+	m_humdrum_text << infile;
 }
 
 
 
 //////////////////////////////
 //
-// Tool_mint::analyzeLine -- Append a **mint spine after every processed
-//    **kern spine on the current line.
+// Tool_mint::getTrackData -- Calculate the **mint spine data for a single
+//    **kern spine, one entry per line of the file (empty for non-data
+//    lines, which are filled in automatically by appendDataSpine/
+//    insertDataSpineBefore).
 //
 
-void Tool_mint::analyzeLine(HumdrumFile& infile, int line) {
-	if (!infile[line].hasSpines()) {
-		m_humdrum_text << infile[line] << "\n";
-		return;
+vector<string> Tool_mint::getTrackData(HTp kernstart, int lineCount) {
+	vector<string> trackData(lineCount);
+	HTp current = kernstart;
+	while (current) {
+		if (current->isData()) {
+			trackData[current->getLineIndex()] = getIntervalToken(current);
+		}
+		current = current->getNextToken();
 	}
-	for (int i = 0; i < infile[line].getFieldCount(); i++) {
-		HTp token = infile.token(line, i);
-		if (!token->isKern() || !m_selectedKernSpines.at(token->getTrack())) {
-			m_humdrum_text << token;
-			if (i < infile[line].getFieldCount() - 1) {
-				m_humdrum_text << '\t';
-			}
-			continue;
-		}
-		i = processKernSpines(infile, line, i);
-		if (i < infile[line].getFieldCount() - 1) {
-			m_humdrum_text << '\t';
-		}
-	}
-	m_humdrum_text << '\n';
-}
-
-
-
-//////////////////////////////
-//
-// Tool_mint::processKernSpines -- Print the tokens of a **kern spine
-//    (including any of its subspines) followed by the matching **mint
-//    analysis tokens.  Returns the field index of the last token that
-//    was processed on the line.
-//
-
-int Tool_mint::processKernSpines(HumdrumFile& infile, int line, int start) {
-	HTp token = infile.token(line, start);
-	int track = token->getTrack();
-	vector<HTp> toks;
-	toks.push_back(token);
-	for (int i = start + 1; i < infile[line].getFieldCount(); i++) {
-		HTp newtok = infile.token(line, i);
-		if (newtok->getTrack() == track) {
-			toks.push_back(newtok);
-			continue;
-		}
-		break;
-	}
-
-	int toksize = (int)toks.size();
-
-	// print the **kern fields
-	for (int i = 0; i < toksize; i++) {
-		m_humdrum_text << toks[i];
-		m_humdrum_text << '\t';
-	}
-
-	// print the parallel **mint analysis fields
-	if (infile[line].isData()) {
-		for (int i = 0; i < toksize; i++) {
-			m_humdrum_text << getIntervalToken(toks[i]);
-			if (i < toksize - 1) {
-				m_humdrum_text << '\t';
-			}
-		}
-	} else if (infile[line].isLocalComment()) {
-		for (int i = 0; i < toksize; i++) {
-			m_humdrum_text << "!";
-			if (i < toksize - 1) {
-				m_humdrum_text << '\t';
-			}
-		}
-	} else if (infile[line].isInterpretation()) {
-		for (int i = 0; i < toksize; i++) {
-			if (toks[i]->compare(0, 2, "**") == 0) {
-				m_humdrum_text << (m_cdataQ ? "**cdata-mint" : "**mint");
-			} else {
-				m_humdrum_text << toks[i];
-			}
-			if (i < toksize - 1) {
-				m_humdrum_text << '\t';
-			}
-		}
-	} else if (infile[line].isBarline()) {
-		for (int i = 0; i < toksize; i++) {
-			m_humdrum_text << toks[0];
-			if (i < toksize - 1) {
-				m_humdrum_text << '\t';
-			}
-		}
-	}
-
-	return start + toksize - 1;
+	return trackData;
 }
 
 

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Fr. 24 Juli 2026 09:50:23 CEST
+// Last Modified: Fr. 24 Juli 2026 10:01:03 CEST
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -111596,18 +111596,18 @@ void Tool_mint::processFile(HumdrumFile& infile) {
 	string exinterp = m_cdataQ ? "**cdata-mint" : "**mint";
 	int lineCount = infile.getLineCount();
 
-	for (int i = 0; i < (int)kernspines.size(); i++) {
-		if (!m_selectedKernSpines.at(kernspines[i]->getTrack())) {
+	// Insert each voice's spine right after its own track, processing from
+	// last to first so that earlier (not-yet-processed) voices' track
+	// numbers are not shifted by a later insertion.
+	for (int i = (int)kernspines.size() - 1; i >= 0; i--) {
+		int track = kernspines[i]->getTrack();
+		if (!m_selectedKernSpines.at(track)) {
 			continue;
 		}
 		vector<string> trackData = getTrackData(kernspines[i], lineCount);
-		if (i + 1 < (int)kernspines.size()) {
-			int nextTrack = kernspines[i + 1]->getTrack();
-			infile.insertDataSpineBefore(nextTrack, trackData, ".", exinterp);
-		} else {
-			infile.appendDataSpine(trackData, ".", exinterp);
-		}
+		infile.insertDataSpineAfter(track, trackData, ".", exinterp);
 	}
+	infile.createLinesFromTokens();
 
 	// Enables usage in verovio (`!!!filter: mint`)
 	m_humdrum_text << infile;

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Sa. 11 Juli 2026 22:39:12 CEST
+// Last Modified: Fr. 24 Juli 2026 09:49:05 CEST
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11
@@ -9752,8 +9752,8 @@ class Tool_mint : public HumTool {
 		bool m_lowestQ   = false; // -l option: use lowest note of a chord instead of the highest
 		bool m_cdataQ    = false; // -x option: label the spine **cdata-mint instead of **mint
 
-		std::string       m_kernTracks  = ""; // used with -k option
-		std::string       m_spineTracks = ""; // used with -s option
+		std::string       m_kernTracks    = ""; // used with -k option
+		std::string       m_spines        = ""; // used with -s option
 		std::vector<bool> m_selectedKernSpines; // used with -k and -s option
 
 };

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Fr. 24 Juli 2026 09:49:05 CEST
+// Last Modified: Fr. 24 Juli 2026 09:50:23 CEST
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11
@@ -9736,14 +9736,13 @@ class Tool_mint : public HumTool {
 		bool run     (HumdrumFile& infile, std::ostream& out);
 
 	protected:
-		void        initialize             (void);
-		void        processFile            (HumdrumFile& infile);
-		void        analyzeLine            (HumdrumFile& infile, int line);
-		int         processKernSpines      (HumdrumFile& infile, int line, int start);
-		std::string getIntervalToken       (HTp token);
-		std::string getIntervalQuality     (int base40interval);
-		HTp         getPreviousAttackToken (HTp token);
-		int         getRepresentativeBase40Pitch(HTp token);
+		void                     initialize             (void);
+		void                     processFile            (HumdrumFile& infile);
+		std::vector<std::string> getTrackData           (HTp kernstart, int lineCount);
+		std::string              getIntervalToken       (HTp token);
+		std::string              getIntervalQuality     (int base40interval);
+		HTp                      getPreviousAttackToken (HTp token);
+		int                      getRepresentativeBase40Pitch(HTp token);
 
 	private:
 		bool m_absoluteQ = false; // -a option: hide direction of the interval

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Fr. 24 Juli 2026 09:50:23 CEST
+// Last Modified: Fr. 24 Juli 2026 10:01:03 CEST
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11

--- a/src/tool-mint.cpp
+++ b/src/tool-mint.cpp
@@ -137,18 +137,18 @@ void Tool_mint::processFile(HumdrumFile& infile) {
 	string exinterp = m_cdataQ ? "**cdata-mint" : "**mint";
 	int lineCount = infile.getLineCount();
 
-	for (int i = 0; i < (int)kernspines.size(); i++) {
-		if (!m_selectedKernSpines.at(kernspines[i]->getTrack())) {
+	// Insert each voice's spine right after its own track, processing from
+	// last to first so that earlier (not-yet-processed) voices' track
+	// numbers are not shifted by a later insertion.
+	for (int i = (int)kernspines.size() - 1; i >= 0; i--) {
+		int track = kernspines[i]->getTrack();
+		if (!m_selectedKernSpines.at(track)) {
 			continue;
 		}
 		vector<string> trackData = getTrackData(kernspines[i], lineCount);
-		if (i + 1 < (int)kernspines.size()) {
-			int nextTrack = kernspines[i + 1]->getTrack();
-			infile.insertDataSpineBefore(nextTrack, trackData, ".", exinterp);
-		} else {
-			infile.appendDataSpine(trackData, ".", exinterp);
-		}
+		infile.insertDataSpineAfter(track, trackData, ".", exinterp);
 	}
+	infile.createLinesFromTokens();
 
 	// Enables usage in verovio (`!!!filter: mint`)
 	m_humdrum_text << infile;

--- a/src/tool-mint.cpp
+++ b/src/tool-mint.cpp
@@ -34,7 +34,7 @@ Tool_mint::Tool_mint(void) {
 	define("l|lowest=b",       "use the lowest note of a chord instead of the highest note");
 	define("x|cdata=b",        "label the spine **cdata-mint instead of **mint");
 	define("k|kern-tracks=s",  "process only the specified kern spines");
-	define("s|spine-tracks|spine|spines|track|tracks=s", "process only the specified spines");
+	define("s|spine|spines=s", "process only the specified spines");
 }
 
 
@@ -93,8 +93,8 @@ void Tool_mint::initialize(void) {
 	m_lowestQ   = getBoolean("lowest");
 	m_cdataQ    = getBoolean("cdata");
 
-	if (getBoolean("spine-tracks")) {
-		m_spineTracks = getString("spine-tracks");
+	if (getBoolean("spines")) {
+		m_spines = getString("spines");
 	} else if (getBoolean("kern-tracks")) {
 		m_kernTracks = getString("kern-tracks");
 	}
@@ -128,9 +128,9 @@ void Tool_mint::processFile(HumdrumFile& infile) {
 			int track = kernspines.at(index)->getTrack();
 			m_selectedKernSpines.at(track) = true;
 		}
-	} else if (!m_spineTracks.empty()) {
+	} else if (!m_spines.empty()) {
 		fill(m_selectedKernSpines.begin(), m_selectedKernSpines.end(), false);
-		infile.makeBooleanTrackList(m_selectedKernSpines, m_spineTracks);
+		infile.makeBooleanTrackList(m_selectedKernSpines, m_spines);
 	}
 
 	for (int i = 0; i < infile.getLineCount(); i++) {

--- a/src/tool-mint.cpp
+++ b/src/tool-mint.cpp
@@ -115,9 +115,10 @@ void Tool_mint::processFile(HumdrumFile& infile) {
 	m_selectedKernSpines.resize(maxTrack + 1); // +1 since track=0 is not used
 	fill(m_selectedKernSpines.begin(), m_selectedKernSpines.end(), true);
 
+	vector<HTp> kernspines = infile.getKernSpineStartList();
+
 	// Calculate which input spines to process based on -k or -s option:
 	if (!m_kernTracks.empty()) {
-		vector<HTp> kernspines = infile.getKernSpineStartList();
 		vector<int> ktracks = Convert::extractIntegerList(m_kernTracks, maxTrack);
 		fill(m_selectedKernSpines.begin(), m_selectedKernSpines.end(), false);
 		for (int i = 0; i < (int)ktracks.size(); i++) {
@@ -133,109 +134,46 @@ void Tool_mint::processFile(HumdrumFile& infile) {
 		infile.makeBooleanTrackList(m_selectedKernSpines, m_spines);
 	}
 
-	for (int i = 0; i < infile.getLineCount(); i++) {
-		analyzeLine(infile, i);
+	string exinterp = m_cdataQ ? "**cdata-mint" : "**mint";
+	int lineCount = infile.getLineCount();
+
+	for (int i = 0; i < (int)kernspines.size(); i++) {
+		if (!m_selectedKernSpines.at(kernspines[i]->getTrack())) {
+			continue;
+		}
+		vector<string> trackData = getTrackData(kernspines[i], lineCount);
+		if (i + 1 < (int)kernspines.size()) {
+			int nextTrack = kernspines[i + 1]->getTrack();
+			infile.insertDataSpineBefore(nextTrack, trackData, ".", exinterp);
+		} else {
+			infile.appendDataSpine(trackData, ".", exinterp);
+		}
 	}
+
+	// Enables usage in verovio (`!!!filter: mint`)
+	m_humdrum_text << infile;
 }
 
 
 
 //////////////////////////////
 //
-// Tool_mint::analyzeLine -- Append a **mint spine after every processed
-//    **kern spine on the current line.
+// Tool_mint::getTrackData -- Calculate the **mint spine data for a single
+//    **kern spine, one entry per line of the file (empty for non-data
+//    lines, which are filled in automatically by appendDataSpine/
+//    insertDataSpineBefore).
 //
 
-void Tool_mint::analyzeLine(HumdrumFile& infile, int line) {
-	if (!infile[line].hasSpines()) {
-		m_humdrum_text << infile[line] << "\n";
-		return;
+vector<string> Tool_mint::getTrackData(HTp kernstart, int lineCount) {
+	vector<string> trackData(lineCount);
+	HTp current = kernstart;
+	while (current) {
+		if (current->isData()) {
+			trackData[current->getLineIndex()] = getIntervalToken(current);
+		}
+		current = current->getNextToken();
 	}
-	for (int i = 0; i < infile[line].getFieldCount(); i++) {
-		HTp token = infile.token(line, i);
-		if (!token->isKern() || !m_selectedKernSpines.at(token->getTrack())) {
-			m_humdrum_text << token;
-			if (i < infile[line].getFieldCount() - 1) {
-				m_humdrum_text << '\t';
-			}
-			continue;
-		}
-		i = processKernSpines(infile, line, i);
-		if (i < infile[line].getFieldCount() - 1) {
-			m_humdrum_text << '\t';
-		}
-	}
-	m_humdrum_text << '\n';
-}
-
-
-
-//////////////////////////////
-//
-// Tool_mint::processKernSpines -- Print the tokens of a **kern spine
-//    (including any of its subspines) followed by the matching **mint
-//    analysis tokens.  Returns the field index of the last token that
-//    was processed on the line.
-//
-
-int Tool_mint::processKernSpines(HumdrumFile& infile, int line, int start) {
-	HTp token = infile.token(line, start);
-	int track = token->getTrack();
-	vector<HTp> toks;
-	toks.push_back(token);
-	for (int i = start + 1; i < infile[line].getFieldCount(); i++) {
-		HTp newtok = infile.token(line, i);
-		if (newtok->getTrack() == track) {
-			toks.push_back(newtok);
-			continue;
-		}
-		break;
-	}
-
-	int toksize = (int)toks.size();
-
-	// print the **kern fields
-	for (int i = 0; i < toksize; i++) {
-		m_humdrum_text << toks[i];
-		m_humdrum_text << '\t';
-	}
-
-	// print the parallel **mint analysis fields
-	if (infile[line].isData()) {
-		for (int i = 0; i < toksize; i++) {
-			m_humdrum_text << getIntervalToken(toks[i]);
-			if (i < toksize - 1) {
-				m_humdrum_text << '\t';
-			}
-		}
-	} else if (infile[line].isLocalComment()) {
-		for (int i = 0; i < toksize; i++) {
-			m_humdrum_text << "!";
-			if (i < toksize - 1) {
-				m_humdrum_text << '\t';
-			}
-		}
-	} else if (infile[line].isInterpretation()) {
-		for (int i = 0; i < toksize; i++) {
-			if (toks[i]->compare(0, 2, "**") == 0) {
-				m_humdrum_text << (m_cdataQ ? "**cdata-mint" : "**mint");
-			} else {
-				m_humdrum_text << toks[i];
-			}
-			if (i < toksize - 1) {
-				m_humdrum_text << '\t';
-			}
-		}
-	} else if (infile[line].isBarline()) {
-		for (int i = 0; i < toksize; i++) {
-			m_humdrum_text << toks[0];
-			if (i < toksize - 1) {
-				m_humdrum_text << '\t';
-			}
-		}
-	}
-
-	return start + toksize - 1;
+	return trackData;
 }
 
 


### PR DESCRIPTION
As requested in https://github.com/craigsapp/humlib/pull/116 I removed `spine-tracks`, `track`, and `tracks` from the `mint` option definition. Additionally, I improved the spine generation using `insertDataSpineBefore`. Tandem interpretations are now replaced with null tokens `*` instead of being kept, but I think this is fine in this case.