### PR TITLE
Add metweight tool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,7 @@ set(SRCS
 	src/tool-imitation.cpp
 	src/tool-mei2hum.cpp
 	src/tool-metlev.cpp
+	src/tool-metweight.cpp
 	src/tool-mint.cpp
 	src/tool-msearch.cpp
 	src/tool-musicxml2hum.cpp
@@ -158,6 +159,7 @@ set(HDRS
 	include/tool-imitation.h
 	include/tool-mei2hum.h
 	include/tool-metlev.h
+	include/tool-metweight.h
 	include/tool-mint.h
 	include/tool-msearch.h
 	include/tool-musicxml2hum.h

--- a/cli/metweight.cpp
+++ b/cli/metweight.cpp
@@ -1,0 +1,15 @@
+//
+// Programmer:    Wolfgang Drescher <drescher.wolfgang@gmail.com>
+// Creation Date: Thu Jul 16 2026
+// Filename:      cli/metweight.cpp
+// URL:           https://github.com/craigsapp/humlib/blob/master/cli/metweight.cpp
+// Syntax:        C++11
+// vim:           ts=3 noexpandtab nowrap
+//
+// Description:   Label the metric weight (strong/half-strong/weak) of notes
+//                and rests in **kern spines.
+//
+
+#include "humlib.h"
+
+STREAM_INTERFACE(Tool_metweight)

--- a/include/tool-metweight.h
+++ b/include/tool-metweight.h
@@ -49,10 +49,10 @@ class Tool_metweight : public HumTool {
 
 		// Metric weight classes (in order from strongest to weakest):
 		enum {
-			WEIGHT_STRONG       = 0,
-			WEIGHT_HALF_STRONG  = 1,
-			WEIGHT_WEAK         = 2,
-			WEIGHT_UNCLASSIFIED = -1
+			WEIGHT_STRONG       = 1,
+			WEIGHT_HALF_STRONG  = 2,
+			WEIGHT_WEAK         = 3,
+			WEIGHT_UNCLASSIFIED = 4
 		};
 
 	private:

--- a/include/tool-metweight.h
+++ b/include/tool-metweight.h
@@ -1,0 +1,73 @@
+//
+// Programmer:    Wolfgang Drescher <drescher.wolfgang@gmail.com>
+// Creation Date: Thu Jul 16 2026
+// Filename:      tool-metweight.h
+// URL:           https://github.com/craigsapp/humlib/blob/master/include/tool-metweight.h
+// Syntax:        C++11; humlib
+// vim:           syntax=cpp ts=3 noexpandtab nowrap
+//
+// Description:   Interface for metweight tool, which labels the metric
+//                weight (strong/half-strong/weak) of note and rest attacks
+//                in **kern spines; see tool-metweight.cpp for details.
+//
+
+#ifndef _TOOL_METWEIGHT_H_INCLUDED
+#define _TOOL_METWEIGHT_H_INCLUDED
+
+#include "HumTool.h"
+#include "HumdrumFile.h"
+#include "HumNum.h"
+
+#include <ostream>
+#include <string>
+#include <vector>
+
+namespace hum {
+
+// START_MERGE
+
+class Tool_metweight : public HumTool {
+
+	public:
+		     Tool_metweight  (void);
+		     ~Tool_metweight () {};
+
+		bool run     (HumdrumFileSet& infiles);
+		bool run     (HumdrumFile& infile);
+		bool run     (const std::string& indata, std::ostream& out);
+		bool run     (HumdrumFile& infile, std::ostream& out);
+
+	protected:
+		void        initialize       (void);
+		void        processFile      (HumdrumFile& infile);
+		void        fillVoiceResults (std::vector<std::vector<std::string>>& results,
+		                             HumdrumFile& infile,
+		                             const std::vector<HTp>& voices);
+		std::string getWeightToken   (HumdrumFile& infile, int line, int track);
+		std::string formatWeightClass(int weightClass);
+		int         getWeightClass   (int top, int bot, HumNum beat);
+
+		// Metric weight classes (in order from strongest to weakest):
+		enum {
+			WEIGHT_STRONG      = 0,
+			WEIGHT_HALF_STRONG = 1,
+			WEIGHT_WEAK        = 2,
+			WEIGHT_NONE        = -1
+		};
+
+	private:
+		bool m_fullQ    = false; // -f option: print full text labels instead of abbreviations
+		bool m_integerQ = false; // -i option: print integer rank labels instead of abbreviations
+		bool m_cdataQ   = false; // -x option: label the spine **cdata-metweight instead of **metweight
+
+		std::string       m_kernTracks  = ""; // used with -k option
+		std::string       m_spineTracks = ""; // used with -s option
+		std::vector<bool> m_selectedKernSpines; // used with -k and -s option
+
+};
+
+// END_MERGE
+
+} // end namespace hum
+
+#endif /* _TOOL_METWEIGHT_H_INCLUDED */

--- a/include/tool-metweight.h
+++ b/include/tool-metweight.h
@@ -59,6 +59,7 @@ class Tool_metweight : public HumTool {
 		bool m_fullQ    = false; // -f option: print full text labels instead of abbreviations
 		bool m_integerQ = false; // -i option: print integer rank labels instead of abbreviations
 		bool m_cdataQ   = false; // -x option: label the spine **cdata-metweight instead of **metweight
+		bool m_nullQ    = false; // -n option: always use the null token . for unclassified positions
 
 		std::string       m_kernTracks  = ""; // used with -k option
 		std::string       m_spineTracks = ""; // used with -s option

--- a/include/tool-metweight.h
+++ b/include/tool-metweight.h
@@ -49,10 +49,10 @@ class Tool_metweight : public HumTool {
 
 		// Metric weight classes (in order from strongest to weakest):
 		enum {
-			WEIGHT_STRONG      = 0,
-			WEIGHT_HALF_STRONG = 1,
-			WEIGHT_WEAK        = 2,
-			WEIGHT_NONE        = -1
+			WEIGHT_STRONG       = 0,
+			WEIGHT_HALF_STRONG  = 1,
+			WEIGHT_WEAK         = 2,
+			WEIGHT_UNCLASSIFIED = -1
 		};
 
 	private:

--- a/include/tool-metweight.h
+++ b/include/tool-metweight.h
@@ -42,12 +42,15 @@ class Tool_metweight : public HumTool {
 		void        processFile      (HumdrumFile& infile);
 		void        addCompositeSpine(HumdrumFile& infile);
 		void        getVoices        (std::vector<HTp>& voices, HumdrumFile& infile);
-		void        fillVoiceResults (std::vector<std::vector<std::string>>& results,
+		void        fillVoiceResults (std::vector<std::vector<int>>& results,
 		                             HumdrumFile& infile,
 		                             const std::vector<HTp>& voices);
-		std::string getWeightToken   (HumdrumFile& infile, int line, int track);
+		void        formatWeights    (std::vector<std::string>& tokens,
+		                             const std::vector<int>& weightClasses,
+		                             int format);
+		int         getTokenWeightClass(HumdrumFile& infile, int line, int track);
 		HTp         getMeterToken    (HumdrumFile& infile, int line);
-		std::string formatWeightClass(int weightClass);
+		std::string formatWeightClass(int weightClass, int format);
 		int         getWeightClass   (int top, int bot, HumNum beat);
 
 		// Metric weight classes (in order from strongest to weakest):
@@ -58,13 +61,22 @@ class Tool_metweight : public HumTool {
 			WEIGHT_UNCLASSIFIED = 4
 		};
 
+		// Token representations of a weight class (see formatWeightClass):
+		enum {
+			FORMAT_ABBREVIATION, // abbreviations: s/hs/w/u (default)
+			FORMAT_FULL,         // -f option: strong/half-strong/weak/unclassified
+			FORMAT_INTEGER,      // -i option: the weight class values 1/2/3/4
+			FORMAT_COLOR         // -c option: a color for each weight class
+		};
+
 	private:
 		bool m_fullQ      = false; // -f option: print full text labels instead of abbreviations
 		bool m_integerQ   = false; // -i option: print integer rank labels instead of abbreviations
 		bool m_cdataQ     = false; // -x option: label the spine **cdata-metweight instead of **metweight
 		bool m_nullQ      = false; // -n option: always use the null token . for unclassified positions
 		bool m_tiedQ      = false; // -t option: label secondary tied notes instead of giving them the null token .
-		bool m_compositeQ = false; // -c option: add a **kern-comp spine below the voices and label only that spine
+		bool m_compositeQ = false; // -C option: add a **kern-comp spine below the voices and label only that spine
+		bool m_colorQ     = false; // -c option: add a **color spine after each **metweight spine
 
 		std::string       m_kernTracks  = ""; // used with -k option
 		std::string       m_spineTracks = ""; // used with -s option

--- a/include/tool-metweight.h
+++ b/include/tool-metweight.h
@@ -60,6 +60,7 @@ class Tool_metweight : public HumTool {
 		bool m_integerQ = false; // -i option: print integer rank labels instead of abbreviations
 		bool m_cdataQ   = false; // -x option: label the spine **cdata-metweight instead of **metweight
 		bool m_nullQ    = false; // -n option: always use the null token . for unclassified positions
+		bool m_tiedQ    = false; // -t option: label secondary tied notes instead of giving them the null token .
 
 		std::string       m_kernTracks  = ""; // used with -k option
 		std::string       m_spineTracks = ""; // used with -s option

--- a/include/tool-metweight.h
+++ b/include/tool-metweight.h
@@ -40,10 +40,13 @@ class Tool_metweight : public HumTool {
 	protected:
 		void        initialize       (void);
 		void        processFile      (HumdrumFile& infile);
+		void        addCompositeSpine(HumdrumFile& infile);
+		void        getVoices        (std::vector<HTp>& voices, HumdrumFile& infile);
 		void        fillVoiceResults (std::vector<std::vector<std::string>>& results,
 		                             HumdrumFile& infile,
 		                             const std::vector<HTp>& voices);
 		std::string getWeightToken   (HumdrumFile& infile, int line, int track);
+		HTp         getMeterToken    (HumdrumFile& infile, int line);
 		std::string formatWeightClass(int weightClass);
 		int         getWeightClass   (int top, int bot, HumNum beat);
 
@@ -56,11 +59,12 @@ class Tool_metweight : public HumTool {
 		};
 
 	private:
-		bool m_fullQ    = false; // -f option: print full text labels instead of abbreviations
-		bool m_integerQ = false; // -i option: print integer rank labels instead of abbreviations
-		bool m_cdataQ   = false; // -x option: label the spine **cdata-metweight instead of **metweight
-		bool m_nullQ    = false; // -n option: always use the null token . for unclassified positions
-		bool m_tiedQ    = false; // -t option: label secondary tied notes instead of giving them the null token .
+		bool m_fullQ      = false; // -f option: print full text labels instead of abbreviations
+		bool m_integerQ   = false; // -i option: print integer rank labels instead of abbreviations
+		bool m_cdataQ     = false; // -x option: label the spine **cdata-metweight instead of **metweight
+		bool m_nullQ      = false; // -n option: always use the null token . for unclassified positions
+		bool m_tiedQ      = false; // -t option: label secondary tied notes instead of giving them the null token .
+		bool m_compositeQ = false; // -c option: add a **kern-comp spine below the voices and label only that spine
 
 		std::string       m_kernTracks  = ""; // used with -k option
 		std::string       m_spineTracks = ""; // used with -s option

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Fr. 24 Juli 2026 09:36:39 CEST
+// Last Modified: Fr. 24 Juli 2026 10:20:37 CEST
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -111528,8 +111528,8 @@ void Tool_metlev::fillVoiceResults(vector<vector<double> >& results,
 //
 
 Tool_metweight::Tool_metweight(void) {
-	define("f|full=b",         "print full text labels (strong/half-strong/weak) instead of abbreviations");
-	define("i|integer=b",      "print integer rank labels (1/2/3) instead of abbreviations");
+	define("f|full=b",         "print full text labels (strong/half-strong/weak/unclassified) instead of abbreviations");
+	define("i|integer=b",      "print integer rank labels (1/2/3/4) instead of abbreviations");
 	define("x|cdata=b",        "label the spine **cdata-metweight instead of **metweight");
 	define("k|kern-tracks=s",  "process only the specified kern spines");
 	define("s|spine|spines=s", "process only the specified spines");

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Fr. 24 Juli 2026 08:33:05 CEST
+// Last Modified: Fr. 24 Juli 2026 08:36:40 CEST
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -111533,6 +111533,7 @@ Tool_metweight::Tool_metweight(void) {
 	define("x|cdata=b",        "label the spine **cdata-metweight instead of **metweight");
 	define("k|kern-tracks=s",  "process only the specified kern spines");
 	define("s|spine|spines=s", "process only the specified spines");
+	define("n|null=b",         "always use the null token . for unclassified positions");
 }
 
 
@@ -111588,6 +111589,7 @@ void Tool_metweight::initialize(void) {
 	m_fullQ    = getBoolean("full");
 	m_integerQ = getBoolean("integer");
 	m_cdataQ   = getBoolean("cdata");
+	m_nullQ    = getBoolean("null");
 
 	if (getBoolean("spine")) {
 		m_spineTracks = getString("spine");
@@ -111789,10 +111791,14 @@ int Tool_metweight::getWeightClass(int top, int bot, HumNum beat) {
 //
 // Tool_metweight::formatWeightClass -- Convert a weight class into the
 //    token representation selected by the -f/-i options (abbreviated
-//    strong/half-strong/weak codes by default).
+//    strong/half-strong/weak codes by default); -n forces the null
+//    token "." for unclassified positions in all three modes.
 //
 
 string Tool_metweight::formatWeightClass(int weightClass) {
+	if (m_nullQ && (weightClass == WEIGHT_NONE)) {
+		return ".";
+	}
 	if (m_integerQ) {
 		switch (weightClass) {
 			case WEIGHT_STRONG:      return "1";

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mon Jul 20 10:35:12 CEST 2026
+// Last Modified: Fr. 24 Juli 2026 08:32:33 CEST
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -95359,6 +95359,8 @@ bool Tool_filter::run(HumdrumFileSet& infiles) {
 			RUNTOOL(meter, infile, commands[i].second, status);
 		} else if (commands[i].first == "metlev") {
 			RUNTOOL(metlev, infile, commands[i].second, status);
+		} else if (commands[i].first == "metweight") {
+			RUNTOOL(metweight, infile, commands[i].second, status);
 		} else if (commands[i].first == "mint") { // humlib version of Humdrum Toolkit mint tool
 			RUNTOOL(mint, infile, commands[i].second, status);
 		} else if (commands[i].first == "mintx") { // humlib cli name
@@ -111513,6 +111515,304 @@ void Tool_metlev::fillVoiceResults(vector<vector<double> >& results,
 				}
 				nonnullcount[v] = 0;
 			}
+		}
+	}
+}
+
+
+
+
+//////////////////////////////
+//
+// Tool_metweight::Tool_metweight -- Set the recognized options for the tool.
+//
+
+Tool_metweight::Tool_metweight(void) {
+	define("f|full=b",         "print full text labels (strong/half-strong/weak) instead of abbreviations");
+	define("i|integer=b",      "print integer rank labels (1/2/3) instead of abbreviations");
+	define("x|cdata=b",        "label the spine **cdata-metweight instead of **metweight");
+	define("k|kern-tracks=s",  "process only the specified kern spines");
+	define("s|spine|spines=s", "process only the specified spines");
+}
+
+
+
+//////////////////////////////
+//
+// Tool_metweight::run -- Do the main work of the tool.
+//
+
+bool Tool_metweight::run(HumdrumFileSet& infiles) {
+	bool status = true;
+	for (int i = 0; i < infiles.getCount(); i++) {
+		status &= run(infiles[i]);
+	}
+	return status;
+}
+
+bool Tool_metweight::run(const string& indata, ostream& out) {
+	HumdrumFile infile(indata);
+	bool status = run(infile);
+	if (hasAnyText()) {
+		getAllText(out);
+	} else {
+		out << infile;
+	}
+	return status;
+}
+
+bool Tool_metweight::run(HumdrumFile& infile, ostream& out) {
+	bool status = run(infile);
+	if (hasAnyText()) {
+		getAllText(out);
+	} else {
+		out << infile;
+	}
+	return status;
+}
+
+bool Tool_metweight::run(HumdrumFile& infile) {
+	initialize();
+	processFile(infile);
+	return true;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_metweight::initialize --
+//
+
+void Tool_metweight::initialize(void) {
+	m_fullQ    = getBoolean("full");
+	m_integerQ = getBoolean("integer");
+	m_cdataQ   = getBoolean("cdata");
+
+	if (getBoolean("spine")) {
+		m_spineTracks = getString("spine");
+	} else if (getBoolean("kern-tracks")) {
+		m_kernTracks = getString("kern-tracks");
+	}
+}
+
+
+
+//////////////////////////////
+//
+// Tool_metweight::processFile -- Insert a **metweight spine after every
+//    processed **kern spine, containing the metric weight of the current
+//    note/rest attack.
+//
+
+void Tool_metweight::processFile(HumdrumFile& infile) {
+	int maxTrack = infile.getMaxTrack();
+
+	m_selectedKernSpines.resize(maxTrack + 1); // +1 since track=0 is not used
+	fill(m_selectedKernSpines.begin(), m_selectedKernSpines.end(), true);
+
+	vector<HTp> kernspines = infile.getKernSpineStartList();
+
+	// Calculate which input spines to process based on -k or -s option:
+	if (!m_kernTracks.empty()) {
+		vector<int> ktracks = Convert::extractIntegerList(m_kernTracks, maxTrack);
+		fill(m_selectedKernSpines.begin(), m_selectedKernSpines.end(), false);
+		for (int i = 0; i < (int)ktracks.size(); i++) {
+			int index = ktracks[i] - 1;
+			if ((index < 0) || (index >= (int)kernspines.size())) {
+				continue;
+			}
+			int track = kernspines.at(index)->getTrack();
+			m_selectedKernSpines.at(track) = true;
+		}
+	} else if (!m_spineTracks.empty()) {
+		fill(m_selectedKernSpines.begin(), m_selectedKernSpines.end(), false);
+		infile.makeBooleanTrackList(m_selectedKernSpines, m_spineTracks);
+	}
+
+	vector<HTp> voices;
+	for (int i = 0; i < (int)kernspines.size(); i++) {
+		if (m_selectedKernSpines.at(kernspines[i]->getTrack())) {
+			voices.push_back(kernspines[i]);
+		}
+	}
+	if (voices.empty()) {
+		return;
+	}
+
+	// Delegate time-signature/beat-position analysis (including pickup
+	// measures) to the meter tool, which annotates each **kern attack
+	// with "auto" parameters read back out below; "-r" also covers rests.
+	Tool_meter meterTool;
+	meterTool.process("-r");
+	meterTool.run(infile);
+
+	vector<vector<string>> results;
+	fillVoiceResults(results, infile, voices);
+
+	string exinterp = m_cdataQ ? "**cdata-metweight" : "**metweight";
+	infile.appendDataSpine(results.back(), ".", exinterp);
+	for (int i = (int)voices.size() - 1; i > 0; i--) {
+		int track = voices[i]->getTrack();
+		infile.insertDataSpineBefore(track, results[i - 1], ".", exinterp);
+	}
+	infile.createLinesFromTokens();
+
+	// Enable usage in verovio (`!!!filter: metweight`)
+	m_humdrum_text << infile;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_metweight::fillVoiceResults -- Calculate the **metweight tokens for
+//    each selected **kern spine, one value per line, for
+//    appendDataSpine()/insertDataSpineBefore() to consume.
+//
+
+void Tool_metweight::fillVoiceResults(vector<vector<string>>& results, HumdrumFile& infile,
+		const vector<HTp>& voices) {
+
+	int lineCount = infile.getLineCount();
+	results.clear();
+	results.resize(voices.size());
+	for (int v = 0; v < (int)voices.size(); v++) {
+		results[v].resize(lineCount, ".");
+	}
+
+	for (int i = 0; i < lineCount; i++) {
+		if (!infile[i].isData()) {
+			continue;
+		}
+		for (int v = 0; v < (int)voices.size(); v++) {
+			results[v][i] = getWeightToken(infile, i, voices[v]->getTrack());
+		}
+	}
+}
+
+
+
+//////////////////////////////
+//
+// Tool_metweight::getWeightToken -- Metric weight token for the track's
+//    **kern token on this line, using the position Tool_meter annotated.
+//    Null tokens return "."; non-attacks/unrecognized meters return WEIGHT_NONE.
+//
+
+string Tool_metweight::getWeightToken(HumdrumFile& infile, int line, int track) {
+	HTp token = NULL;
+	for (int j = 0; j < infile[line].getFieldCount(); j++) {
+		HTp tok = infile.token(line, j);
+		if (tok->getTrack() == track) {
+			token = tok;
+			break;
+		}
+	}
+	if (!token) {
+		return ".";
+	}
+
+	if (token->isNull()) {
+		return ".";
+	}
+
+	if (!token->getValueBool("auto", "hasData")) {
+		return formatWeightClass(WEIGHT_NONE);
+	}
+
+	int top = token->getValueInt("auto", "numerator");
+	int bot = token->getValueInt("auto", "denominator");
+	HumNum beat(token->getValue("auto", "zeroBeat"));
+
+	return formatWeightClass(getWeightClass(top, bot, beat));
+}
+
+
+
+//////////////////////////////
+//
+// Tool_metweight::getWeightClass -- Derive the metric weight of a
+//    0-indexed beat position (Tool_meter's "zeroBeat" units) from the time
+//    signature by bisecting the measure's main beats: the downbeat is
+//    strong; if there is an even number of main beats, the one starting
+//    the second half is half-strong; every other main beat is weak.  A
+//    compound meter with exactly 2 main beats (6/8) also classifies its
+//    eighth-note subdivisions as weak, since those are themselves counted;
+//    everything else (a simple beat's "and", 9/8's/12/8's subdivisions,
+//    deeper subdivisions, syncopated offbeats) is left unclassified.
+//
+
+int Tool_metweight::getWeightClass(int top, int bot, HumNum beat) {
+	if ((top <= 0) || (bot <= 0) || (beat < 0)) {
+		return WEIGHT_NONE;
+	}
+
+	int multiple = top / 3;
+	int remainder = top % 3;
+	bool compound = (bot >= 8) && (multiple > 1) && (remainder == 0);
+
+	int mainBeatCount = compound ? multiple : top;
+	if (mainBeatCount <= 0) {
+		return WEIGHT_NONE;
+	}
+
+	int mainBeatIndex = beat.getInteger();
+	HumNum fraction = beat - HumNum(mainBeatIndex);
+
+	if (fraction == 0) {
+		if (mainBeatIndex == 0) {
+			return WEIGHT_STRONG;
+		}
+		if (((mainBeatCount % 2) == 0) && (mainBeatIndex == mainBeatCount / 2)) {
+			return WEIGHT_HALF_STRONG;
+		}
+		if (mainBeatIndex < mainBeatCount) {
+			return WEIGHT_WEAK;
+		}
+		return WEIGHT_NONE;
+	}
+
+	// Only a compound meter with exactly 2 main beats (6/8) classifies its
+	// eighth-note subdivisions as weak; 9/8, 12/8, etc. are felt/conducted
+	// at the main-beat level only, so their subdivisions stay unclassified.
+	if (compound && (mainBeatCount == 2) && ((fraction == HumNum(1, 3)) || (fraction == HumNum(2, 3)))) {
+		return WEIGHT_WEAK;
+	}
+
+	return WEIGHT_NONE;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_metweight::formatWeightClass -- Convert a weight class into the
+//    token representation selected by the -f/-i options (abbreviated
+//    strong/half-strong/weak codes by default).
+//
+
+string Tool_metweight::formatWeightClass(int weightClass) {
+	if (m_integerQ) {
+		switch (weightClass) {
+			case WEIGHT_STRONG:      return "1";
+			case WEIGHT_HALF_STRONG: return "2";
+			case WEIGHT_WEAK:        return "3";
+			default:                 return ".";
+		}
+	} else if (m_fullQ) {
+		switch (weightClass) {
+			case WEIGHT_STRONG:      return "strong";
+			case WEIGHT_HALF_STRONG: return "half-strong";
+			case WEIGHT_WEAK:        return "weak";
+			default:                 return ".";
+		}
+	} else {
+		switch (weightClass) {
+			case WEIGHT_STRONG:      return "s";
+			case WEIGHT_HALF_STRONG: return "hs";
+			case WEIGHT_WEAK:        return "w";
+			default:                 return ".";
 		}
 	}
 }

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Fr. 24 Juli 2026 08:58:41 CEST
+// Last Modified: Fr. 24 Juli 2026 09:04:33 CEST
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -111699,7 +111699,8 @@ void Tool_metweight::fillVoiceResults(vector<vector<string>>& results, HumdrumFi
 //
 // Tool_metweight::getWeightToken -- Metric weight token for the track's
 //    **kern token on this line, using the position Tool_meter annotated.
-//    Null tokens return "."; non-attacks/unrecognized meters return WEIGHT_NONE.
+//    Null tokens return "."; non-attacks/unrecognized meters return
+//    WEIGHT_UNCLASSIFIED.
 //
 
 string Tool_metweight::getWeightToken(HumdrumFile& infile, int line, int track) {
@@ -111720,7 +111721,7 @@ string Tool_metweight::getWeightToken(HumdrumFile& infile, int line, int track) 
 	}
 
 	if (!token->getValueBool("auto", "hasData")) {
-		return formatWeightClass(WEIGHT_NONE);
+		return formatWeightClass(WEIGHT_UNCLASSIFIED);
 	}
 
 	int top = token->getValueInt("auto", "numerator");
@@ -111756,7 +111757,7 @@ int Tool_metweight::getWeightClass(int top, int bot, HumNum beat) {
 	// a negative position (should not normally happen, but would break
 	// the arithmetic below if it did).
 	if ((top <= 0) || (bot <= 0) || (beat < 0)) {
-		return WEIGHT_NONE;
+		return WEIGHT_UNCLASSIFIED;
 	}
 
 	// How many main beats does this measure have, and is the meter
@@ -111774,7 +111775,7 @@ int Tool_metweight::getWeightClass(int top, int bot, HumNum beat) {
 	if (mainBeatCount <= 0) {
 		// Defensive: cannot happen for a valid time signature (top > 0),
 		// but avoids a divide-by-zero-flavored mainBeatCount/2 below.
-		return WEIGHT_NONE;
+		return WEIGHT_UNCLASSIFIED;
 	}
 
 	// Split "beat" (e.g. 4/3 for the second eighth note of the second
@@ -111803,7 +111804,7 @@ int Tool_metweight::getWeightClass(int top, int bot, HumNum beat) {
 		// mainBeatIndex >= mainBeatCount would mean the position is at or
 		// past the end of the measure; not expected in practice, but
 		// left unclassified rather than guessing a weight for it.
-		return WEIGHT_NONE;
+		return WEIGHT_UNCLASSIFIED;
 	}
 
 	// A position between main beats (nonzero fraction, some subdivision
@@ -111819,7 +111820,7 @@ int Tool_metweight::getWeightClass(int top, int bot, HumNum beat) {
 	// subdivisions of 9/8 or 12/8, sixteenth notes and other deeper
 	// subdivisions, syncopated offbeats): not a notated counting position
 	// of this meter, so it is left unclassified.
-	return WEIGHT_NONE;
+	return WEIGHT_UNCLASSIFIED;
 }
 
 
@@ -111833,7 +111834,7 @@ int Tool_metweight::getWeightClass(int top, int bot, HumNum beat) {
 //
 
 string Tool_metweight::formatWeightClass(int weightClass) {
-	if (m_nullQ && (weightClass == WEIGHT_NONE)) {
+	if (m_nullQ && (weightClass == WEIGHT_UNCLASSIFIED)) {
 		return ".";
 	}
 	if (m_integerQ) {
@@ -111848,14 +111849,14 @@ string Tool_metweight::formatWeightClass(int weightClass) {
 			case WEIGHT_STRONG:      return "strong";
 			case WEIGHT_HALF_STRONG: return "half-strong";
 			case WEIGHT_WEAK:        return "weak";
-			default:                 return "none";
+			default:                 return "unclassified";
 		}
 	} else {
 		switch (weightClass) {
 			case WEIGHT_STRONG:      return "s";
 			case WEIGHT_HALF_STRONG: return "hs";
 			case WEIGHT_WEAK:        return "w";
-			default:                 return "n";
+			default:                 return "u";
 		}
 	}
 }

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Fr. 24 Juli 2026 09:04:33 CEST
+// Last Modified: Fr. 24 Juli 2026 09:15:49 CEST
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -111838,12 +111838,7 @@ string Tool_metweight::formatWeightClass(int weightClass) {
 		return ".";
 	}
 	if (m_integerQ) {
-		switch (weightClass) {
-			case WEIGHT_STRONG:      return "1";
-			case WEIGHT_HALF_STRONG: return "2";
-			case WEIGHT_WEAK:        return "3";
-			default:                 return "4";
-		}
+		return to_string(weightClass);
 	} else if (m_fullQ) {
 		switch (weightClass) {
 			case WEIGHT_STRONG:      return "strong";

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Fr. 24 Juli 2026 09:15:49 CEST
+// Last Modified: Fr. 24 Juli 2026 09:36:39 CEST
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -111652,11 +111652,13 @@ void Tool_metweight::processFile(HumdrumFile& infile) {
 	vector<vector<string>> results;
 	fillVoiceResults(results, infile, voices);
 
+	// Insert each voice's spine right after its own track, processing from
+	// last to first so that earlier (not-yet-processed) voices' track
+	// numbers are not shifted by a later insertion.
 	string exinterp = m_cdataQ ? "**cdata-metweight" : "**metweight";
-	infile.appendDataSpine(results.back(), ".", exinterp);
-	for (int i = (int)voices.size() - 1; i > 0; i--) {
+	for (int i = (int)voices.size() - 1; i >= 0; i--) {
 		int track = voices[i]->getTrack();
-		infile.insertDataSpineBefore(track, results[i - 1], ".", exinterp);
+		infile.insertDataSpineAfter(track, results[i], ".", exinterp);
 	}
 	infile.createLinesFromTokens();
 

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Fr. 24 Juli 2026 08:32:33 CEST
+// Last Modified: Fr. 24 Juli 2026 08:33:05 CEST
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -111798,21 +111798,21 @@ string Tool_metweight::formatWeightClass(int weightClass) {
 			case WEIGHT_STRONG:      return "1";
 			case WEIGHT_HALF_STRONG: return "2";
 			case WEIGHT_WEAK:        return "3";
-			default:                 return ".";
+			default:                 return "4";
 		}
 	} else if (m_fullQ) {
 		switch (weightClass) {
 			case WEIGHT_STRONG:      return "strong";
 			case WEIGHT_HALF_STRONG: return "half-strong";
 			case WEIGHT_WEAK:        return "weak";
-			default:                 return ".";
+			default:                 return "none";
 		}
 	} else {
 		switch (weightClass) {
 			case WEIGHT_STRONG:      return "s";
 			case WEIGHT_HALF_STRONG: return "hs";
 			case WEIGHT_WEAK:        return "w";
-			default:                 return ".";
+			default:                 return "n";
 		}
 	}
 }

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Fr. 24 Juli 2026 08:36:40 CEST
+// Last Modified: Fr. 24 Juli 2026 08:58:41 CEST
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -111734,54 +111734,91 @@ string Tool_metweight::getWeightToken(HumdrumFile& infile, int line, int track) 
 
 //////////////////////////////
 //
-// Tool_metweight::getWeightClass -- Derive the metric weight of a
-//    0-indexed beat position (Tool_meter's "zeroBeat" units) from the time
-//    signature by bisecting the measure's main beats: the downbeat is
-//    strong; if there is an even number of main beats, the one starting
-//    the second half is half-strong; every other main beat is weak.  A
-//    compound meter with exactly 2 main beats (6/8) also classifies its
-//    eighth-note subdivisions as weak, since those are themselves counted;
-//    everything else (a simple beat's "and", 9/8's/12/8's subdivisions,
-//    deeper subdivisions, syncopated offbeats) is left unclassified.
+// Tool_metweight::getWeightClass -- Derive the metric weight
+//    (strong/half-strong/weak/unclassified) of a beat position from the
+//    time signature.  "beat" is Tool_meter's "zeroBeat": a 0-indexed
+//    count of main beats (quarter note in 4/4, dotted quarter in 6/8)
+//    from the start of the measure; a fractional beat (e.g. 1/3) is a
+//    subdivision within a beat.
+//
+//    Algorithm: split "beat" into a whole main-beat index and a leftover
+//    fraction.  Fraction 0 is a main beat: index 0 is strong, the beat
+//    starting the second half of the measure (only if mainBeatCount is
+//    even) is half-strong, every other main beat is weak.  A nonzero
+//    fraction is only classified (weak) for a compound meter with
+//    exactly 2 main beats (6/8), at its second/third eighth note
+//    (fraction 1/3 or 2/3); everything else is left unclassified.
 //
 
 int Tool_metweight::getWeightClass(int top, int bot, HumNum beat) {
+	// Guard against an unset/unrecognized time signature (top or bot not
+	// yet known, e.g. before the first *M interpretation in the file) or
+	// a negative position (should not normally happen, but would break
+	// the arithmetic below if it did).
 	if ((top <= 0) || (bot <= 0) || (beat < 0)) {
 		return WEIGHT_NONE;
 	}
 
+	// How many main beats does this measure have, and is the meter
+	// compound (does each main beat itself split into three)?  "multiple"
+	// and "remainder" are just top divided/modulo 3, reused below to
+	// test "is top a multiple of 3 that is greater than 3".
 	int multiple = top / 3;
 	int remainder = top % 3;
 	bool compound = (bot >= 8) && (multiple > 1) && (remainder == 0);
 
+	// Compound: 3 eighth notes per main beat, so top/3 main beats
+	// (6/8 -> 2, 9/8 -> 3, 12/8 -> 4).  Simple: one main beat per counted
+	// unit, so top main beats (4/4 -> 4, 3/4 -> 3, 6/4 -> 6).
 	int mainBeatCount = compound ? multiple : top;
 	if (mainBeatCount <= 0) {
+		// Defensive: cannot happen for a valid time signature (top > 0),
+		// but avoids a divide-by-zero-flavored mainBeatCount/2 below.
 		return WEIGHT_NONE;
 	}
 
+	// Split "beat" (e.g. 4/3 for the second eighth note of the second
+	// compound beat) into its whole main-beat index (1) and the
+	// fraction of a beat left over (1/3).
 	int mainBeatIndex = beat.getInteger();
 	HumNum fraction = beat - HumNum(mainBeatIndex);
 
+	// A main-beat position (no leftover fraction):
 	if (fraction == 0) {
 		if (mainBeatIndex == 0) {
+			// The downbeat: always the strongest position of the measure.
 			return WEIGHT_STRONG;
 		}
 		if (((mainBeatCount % 2) == 0) && (mainBeatIndex == mainBeatCount / 2)) {
+			// Exactly the main beat that starts the second half of the
+			// measure (only exists when there is an even number of main
+			// beats): the secondary/half-strong accent.
 			return WEIGHT_HALF_STRONG;
 		}
 		if (mainBeatIndex < mainBeatCount) {
+			// Any other in-range main beat: weak (e.g. beats 2 and 4 of
+			// a 4/4 measure).
 			return WEIGHT_WEAK;
 		}
+		// mainBeatIndex >= mainBeatCount would mean the position is at or
+		// past the end of the measure; not expected in practice, but
+		// left unclassified rather than guessing a weight for it.
 		return WEIGHT_NONE;
 	}
 
-	// Only a compound meter with exactly 2 main beats (6/8) classifies its
-	// eighth-note subdivisions as weak; 9/8, 12/8, etc. are felt/conducted
-	// at the main-beat level only, so their subdivisions stay unclassified.
+	// A position between main beats (nonzero fraction, some subdivision
+	// or syncopated offset).  Only give this a weight in the one case
+	// where the subdivision is itself a genuinely counted part of the
+	// meter: a compound meter with exactly 2 main beats (6/8), at the
+	// second or third eighth note of a beat (fraction 1/3 or 2/3).
 	if (compound && (mainBeatCount == 2) && ((fraction == HumNum(1, 3)) || (fraction == HumNum(2, 3)))) {
 		return WEIGHT_WEAK;
 	}
 
+	// Everything else (a simple meter's "and" of the beat, the eighth-note
+	// subdivisions of 9/8 or 12/8, sixteenth notes and other deeper
+	// subdivisions, syncopated offbeats): not a notated counting position
+	// of this meter, so it is left unclassified.
 	return WEIGHT_NONE;
 }
 

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mo. 27 Juli 2026 23:38:23 CEST
+// Last Modified: Di. 28 Juli 2026 00:12:50 CEST
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -111534,6 +111534,7 @@ Tool_metweight::Tool_metweight(void) {
 	define("k|kern-tracks=s",  "process only the specified kern spines");
 	define("s|spine|spines=s", "process only the specified spines");
 	define("n|null=b",         "always use the null token . for unclassified positions");
+	define("t|tied=b",         "label secondary tied notes instead of giving them the null token .");
 }
 
 
@@ -111590,6 +111591,7 @@ void Tool_metweight::initialize(void) {
 	m_integerQ = getBoolean("integer");
 	m_cdataQ   = getBoolean("cdata");
 	m_nullQ    = getBoolean("null");
+	m_tiedQ    = getBoolean("tied");
 
 	if (getBoolean("spine")) {
 		m_spineTracks = getString("spine");
@@ -111719,6 +111721,12 @@ string Tool_metweight::getWeightToken(HumdrumFile& infile, int line, int track) 
 	}
 
 	if (token->isNull()) {
+		return ".";
+	}
+
+	if (!m_tiedQ && token->isSecondaryTiedNote()) {
+		// The continuation of a tie is not a new attack, so it has no
+		// metric weight of its own (-t restores labeling it anyway).
 		return ".";
 	}
 

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Di. 28 Juli 2026 01:02:39 CEST
+// Last Modified: Di. 28 Juli 2026 01:41:32 CEST
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -111535,7 +111535,8 @@ Tool_metweight::Tool_metweight(void) {
 	define("s|spine|spines=s", "process only the specified spines");
 	define("n|null=b",         "always use the null token . for unclassified positions");
 	define("t|tied=b",         "label secondary tied notes instead of giving them the null token .");
-	define("c|composite=b",    "add a **kern-comp spine (composite rhythm of all voices) below the voices and label only that spine");
+	define("C|composite=b",    "add a **kern-comp spine (composite rhythm of all voices) below the voices and label only that spine");
+	define("c|color=b",        "add a **color spine with a color for each weight class after every **metweight spine");
 }
 
 
@@ -111594,6 +111595,7 @@ void Tool_metweight::initialize(void) {
 	m_nullQ      = getBoolean("null");
 	m_tiedQ      = getBoolean("tied");
 	m_compositeQ = getBoolean("composite");
+	m_colorQ     = getBoolean("color");
 
 	if (getBoolean("spine")) {
 		m_spineTracks = getString("spine");
@@ -111608,7 +111610,7 @@ void Tool_metweight::initialize(void) {
 //
 // Tool_metweight::processFile -- Insert a **metweight spine after every
 //    processed **kern spine, containing the metric weight of the current
-//    note/rest attack.  With -c only a composite spine is added below the
+//    note/rest attack.  With -C only a composite spine is added below the
 //    voices, and only that spine gets a **metweight spine.
 //
 
@@ -111632,16 +111634,31 @@ void Tool_metweight::processFile(HumdrumFile& infile) {
 	meterTool.process("-r");
 	meterTool.run(infile);
 
-	vector<vector<string>> results;
+	vector<vector<int>> results;
 	fillVoiceResults(results, infile, voices);
+
+	int format = FORMAT_ABBREVIATION;
+	if (m_integerQ) {
+		format = FORMAT_INTEGER;
+	} else if (m_fullQ) {
+		format = FORMAT_FULL;
+	}
 
 	// Insert each voice's spine right after its own track, processing from
 	// last to first so that earlier (not-yet-processed) voices' track
 	// numbers are not shifted by a later insertion.
 	string exinterp = m_cdataQ ? "**cdata-metweight" : "**metweight";
+	vector<string> tokens;
 	for (int i = (int)voices.size() - 1; i >= 0; i--) {
 		int track = voices[i]->getTrack();
-		infile.insertDataSpineAfter(track, results[i], ".", exinterp);
+		if (m_colorQ) {
+			// Inserted first so that the **metweight spine inserted below
+			// ends up between the voice and its **color spine.
+			formatWeights(tokens, results[i], FORMAT_COLOR);
+			infile.insertDataSpineAfter(track, tokens, ".", "**color");
+		}
+		formatWeights(tokens, results[i], format);
+		infile.insertDataSpineAfter(track, tokens, ".", exinterp);
 	}
 	infile.createLinesFromTokens();
 
@@ -111653,7 +111670,7 @@ void Tool_metweight::processFile(HumdrumFile& infile) {
 
 //////////////////////////////
 //
-// Tool_metweight::addCompositeSpine -- -c option: replace the input with the
+// Tool_metweight::addCompositeSpine -- -C option: replace the input with the
 //    output of the composite tool, which adds a **kern-comp spine (the merged
 //    rhythm of all voices) below the existing voices.  Without "-a" the
 //    composite spine is prepended, which places it below the input voices in
@@ -111676,7 +111693,7 @@ void Tool_metweight::addCompositeSpine(HumdrumFile& infile) {
 
 //////////////////////////////
 //
-// Tool_metweight::getVoices -- The spines to label: with -c only the
+// Tool_metweight::getVoices -- The spines to label: with -C only the
 //    composite spine, otherwise the **kern spines selected by -k or -s (all
 //    of them when neither option is given).  The composite rhythm is always
 //    built from all **kern spines, so -k/-s do not apply in that mode.
@@ -111730,19 +111747,20 @@ void Tool_metweight::getVoices(vector<HTp>& voices, HumdrumFile& infile) {
 
 //////////////////////////////
 //
-// Tool_metweight::fillVoiceResults -- Calculate the **metweight tokens for
-//    each selected **kern spine, one value per line, for
-//    appendDataSpine()/insertDataSpineBefore() to consume.
+// Tool_metweight::fillVoiceResults -- Calculate the metric weight class of
+//    each selected **kern spine, one value per line.  Lines without a weight
+//    (non-data lines, null tokens, tie continuations) get 0, which is not a
+//    weight class; formatWeights() turns the classes into spine tokens.
 //
 
-void Tool_metweight::fillVoiceResults(vector<vector<string>>& results, HumdrumFile& infile,
+void Tool_metweight::fillVoiceResults(vector<vector<int>>& results, HumdrumFile& infile,
 		const vector<HTp>& voices) {
 
 	int lineCount = infile.getLineCount();
 	results.clear();
 	results.resize(voices.size());
 	for (int v = 0; v < (int)voices.size(); v++) {
-		results[v].resize(lineCount, ".");
+		results[v].resize(lineCount, 0);
 	}
 
 	for (int i = 0; i < lineCount; i++) {
@@ -111750,7 +111768,7 @@ void Tool_metweight::fillVoiceResults(vector<vector<string>>& results, HumdrumFi
 			continue;
 		}
 		for (int v = 0; v < (int)voices.size(); v++) {
-			results[v][i] = getWeightToken(infile, i, voices[v]->getTrack());
+			results[v][i] = getTokenWeightClass(infile, i, voices[v]->getTrack());
 		}
 	}
 }
@@ -111759,13 +111777,41 @@ void Tool_metweight::fillVoiceResults(vector<vector<string>>& results, HumdrumFi
 
 //////////////////////////////
 //
-// Tool_metweight::getWeightToken -- Metric weight token for the track's
-//    **kern token on this line, using the position Tool_meter annotated.
-//    Null tokens return "."; non-attacks/unrecognized meters return
-//    WEIGHT_UNCLASSIFIED.
+// Tool_metweight::formatWeights -- Convert a voice's weight classes into the
+//    tokens of one data spine.  Positions without a weight get the null
+//    token ".", and so do unclassified positions when -n is given -- except
+//    in the **color spine, where a null token would make a note keep the
+//    color of the previous one instead of leaving it uncolored.
 //
 
-string Tool_metweight::getWeightToken(HumdrumFile& infile, int line, int track) {
+void Tool_metweight::formatWeights(vector<string>& tokens, const vector<int>& weightClasses,
+		int format) {
+
+	bool nullUnclassifiedQ = m_nullQ && (format != FORMAT_COLOR);
+
+	tokens.clear();
+	tokens.resize(weightClasses.size());
+	for (int i = 0; i < (int)weightClasses.size(); i++) {
+		int weightClass = weightClasses[i];
+		if ((weightClass == 0) || (nullUnclassifiedQ && (weightClass == WEIGHT_UNCLASSIFIED))) {
+			tokens[i] = ".";
+		} else {
+			tokens[i] = formatWeightClass(weightClass, format);
+		}
+	}
+}
+
+
+
+//////////////////////////////
+//
+// Tool_metweight::getTokenWeightClass -- Metric weight class of the track's
+//    **kern token on this line, using the position Tool_meter annotated.
+//    Null tokens and tie continuations have no weight at all (0);
+//    non-attacks/unrecognized meters are WEIGHT_UNCLASSIFIED.
+//
+
+int Tool_metweight::getTokenWeightClass(HumdrumFile& infile, int line, int track) {
 	HTp token = NULL;
 	for (int j = 0; j < infile[line].getFieldCount(); j++) {
 		HTp tok = infile.token(line, j);
@@ -111775,11 +111821,11 @@ string Tool_metweight::getWeightToken(HumdrumFile& infile, int line, int track) 
 		}
 	}
 	if (!token) {
-		return ".";
+		return 0;
 	}
 
 	if (token->isNull()) {
-		return ".";
+		return 0;
 	}
 
 	// The continuation of a tie is not a new attack, so it has no metric
@@ -111787,7 +111833,7 @@ string Tool_metweight::getWeightToken(HumdrumFile& infile, int line, int track) 
 	// isSecondaryTiedNote() only accepts plain **kern, so test the token
 	// text directly to cover **kern-comp spines as well.
 	if (!m_tiedQ && Convert::isKernSecondaryTiedNote(*token)) {
-		return ".";
+		return 0;
 	}
 
 	HTp position = token;
@@ -111799,14 +111845,14 @@ string Tool_metweight::getWeightToken(HumdrumFile& infile, int line, int track) 
 		position = getMeterToken(infile, line);
 	}
 	if (!position || !position->getValueBool("auto", "hasData")) {
-		return formatWeightClass(WEIGHT_UNCLASSIFIED);
+		return WEIGHT_UNCLASSIFIED;
 	}
 
 	int top = position->getValueInt("auto", "numerator");
 	int bot = position->getValueInt("auto", "denominator");
 	HumNum beat(position->getValue("auto", "zeroBeat"));
 
-	return formatWeightClass(getWeightClass(top, bot, beat));
+	return getWeightClass(top, bot, beat);
 }
 
 
@@ -111924,32 +111970,41 @@ int Tool_metweight::getWeightClass(int top, int bot, HumNum beat) {
 
 //////////////////////////////
 //
-// Tool_metweight::formatWeightClass -- Convert a weight class into the
-//    token representation selected by the -f/-i options (abbreviated
-//    strong/half-strong/weak codes by default); -n forces the null
-//    token "." for unclassified positions in all three modes.
+// Tool_metweight::formatWeightClass -- Convert a weight class into one of
+//    its token representations: the abbreviations used by the **metweight
+//    spine by default, the full labels of -f, the integer ranks of -i, or
+//    the colors of the **color spine added by -c.
 //
 
-string Tool_metweight::formatWeightClass(int weightClass) {
-	if (m_nullQ && (weightClass == WEIGHT_UNCLASSIFIED)) {
-		return ".";
-	}
-	if (m_integerQ) {
-		return to_string(weightClass);
-	} else if (m_fullQ) {
-		switch (weightClass) {
-			case WEIGHT_STRONG:      return "strong";
-			case WEIGHT_HALF_STRONG: return "half-strong";
-			case WEIGHT_WEAK:        return "weak";
-			default:                 return "unclassified";
-		}
-	} else {
-		switch (weightClass) {
-			case WEIGHT_STRONG:      return "s";
-			case WEIGHT_HALF_STRONG: return "hs";
-			case WEIGHT_WEAK:        return "w";
-			default:                 return "u";
-		}
+string Tool_metweight::formatWeightClass(int weightClass, int format) {
+	switch (format) {
+
+		case FORMAT_INTEGER:
+			return to_string(weightClass);
+
+		case FORMAT_FULL:
+			switch (weightClass) {
+				case WEIGHT_STRONG:      return "strong";
+				case WEIGHT_HALF_STRONG: return "half-strong";
+				case WEIGHT_WEAK:        return "weak";
+				default:                 return "unclassified";
+			}
+
+		case FORMAT_COLOR:
+			switch (weightClass) {
+				case WEIGHT_STRONG:      return "crimson";
+				case WEIGHT_HALF_STRONG: return "orange";
+				case WEIGHT_WEAK:        return "limegreen";
+				default:                 return "black";
+			}
+
+		default:
+			switch (weightClass) {
+				case WEIGHT_STRONG:      return "s";
+				case WEIGHT_HALF_STRONG: return "hs";
+				case WEIGHT_WEAK:        return "w";
+				default:                 return "u";
+			}
 	}
 }
 

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Di. 28 Juli 2026 00:12:50 CEST
+// Last Modified: Di. 28 Juli 2026 01:02:39 CEST
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -111535,6 +111535,7 @@ Tool_metweight::Tool_metweight(void) {
 	define("s|spine|spines=s", "process only the specified spines");
 	define("n|null=b",         "always use the null token . for unclassified positions");
 	define("t|tied=b",         "label secondary tied notes instead of giving them the null token .");
+	define("c|composite=b",    "add a **kern-comp spine (composite rhythm of all voices) below the voices and label only that spine");
 }
 
 
@@ -111587,11 +111588,12 @@ bool Tool_metweight::run(HumdrumFile& infile) {
 //
 
 void Tool_metweight::initialize(void) {
-	m_fullQ    = getBoolean("full");
-	m_integerQ = getBoolean("integer");
-	m_cdataQ   = getBoolean("cdata");
-	m_nullQ    = getBoolean("null");
-	m_tiedQ    = getBoolean("tied");
+	m_fullQ      = getBoolean("full");
+	m_integerQ   = getBoolean("integer");
+	m_cdataQ     = getBoolean("cdata");
+	m_nullQ      = getBoolean("null");
+	m_tiedQ      = getBoolean("tied");
+	m_compositeQ = getBoolean("composite");
 
 	if (getBoolean("spine")) {
 		m_spineTracks = getString("spine");
@@ -111606,41 +111608,20 @@ void Tool_metweight::initialize(void) {
 //
 // Tool_metweight::processFile -- Insert a **metweight spine after every
 //    processed **kern spine, containing the metric weight of the current
-//    note/rest attack.
+//    note/rest attack.  With -c only a composite spine is added below the
+//    voices, and only that spine gets a **metweight spine.
 //
 
 void Tool_metweight::processFile(HumdrumFile& infile) {
-	int maxTrack = infile.getMaxTrack();
-
-	m_selectedKernSpines.resize(maxTrack + 1); // +1 since track=0 is not used
-	fill(m_selectedKernSpines.begin(), m_selectedKernSpines.end(), true);
-
-	vector<HTp> kernspines = infile.getKernSpineStartList();
-
-	// Calculate which input spines to process based on -k or -s option:
-	if (!m_kernTracks.empty()) {
-		vector<int> ktracks = Convert::extractIntegerList(m_kernTracks, maxTrack);
-		fill(m_selectedKernSpines.begin(), m_selectedKernSpines.end(), false);
-		for (int i = 0; i < (int)ktracks.size(); i++) {
-			int index = ktracks[i] - 1;
-			if ((index < 0) || (index >= (int)kernspines.size())) {
-				continue;
-			}
-			int track = kernspines.at(index)->getTrack();
-			m_selectedKernSpines.at(track) = true;
-		}
-	} else if (!m_spineTracks.empty()) {
-		fill(m_selectedKernSpines.begin(), m_selectedKernSpines.end(), false);
-		infile.makeBooleanTrackList(m_selectedKernSpines, m_spineTracks);
+	if (m_compositeQ) {
+		addCompositeSpine(infile);
 	}
 
 	vector<HTp> voices;
-	for (int i = 0; i < (int)kernspines.size(); i++) {
-		if (m_selectedKernSpines.at(kernspines[i]->getTrack())) {
-			voices.push_back(kernspines[i]);
-		}
-	}
+	getVoices(voices, infile);
 	if (voices.empty()) {
+		// Nothing to label, but pass the input on unchanged.
+		m_humdrum_text << infile;
 		return;
 	}
 
@@ -111666,6 +111647,83 @@ void Tool_metweight::processFile(HumdrumFile& infile) {
 
 	// Enable usage in verovio (`!!!filter: metweight`)
 	m_humdrum_text << infile;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_metweight::addCompositeSpine -- -c option: replace the input with the
+//    output of the composite tool, which adds a **kern-comp spine (the merged
+//    rhythm of all voices) below the existing voices.  Without "-a" the
+//    composite spine is prepended, which places it below the input voices in
+//    the rendered score.
+//
+
+void Tool_metweight::addCompositeSpine(HumdrumFile& infile) {
+	if (infile.getKernSpineStartList().empty()) {
+		return;
+	}
+
+	stringstream composite;
+	Tool_composite compositeTool;
+	compositeTool.process("");
+	compositeTool.run(infile, composite);
+	infile.readString(composite.str());
+}
+
+
+
+//////////////////////////////
+//
+// Tool_metweight::getVoices -- The spines to label: with -c only the
+//    composite spine, otherwise the **kern spines selected by -k or -s (all
+//    of them when neither option is given).  The composite rhythm is always
+//    built from all **kern spines, so -k/-s do not apply in that mode.
+//
+
+void Tool_metweight::getVoices(vector<HTp>& voices, HumdrumFile& infile) {
+	voices.clear();
+
+	if (m_compositeQ) {
+		vector<HTp> spinestarts = infile.getKernLikeSpineStartList();
+		for (int i = 0; i < (int)spinestarts.size(); i++) {
+			if (*spinestarts[i] == "**kern-comp") {
+				voices.push_back(spinestarts[i]);
+			}
+		}
+		return;
+	}
+
+	int maxTrack = infile.getMaxTrack();
+
+	m_selectedKernSpines.resize(maxTrack + 1); // +1 since track=0 is not used
+	fill(m_selectedKernSpines.begin(), m_selectedKernSpines.end(), true);
+
+	vector<HTp> kernspines = infile.getKernSpineStartList();
+
+	// Calculate which input spines to process based on -k or -s option:
+	if (!m_kernTracks.empty()) {
+		vector<int> ktracks = Convert::extractIntegerList(m_kernTracks, maxTrack);
+		fill(m_selectedKernSpines.begin(), m_selectedKernSpines.end(), false);
+		for (int i = 0; i < (int)ktracks.size(); i++) {
+			int index = ktracks[i] - 1;
+			if ((index < 0) || (index >= (int)kernspines.size())) {
+				continue;
+			}
+			int track = kernspines.at(index)->getTrack();
+			m_selectedKernSpines.at(track) = true;
+		}
+	} else if (!m_spineTracks.empty()) {
+		fill(m_selectedKernSpines.begin(), m_selectedKernSpines.end(), false);
+		infile.makeBooleanTrackList(m_selectedKernSpines, m_spineTracks);
+	}
+
+	for (int i = 0; i < (int)kernspines.size(); i++) {
+		if (m_selectedKernSpines.at(kernspines[i]->getTrack())) {
+			voices.push_back(kernspines[i]);
+		}
+	}
 }
 
 
@@ -111724,21 +111782,50 @@ string Tool_metweight::getWeightToken(HumdrumFile& infile, int line, int track) 
 		return ".";
 	}
 
-	if (!m_tiedQ && token->isSecondaryTiedNote()) {
-		// The continuation of a tie is not a new attack, so it has no
-		// metric weight of its own (-t restores labeling it anyway).
+	// The continuation of a tie is not a new attack, so it has no metric
+	// weight of its own (-t restores labeling it anyway).  HumdrumToken::
+	// isSecondaryTiedNote() only accepts plain **kern, so test the token
+	// text directly to cover **kern-comp spines as well.
+	if (!m_tiedQ && Convert::isKernSecondaryTiedNote(*token)) {
 		return ".";
 	}
 
-	if (!token->getValueBool("auto", "hasData")) {
+	HTp position = token;
+	if (m_compositeQ && !position->getValueBool("auto", "hasData")) {
+		// The meter tool only analyzes **kern spines, so a **kern-comp
+		// token is never annotated itself.  The metric position is a
+		// property of the line rather than of a particular voice, so read
+		// it from a **kern attack on the same line instead.
+		position = getMeterToken(infile, line);
+	}
+	if (!position || !position->getValueBool("auto", "hasData")) {
 		return formatWeightClass(WEIGHT_UNCLASSIFIED);
 	}
 
-	int top = token->getValueInt("auto", "numerator");
-	int bot = token->getValueInt("auto", "denominator");
-	HumNum beat(token->getValue("auto", "zeroBeat"));
+	int top = position->getValueInt("auto", "numerator");
+	int bot = position->getValueInt("auto", "denominator");
+	HumNum beat(position->getValue("auto", "zeroBeat"));
 
 	return formatWeightClass(getWeightClass(top, bot, beat));
+}
+
+
+
+//////////////////////////////
+//
+// Tool_metweight::getMeterToken -- First token on the line that the meter
+//    tool annotated with a metric position, or NULL if there is none (for
+//    example when every voice is sustaining a note across this line).
+//
+
+HTp Tool_metweight::getMeterToken(HumdrumFile& infile, int line) {
+	for (int j = 0; j < infile[line].getFieldCount(); j++) {
+		HTp token = infile.token(line, j);
+		if (token->getValueBool("auto", "hasData")) {
+			return token;
+		}
+	}
+	return NULL;
 }
 
 

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Fr. 24 Juli 2026 09:15:49 CEST
+// Last Modified: Fr. 24 Juli 2026 09:36:39 CEST
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mon Jul 20 10:35:12 CEST 2026
+// Last Modified: Fr. 24 Juli 2026 08:32:33 CEST
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11
@@ -9727,6 +9727,47 @@ class Tool_metlev : public HumTool {
 
 };
 
+
+
+class Tool_metweight : public HumTool {
+
+	public:
+		     Tool_metweight  (void);
+		     ~Tool_metweight () {};
+
+		bool run     (HumdrumFileSet& infiles);
+		bool run     (HumdrumFile& infile);
+		bool run     (const std::string& indata, std::ostream& out);
+		bool run     (HumdrumFile& infile, std::ostream& out);
+
+	protected:
+		void        initialize       (void);
+		void        processFile      (HumdrumFile& infile);
+		void        fillVoiceResults (std::vector<std::vector<std::string>>& results,
+		                             HumdrumFile& infile,
+		                             const std::vector<HTp>& voices);
+		std::string getWeightToken   (HumdrumFile& infile, int line, int track);
+		std::string formatWeightClass(int weightClass);
+		int         getWeightClass   (int top, int bot, HumNum beat);
+
+		// Metric weight classes (in order from strongest to weakest):
+		enum {
+			WEIGHT_STRONG      = 0,
+			WEIGHT_HALF_STRONG = 1,
+			WEIGHT_WEAK        = 2,
+			WEIGHT_NONE        = -1
+		};
+
+	private:
+		bool m_fullQ    = false; // -f option: print full text labels instead of abbreviations
+		bool m_integerQ = false; // -i option: print integer rank labels instead of abbreviations
+		bool m_cdataQ   = false; // -x option: label the spine **cdata-metweight instead of **metweight
+
+		std::string       m_kernTracks  = ""; // used with -k option
+		std::string       m_spineTracks = ""; // used with -s option
+		std::vector<bool> m_selectedKernSpines; // used with -k and -s option
+
+};
 
 
 class Tool_mint : public HumTool {

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Fr. 24 Juli 2026 08:33:05 CEST
+// Last Modified: Fr. 24 Juli 2026 08:36:40 CEST
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11
@@ -9762,6 +9762,7 @@ class Tool_metweight : public HumTool {
 		bool m_fullQ    = false; // -f option: print full text labels instead of abbreviations
 		bool m_integerQ = false; // -i option: print integer rank labels instead of abbreviations
 		bool m_cdataQ   = false; // -x option: label the spine **cdata-metweight instead of **metweight
+		bool m_nullQ    = false; // -n option: always use the null token . for unclassified positions
 
 		std::string       m_kernTracks  = ""; // used with -k option
 		std::string       m_spineTracks = ""; // used with -s option

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Fr. 24 Juli 2026 08:36:40 CEST
+// Last Modified: Fr. 24 Juli 2026 08:58:41 CEST
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Fr. 24 Juli 2026 09:36:39 CEST
+// Last Modified: Fr. 24 Juli 2026 10:20:37 CEST
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Fr. 24 Juli 2026 08:32:33 CEST
+// Last Modified: Fr. 24 Juli 2026 08:33:05 CEST
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Fr. 24 Juli 2026 08:58:41 CEST
+// Last Modified: Fr. 24 Juli 2026 09:04:33 CEST
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11
@@ -9752,10 +9752,10 @@ class Tool_metweight : public HumTool {
 
 		// Metric weight classes (in order from strongest to weakest):
 		enum {
-			WEIGHT_STRONG      = 0,
-			WEIGHT_HALF_STRONG = 1,
-			WEIGHT_WEAK        = 2,
-			WEIGHT_NONE        = -1
+			WEIGHT_STRONG       = 0,
+			WEIGHT_HALF_STRONG  = 1,
+			WEIGHT_WEAK         = 2,
+			WEIGHT_UNCLASSIFIED = -1
 		};
 
 	private:

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Fr. 24 Juli 2026 09:04:33 CEST
+// Last Modified: Fr. 24 Juli 2026 09:15:49 CEST
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11
@@ -9752,10 +9752,10 @@ class Tool_metweight : public HumTool {
 
 		// Metric weight classes (in order from strongest to weakest):
 		enum {
-			WEIGHT_STRONG       = 0,
-			WEIGHT_HALF_STRONG  = 1,
-			WEIGHT_WEAK         = 2,
-			WEIGHT_UNCLASSIFIED = -1
+			WEIGHT_STRONG       = 1,
+			WEIGHT_HALF_STRONG  = 2,
+			WEIGHT_WEAK         = 3,
+			WEIGHT_UNCLASSIFIED = 4
 		};
 
 	private:

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mo. 27 Juli 2026 23:38:23 CEST
+// Last Modified: Di. 28 Juli 2026 00:12:50 CEST
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11
@@ -9763,6 +9763,7 @@ class Tool_metweight : public HumTool {
 		bool m_integerQ = false; // -i option: print integer rank labels instead of abbreviations
 		bool m_cdataQ   = false; // -x option: label the spine **cdata-metweight instead of **metweight
 		bool m_nullQ    = false; // -n option: always use the null token . for unclassified positions
+		bool m_tiedQ    = false; // -t option: label secondary tied notes instead of giving them the null token .
 
 		std::string       m_kernTracks  = ""; // used with -k option
 		std::string       m_spineTracks = ""; // used with -s option

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Di. 28 Juli 2026 00:12:50 CEST
+// Last Modified: Di. 28 Juli 2026 01:02:39 CEST
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11
@@ -9743,10 +9743,13 @@ class Tool_metweight : public HumTool {
 	protected:
 		void        initialize       (void);
 		void        processFile      (HumdrumFile& infile);
+		void        addCompositeSpine(HumdrumFile& infile);
+		void        getVoices        (std::vector<HTp>& voices, HumdrumFile& infile);
 		void        fillVoiceResults (std::vector<std::vector<std::string>>& results,
 		                             HumdrumFile& infile,
 		                             const std::vector<HTp>& voices);
 		std::string getWeightToken   (HumdrumFile& infile, int line, int track);
+		HTp         getMeterToken    (HumdrumFile& infile, int line);
 		std::string formatWeightClass(int weightClass);
 		int         getWeightClass   (int top, int bot, HumNum beat);
 
@@ -9759,11 +9762,12 @@ class Tool_metweight : public HumTool {
 		};
 
 	private:
-		bool m_fullQ    = false; // -f option: print full text labels instead of abbreviations
-		bool m_integerQ = false; // -i option: print integer rank labels instead of abbreviations
-		bool m_cdataQ   = false; // -x option: label the spine **cdata-metweight instead of **metweight
-		bool m_nullQ    = false; // -n option: always use the null token . for unclassified positions
-		bool m_tiedQ    = false; // -t option: label secondary tied notes instead of giving them the null token .
+		bool m_fullQ      = false; // -f option: print full text labels instead of abbreviations
+		bool m_integerQ   = false; // -i option: print integer rank labels instead of abbreviations
+		bool m_cdataQ     = false; // -x option: label the spine **cdata-metweight instead of **metweight
+		bool m_nullQ      = false; // -n option: always use the null token . for unclassified positions
+		bool m_tiedQ      = false; // -t option: label secondary tied notes instead of giving them the null token .
+		bool m_compositeQ = false; // -c option: add a **kern-comp spine below the voices and label only that spine
 
 		std::string       m_kernTracks  = ""; // used with -k option
 		std::string       m_spineTracks = ""; // used with -s option

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Di. 28 Juli 2026 01:02:39 CEST
+// Last Modified: Di. 28 Juli 2026 01:41:32 CEST
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11
@@ -9745,12 +9745,15 @@ class Tool_metweight : public HumTool {
 		void        processFile      (HumdrumFile& infile);
 		void        addCompositeSpine(HumdrumFile& infile);
 		void        getVoices        (std::vector<HTp>& voices, HumdrumFile& infile);
-		void        fillVoiceResults (std::vector<std::vector<std::string>>& results,
+		void        fillVoiceResults (std::vector<std::vector<int>>& results,
 		                             HumdrumFile& infile,
 		                             const std::vector<HTp>& voices);
-		std::string getWeightToken   (HumdrumFile& infile, int line, int track);
+		void        formatWeights    (std::vector<std::string>& tokens,
+		                             const std::vector<int>& weightClasses,
+		                             int format);
+		int         getTokenWeightClass(HumdrumFile& infile, int line, int track);
 		HTp         getMeterToken    (HumdrumFile& infile, int line);
-		std::string formatWeightClass(int weightClass);
+		std::string formatWeightClass(int weightClass, int format);
 		int         getWeightClass   (int top, int bot, HumNum beat);
 
 		// Metric weight classes (in order from strongest to weakest):
@@ -9761,13 +9764,22 @@ class Tool_metweight : public HumTool {
 			WEIGHT_UNCLASSIFIED = 4
 		};
 
+		// Token representations of a weight class (see formatWeightClass):
+		enum {
+			FORMAT_ABBREVIATION, // abbreviations: s/hs/w/u (default)
+			FORMAT_FULL,         // -f option: strong/half-strong/weak/unclassified
+			FORMAT_INTEGER,      // -i option: the weight class values 1/2/3/4
+			FORMAT_COLOR         // -c option: a color for each weight class
+		};
+
 	private:
 		bool m_fullQ      = false; // -f option: print full text labels instead of abbreviations
 		bool m_integerQ   = false; // -i option: print integer rank labels instead of abbreviations
 		bool m_cdataQ     = false; // -x option: label the spine **cdata-metweight instead of **metweight
 		bool m_nullQ      = false; // -n option: always use the null token . for unclassified positions
 		bool m_tiedQ      = false; // -t option: label secondary tied notes instead of giving them the null token .
-		bool m_compositeQ = false; // -c option: add a **kern-comp spine below the voices and label only that spine
+		bool m_compositeQ = false; // -C option: add a **kern-comp spine below the voices and label only that spine
+		bool m_colorQ     = false; // -c option: add a **color spine after each **metweight spine
 
 		std::string       m_kernTracks  = ""; // used with -k option
 		std::string       m_spineTracks = ""; // used with -s option

--- a/src/tool-filter.cpp
+++ b/src/tool-filter.cpp
@@ -62,6 +62,7 @@
 #include "tool-mens2kern.h"
 #include "tool-meter.h"
 #include "tool-metlev.h"
+#include "tool-metweight.h"
 #include "tool-mint.h"
 #include "tool-modori.h"
 #include "tool-msearch.h"
@@ -335,6 +336,8 @@ bool Tool_filter::run(HumdrumFileSet& infiles) {
 			RUNTOOL(meter, infile, commands[i].second, status);
 		} else if (commands[i].first == "metlev") {
 			RUNTOOL(metlev, infile, commands[i].second, status);
+		} else if (commands[i].first == "metweight") {
+			RUNTOOL(metweight, infile, commands[i].second, status);
 		} else if (commands[i].first == "mint") { // humlib version of Humdrum Toolkit mint tool
 			RUNTOOL(mint, infile, commands[i].second, status);
 		} else if (commands[i].first == "mintx") { // humlib cli name

--- a/src/tool-metweight.cpp
+++ b/src/tool-metweight.cpp
@@ -199,7 +199,8 @@ void Tool_metweight::fillVoiceResults(vector<vector<string>>& results, HumdrumFi
 //
 // Tool_metweight::getWeightToken -- Metric weight token for the track's
 //    **kern token on this line, using the position Tool_meter annotated.
-//    Null tokens return "."; non-attacks/unrecognized meters return WEIGHT_NONE.
+//    Null tokens return "."; non-attacks/unrecognized meters return
+//    WEIGHT_UNCLASSIFIED.
 //
 
 string Tool_metweight::getWeightToken(HumdrumFile& infile, int line, int track) {
@@ -220,7 +221,7 @@ string Tool_metweight::getWeightToken(HumdrumFile& infile, int line, int track) 
 	}
 
 	if (!token->getValueBool("auto", "hasData")) {
-		return formatWeightClass(WEIGHT_NONE);
+		return formatWeightClass(WEIGHT_UNCLASSIFIED);
 	}
 
 	int top = token->getValueInt("auto", "numerator");
@@ -256,7 +257,7 @@ int Tool_metweight::getWeightClass(int top, int bot, HumNum beat) {
 	// a negative position (should not normally happen, but would break
 	// the arithmetic below if it did).
 	if ((top <= 0) || (bot <= 0) || (beat < 0)) {
-		return WEIGHT_NONE;
+		return WEIGHT_UNCLASSIFIED;
 	}
 
 	// How many main beats does this measure have, and is the meter
@@ -274,7 +275,7 @@ int Tool_metweight::getWeightClass(int top, int bot, HumNum beat) {
 	if (mainBeatCount <= 0) {
 		// Defensive: cannot happen for a valid time signature (top > 0),
 		// but avoids a divide-by-zero-flavored mainBeatCount/2 below.
-		return WEIGHT_NONE;
+		return WEIGHT_UNCLASSIFIED;
 	}
 
 	// Split "beat" (e.g. 4/3 for the second eighth note of the second
@@ -303,7 +304,7 @@ int Tool_metweight::getWeightClass(int top, int bot, HumNum beat) {
 		// mainBeatIndex >= mainBeatCount would mean the position is at or
 		// past the end of the measure; not expected in practice, but
 		// left unclassified rather than guessing a weight for it.
-		return WEIGHT_NONE;
+		return WEIGHT_UNCLASSIFIED;
 	}
 
 	// A position between main beats (nonzero fraction, some subdivision
@@ -319,7 +320,7 @@ int Tool_metweight::getWeightClass(int top, int bot, HumNum beat) {
 	// subdivisions of 9/8 or 12/8, sixteenth notes and other deeper
 	// subdivisions, syncopated offbeats): not a notated counting position
 	// of this meter, so it is left unclassified.
-	return WEIGHT_NONE;
+	return WEIGHT_UNCLASSIFIED;
 }
 
 
@@ -333,7 +334,7 @@ int Tool_metweight::getWeightClass(int top, int bot, HumNum beat) {
 //
 
 string Tool_metweight::formatWeightClass(int weightClass) {
-	if (m_nullQ && (weightClass == WEIGHT_NONE)) {
+	if (m_nullQ && (weightClass == WEIGHT_UNCLASSIFIED)) {
 		return ".";
 	}
 	if (m_integerQ) {
@@ -348,14 +349,14 @@ string Tool_metweight::formatWeightClass(int weightClass) {
 			case WEIGHT_STRONG:      return "strong";
 			case WEIGHT_HALF_STRONG: return "half-strong";
 			case WEIGHT_WEAK:        return "weak";
-			default:                 return "none";
+			default:                 return "unclassified";
 		}
 	} else {
 		switch (weightClass) {
 			case WEIGHT_STRONG:      return "s";
 			case WEIGHT_HALF_STRONG: return "hs";
 			case WEIGHT_WEAK:        return "w";
-			default:                 return "n";
+			default:                 return "u";
 		}
 	}
 }

--- a/src/tool-metweight.cpp
+++ b/src/tool-metweight.cpp
@@ -28,8 +28,8 @@ namespace hum {
 //
 
 Tool_metweight::Tool_metweight(void) {
-	define("f|full=b",         "print full text labels (strong/half-strong/weak) instead of abbreviations");
-	define("i|integer=b",      "print integer rank labels (1/2/3) instead of abbreviations");
+	define("f|full=b",         "print full text labels (strong/half-strong/weak/unclassified) instead of abbreviations");
+	define("i|integer=b",      "print integer rank labels (1/2/3/4) instead of abbreviations");
 	define("x|cdata=b",        "label the spine **cdata-metweight instead of **metweight");
 	define("k|kern-tracks=s",  "process only the specified kern spines");
 	define("s|spine|spines=s", "process only the specified spines");

--- a/src/tool-metweight.cpp
+++ b/src/tool-metweight.cpp
@@ -152,11 +152,13 @@ void Tool_metweight::processFile(HumdrumFile& infile) {
 	vector<vector<string>> results;
 	fillVoiceResults(results, infile, voices);
 
+	// Insert each voice's spine right after its own track, processing from
+	// last to first so that earlier (not-yet-processed) voices' track
+	// numbers are not shifted by a later insertion.
 	string exinterp = m_cdataQ ? "**cdata-metweight" : "**metweight";
-	infile.appendDataSpine(results.back(), ".", exinterp);
-	for (int i = (int)voices.size() - 1; i > 0; i--) {
+	for (int i = (int)voices.size() - 1; i >= 0; i--) {
 		int track = voices[i]->getTrack();
-		infile.insertDataSpineBefore(track, results[i - 1], ".", exinterp);
+		infile.insertDataSpineAfter(track, results[i], ".", exinterp);
 	}
 	infile.createLinesFromTokens();
 

--- a/src/tool-metweight.cpp
+++ b/src/tool-metweight.cpp
@@ -1,0 +1,323 @@
+//
+// Programmer:    Wolfgang Drescher <drescher.wolfgang@gmail.com>
+// Creation Date: Thu Jul 16 2026
+// Filename:      tool-metweight.cpp
+// URL:           https://github.com/craigsapp/humlib/blob/master/src/tool-metweight.cpp
+// Syntax:        C++11; humlib
+// vim:           syntax=cpp ts=3 noexpandtab nowrap
+//
+// Description:   Label the metric weight (strong/half-strong/weak) of note
+//                and rest attacks in **kern spines, derived algorithmically
+//                from the time signature (see getWeightClass).
+//
+
+#include "tool-metweight.h"
+#include "tool-meter.h"
+#include "Convert.h"
+
+using namespace std;
+
+namespace hum {
+
+// START_MERGE
+
+
+//////////////////////////////
+//
+// Tool_metweight::Tool_metweight -- Set the recognized options for the tool.
+//
+
+Tool_metweight::Tool_metweight(void) {
+	define("f|full=b",         "print full text labels (strong/half-strong/weak) instead of abbreviations");
+	define("i|integer=b",      "print integer rank labels (1/2/3) instead of abbreviations");
+	define("x|cdata=b",        "label the spine **cdata-metweight instead of **metweight");
+	define("k|kern-tracks=s",  "process only the specified kern spines");
+	define("s|spine|spines=s", "process only the specified spines");
+}
+
+
+
+//////////////////////////////
+//
+// Tool_metweight::run -- Do the main work of the tool.
+//
+
+bool Tool_metweight::run(HumdrumFileSet& infiles) {
+	bool status = true;
+	for (int i = 0; i < infiles.getCount(); i++) {
+		status &= run(infiles[i]);
+	}
+	return status;
+}
+
+bool Tool_metweight::run(const string& indata, ostream& out) {
+	HumdrumFile infile(indata);
+	bool status = run(infile);
+	if (hasAnyText()) {
+		getAllText(out);
+	} else {
+		out << infile;
+	}
+	return status;
+}
+
+bool Tool_metweight::run(HumdrumFile& infile, ostream& out) {
+	bool status = run(infile);
+	if (hasAnyText()) {
+		getAllText(out);
+	} else {
+		out << infile;
+	}
+	return status;
+}
+
+bool Tool_metweight::run(HumdrumFile& infile) {
+	initialize();
+	processFile(infile);
+	return true;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_metweight::initialize --
+//
+
+void Tool_metweight::initialize(void) {
+	m_fullQ    = getBoolean("full");
+	m_integerQ = getBoolean("integer");
+	m_cdataQ   = getBoolean("cdata");
+
+	if (getBoolean("spine")) {
+		m_spineTracks = getString("spine");
+	} else if (getBoolean("kern-tracks")) {
+		m_kernTracks = getString("kern-tracks");
+	}
+}
+
+
+
+//////////////////////////////
+//
+// Tool_metweight::processFile -- Insert a **metweight spine after every
+//    processed **kern spine, containing the metric weight of the current
+//    note/rest attack.
+//
+
+void Tool_metweight::processFile(HumdrumFile& infile) {
+	int maxTrack = infile.getMaxTrack();
+
+	m_selectedKernSpines.resize(maxTrack + 1); // +1 since track=0 is not used
+	fill(m_selectedKernSpines.begin(), m_selectedKernSpines.end(), true);
+
+	vector<HTp> kernspines = infile.getKernSpineStartList();
+
+	// Calculate which input spines to process based on -k or -s option:
+	if (!m_kernTracks.empty()) {
+		vector<int> ktracks = Convert::extractIntegerList(m_kernTracks, maxTrack);
+		fill(m_selectedKernSpines.begin(), m_selectedKernSpines.end(), false);
+		for (int i = 0; i < (int)ktracks.size(); i++) {
+			int index = ktracks[i] - 1;
+			if ((index < 0) || (index >= (int)kernspines.size())) {
+				continue;
+			}
+			int track = kernspines.at(index)->getTrack();
+			m_selectedKernSpines.at(track) = true;
+		}
+	} else if (!m_spineTracks.empty()) {
+		fill(m_selectedKernSpines.begin(), m_selectedKernSpines.end(), false);
+		infile.makeBooleanTrackList(m_selectedKernSpines, m_spineTracks);
+	}
+
+	vector<HTp> voices;
+	for (int i = 0; i < (int)kernspines.size(); i++) {
+		if (m_selectedKernSpines.at(kernspines[i]->getTrack())) {
+			voices.push_back(kernspines[i]);
+		}
+	}
+	if (voices.empty()) {
+		return;
+	}
+
+	// Delegate time-signature/beat-position analysis (including pickup
+	// measures) to the meter tool, which annotates each **kern attack
+	// with "auto" parameters read back out below; "-r" also covers rests.
+	Tool_meter meterTool;
+	meterTool.process("-r");
+	meterTool.run(infile);
+
+	vector<vector<string>> results;
+	fillVoiceResults(results, infile, voices);
+
+	string exinterp = m_cdataQ ? "**cdata-metweight" : "**metweight";
+	infile.appendDataSpine(results.back(), ".", exinterp);
+	for (int i = (int)voices.size() - 1; i > 0; i--) {
+		int track = voices[i]->getTrack();
+		infile.insertDataSpineBefore(track, results[i - 1], ".", exinterp);
+	}
+	infile.createLinesFromTokens();
+
+	// Enable usage in verovio (`!!!filter: metweight`)
+	m_humdrum_text << infile;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_metweight::fillVoiceResults -- Calculate the **metweight tokens for
+//    each selected **kern spine, one value per line, for
+//    appendDataSpine()/insertDataSpineBefore() to consume.
+//
+
+void Tool_metweight::fillVoiceResults(vector<vector<string>>& results, HumdrumFile& infile,
+		const vector<HTp>& voices) {
+
+	int lineCount = infile.getLineCount();
+	results.clear();
+	results.resize(voices.size());
+	for (int v = 0; v < (int)voices.size(); v++) {
+		results[v].resize(lineCount, ".");
+	}
+
+	for (int i = 0; i < lineCount; i++) {
+		if (!infile[i].isData()) {
+			continue;
+		}
+		for (int v = 0; v < (int)voices.size(); v++) {
+			results[v][i] = getWeightToken(infile, i, voices[v]->getTrack());
+		}
+	}
+}
+
+
+
+//////////////////////////////
+//
+// Tool_metweight::getWeightToken -- Metric weight token for the track's
+//    **kern token on this line, using the position Tool_meter annotated.
+//    Null tokens return "."; non-attacks/unrecognized meters return WEIGHT_NONE.
+//
+
+string Tool_metweight::getWeightToken(HumdrumFile& infile, int line, int track) {
+	HTp token = NULL;
+	for (int j = 0; j < infile[line].getFieldCount(); j++) {
+		HTp tok = infile.token(line, j);
+		if (tok->getTrack() == track) {
+			token = tok;
+			break;
+		}
+	}
+	if (!token) {
+		return ".";
+	}
+
+	if (token->isNull()) {
+		return ".";
+	}
+
+	if (!token->getValueBool("auto", "hasData")) {
+		return formatWeightClass(WEIGHT_NONE);
+	}
+
+	int top = token->getValueInt("auto", "numerator");
+	int bot = token->getValueInt("auto", "denominator");
+	HumNum beat(token->getValue("auto", "zeroBeat"));
+
+	return formatWeightClass(getWeightClass(top, bot, beat));
+}
+
+
+
+//////////////////////////////
+//
+// Tool_metweight::getWeightClass -- Derive the metric weight of a
+//    0-indexed beat position (Tool_meter's "zeroBeat" units) from the time
+//    signature by bisecting the measure's main beats: the downbeat is
+//    strong; if there is an even number of main beats, the one starting
+//    the second half is half-strong; every other main beat is weak.  A
+//    compound meter with exactly 2 main beats (6/8) also classifies its
+//    eighth-note subdivisions as weak, since those are themselves counted;
+//    everything else (a simple beat's "and", 9/8's/12/8's subdivisions,
+//    deeper subdivisions, syncopated offbeats) is left unclassified.
+//
+
+int Tool_metweight::getWeightClass(int top, int bot, HumNum beat) {
+	if ((top <= 0) || (bot <= 0) || (beat < 0)) {
+		return WEIGHT_NONE;
+	}
+
+	int multiple = top / 3;
+	int remainder = top % 3;
+	bool compound = (bot >= 8) && (multiple > 1) && (remainder == 0);
+
+	int mainBeatCount = compound ? multiple : top;
+	if (mainBeatCount <= 0) {
+		return WEIGHT_NONE;
+	}
+
+	int mainBeatIndex = beat.getInteger();
+	HumNum fraction = beat - HumNum(mainBeatIndex);
+
+	if (fraction == 0) {
+		if (mainBeatIndex == 0) {
+			return WEIGHT_STRONG;
+		}
+		if (((mainBeatCount % 2) == 0) && (mainBeatIndex == mainBeatCount / 2)) {
+			return WEIGHT_HALF_STRONG;
+		}
+		if (mainBeatIndex < mainBeatCount) {
+			return WEIGHT_WEAK;
+		}
+		return WEIGHT_NONE;
+	}
+
+	// Only a compound meter with exactly 2 main beats (6/8) classifies its
+	// eighth-note subdivisions as weak; 9/8, 12/8, etc. are felt/conducted
+	// at the main-beat level only, so their subdivisions stay unclassified.
+	if (compound && (mainBeatCount == 2) && ((fraction == HumNum(1, 3)) || (fraction == HumNum(2, 3)))) {
+		return WEIGHT_WEAK;
+	}
+
+	return WEIGHT_NONE;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_metweight::formatWeightClass -- Convert a weight class into the
+//    token representation selected by the -f/-i options (abbreviated
+//    strong/half-strong/weak codes by default).
+//
+
+string Tool_metweight::formatWeightClass(int weightClass) {
+	if (m_integerQ) {
+		switch (weightClass) {
+			case WEIGHT_STRONG:      return "1";
+			case WEIGHT_HALF_STRONG: return "2";
+			case WEIGHT_WEAK:        return "3";
+			default:                 return ".";
+		}
+	} else if (m_fullQ) {
+		switch (weightClass) {
+			case WEIGHT_STRONG:      return "strong";
+			case WEIGHT_HALF_STRONG: return "half-strong";
+			case WEIGHT_WEAK:        return "weak";
+			default:                 return ".";
+		}
+	} else {
+		switch (weightClass) {
+			case WEIGHT_STRONG:      return "s";
+			case WEIGHT_HALF_STRONG: return "hs";
+			case WEIGHT_WEAK:        return "w";
+			default:                 return ".";
+		}
+	}
+}
+
+
+// END_MERGE
+
+} // end namespace hum

--- a/src/tool-metweight.cpp
+++ b/src/tool-metweight.cpp
@@ -33,6 +33,7 @@ Tool_metweight::Tool_metweight(void) {
 	define("x|cdata=b",        "label the spine **cdata-metweight instead of **metweight");
 	define("k|kern-tracks=s",  "process only the specified kern spines");
 	define("s|spine|spines=s", "process only the specified spines");
+	define("n|null=b",         "always use the null token . for unclassified positions");
 }
 
 
@@ -88,6 +89,7 @@ void Tool_metweight::initialize(void) {
 	m_fullQ    = getBoolean("full");
 	m_integerQ = getBoolean("integer");
 	m_cdataQ   = getBoolean("cdata");
+	m_nullQ    = getBoolean("null");
 
 	if (getBoolean("spine")) {
 		m_spineTracks = getString("spine");
@@ -289,10 +291,14 @@ int Tool_metweight::getWeightClass(int top, int bot, HumNum beat) {
 //
 // Tool_metweight::formatWeightClass -- Convert a weight class into the
 //    token representation selected by the -f/-i options (abbreviated
-//    strong/half-strong/weak codes by default).
+//    strong/half-strong/weak codes by default); -n forces the null
+//    token "." for unclassified positions in all three modes.
 //
 
 string Tool_metweight::formatWeightClass(int weightClass) {
+	if (m_nullQ && (weightClass == WEIGHT_NONE)) {
+		return ".";
+	}
 	if (m_integerQ) {
 		switch (weightClass) {
 			case WEIGHT_STRONG:      return "1";

--- a/src/tool-metweight.cpp
+++ b/src/tool-metweight.cpp
@@ -338,12 +338,7 @@ string Tool_metweight::formatWeightClass(int weightClass) {
 		return ".";
 	}
 	if (m_integerQ) {
-		switch (weightClass) {
-			case WEIGHT_STRONG:      return "1";
-			case WEIGHT_HALF_STRONG: return "2";
-			case WEIGHT_WEAK:        return "3";
-			default:                 return "4";
-		}
+		return to_string(weightClass);
 	} else if (m_fullQ) {
 		switch (weightClass) {
 			case WEIGHT_STRONG:      return "strong";

--- a/src/tool-metweight.cpp
+++ b/src/tool-metweight.cpp
@@ -234,54 +234,91 @@ string Tool_metweight::getWeightToken(HumdrumFile& infile, int line, int track) 
 
 //////////////////////////////
 //
-// Tool_metweight::getWeightClass -- Derive the metric weight of a
-//    0-indexed beat position (Tool_meter's "zeroBeat" units) from the time
-//    signature by bisecting the measure's main beats: the downbeat is
-//    strong; if there is an even number of main beats, the one starting
-//    the second half is half-strong; every other main beat is weak.  A
-//    compound meter with exactly 2 main beats (6/8) also classifies its
-//    eighth-note subdivisions as weak, since those are themselves counted;
-//    everything else (a simple beat's "and", 9/8's/12/8's subdivisions,
-//    deeper subdivisions, syncopated offbeats) is left unclassified.
+// Tool_metweight::getWeightClass -- Derive the metric weight
+//    (strong/half-strong/weak/unclassified) of a beat position from the
+//    time signature.  "beat" is Tool_meter's "zeroBeat": a 0-indexed
+//    count of main beats (quarter note in 4/4, dotted quarter in 6/8)
+//    from the start of the measure; a fractional beat (e.g. 1/3) is a
+//    subdivision within a beat.
+//
+//    Algorithm: split "beat" into a whole main-beat index and a leftover
+//    fraction.  Fraction 0 is a main beat: index 0 is strong, the beat
+//    starting the second half of the measure (only if mainBeatCount is
+//    even) is half-strong, every other main beat is weak.  A nonzero
+//    fraction is only classified (weak) for a compound meter with
+//    exactly 2 main beats (6/8), at its second/third eighth note
+//    (fraction 1/3 or 2/3); everything else is left unclassified.
 //
 
 int Tool_metweight::getWeightClass(int top, int bot, HumNum beat) {
+	// Guard against an unset/unrecognized time signature (top or bot not
+	// yet known, e.g. before the first *M interpretation in the file) or
+	// a negative position (should not normally happen, but would break
+	// the arithmetic below if it did).
 	if ((top <= 0) || (bot <= 0) || (beat < 0)) {
 		return WEIGHT_NONE;
 	}
 
+	// How many main beats does this measure have, and is the meter
+	// compound (does each main beat itself split into three)?  "multiple"
+	// and "remainder" are just top divided/modulo 3, reused below to
+	// test "is top a multiple of 3 that is greater than 3".
 	int multiple = top / 3;
 	int remainder = top % 3;
 	bool compound = (bot >= 8) && (multiple > 1) && (remainder == 0);
 
+	// Compound: 3 eighth notes per main beat, so top/3 main beats
+	// (6/8 -> 2, 9/8 -> 3, 12/8 -> 4).  Simple: one main beat per counted
+	// unit, so top main beats (4/4 -> 4, 3/4 -> 3, 6/4 -> 6).
 	int mainBeatCount = compound ? multiple : top;
 	if (mainBeatCount <= 0) {
+		// Defensive: cannot happen for a valid time signature (top > 0),
+		// but avoids a divide-by-zero-flavored mainBeatCount/2 below.
 		return WEIGHT_NONE;
 	}
 
+	// Split "beat" (e.g. 4/3 for the second eighth note of the second
+	// compound beat) into its whole main-beat index (1) and the
+	// fraction of a beat left over (1/3).
 	int mainBeatIndex = beat.getInteger();
 	HumNum fraction = beat - HumNum(mainBeatIndex);
 
+	// A main-beat position (no leftover fraction):
 	if (fraction == 0) {
 		if (mainBeatIndex == 0) {
+			// The downbeat: always the strongest position of the measure.
 			return WEIGHT_STRONG;
 		}
 		if (((mainBeatCount % 2) == 0) && (mainBeatIndex == mainBeatCount / 2)) {
+			// Exactly the main beat that starts the second half of the
+			// measure (only exists when there is an even number of main
+			// beats): the secondary/half-strong accent.
 			return WEIGHT_HALF_STRONG;
 		}
 		if (mainBeatIndex < mainBeatCount) {
+			// Any other in-range main beat: weak (e.g. beats 2 and 4 of
+			// a 4/4 measure).
 			return WEIGHT_WEAK;
 		}
+		// mainBeatIndex >= mainBeatCount would mean the position is at or
+		// past the end of the measure; not expected in practice, but
+		// left unclassified rather than guessing a weight for it.
 		return WEIGHT_NONE;
 	}
 
-	// Only a compound meter with exactly 2 main beats (6/8) classifies its
-	// eighth-note subdivisions as weak; 9/8, 12/8, etc. are felt/conducted
-	// at the main-beat level only, so their subdivisions stay unclassified.
+	// A position between main beats (nonzero fraction, some subdivision
+	// or syncopated offset).  Only give this a weight in the one case
+	// where the subdivision is itself a genuinely counted part of the
+	// meter: a compound meter with exactly 2 main beats (6/8), at the
+	// second or third eighth note of a beat (fraction 1/3 or 2/3).
 	if (compound && (mainBeatCount == 2) && ((fraction == HumNum(1, 3)) || (fraction == HumNum(2, 3)))) {
 		return WEIGHT_WEAK;
 	}
 
+	// Everything else (a simple meter's "and" of the beat, the eighth-note
+	// subdivisions of 9/8 or 12/8, sixteenth notes and other deeper
+	// subdivisions, syncopated offbeats): not a notated counting position
+	// of this meter, so it is left unclassified.
 	return WEIGHT_NONE;
 }
 

--- a/src/tool-metweight.cpp
+++ b/src/tool-metweight.cpp
@@ -298,21 +298,21 @@ string Tool_metweight::formatWeightClass(int weightClass) {
 			case WEIGHT_STRONG:      return "1";
 			case WEIGHT_HALF_STRONG: return "2";
 			case WEIGHT_WEAK:        return "3";
-			default:                 return ".";
+			default:                 return "4";
 		}
 	} else if (m_fullQ) {
 		switch (weightClass) {
 			case WEIGHT_STRONG:      return "strong";
 			case WEIGHT_HALF_STRONG: return "half-strong";
 			case WEIGHT_WEAK:        return "weak";
-			default:                 return ".";
+			default:                 return "none";
 		}
 	} else {
 		switch (weightClass) {
 			case WEIGHT_STRONG:      return "s";
 			case WEIGHT_HALF_STRONG: return "hs";
 			case WEIGHT_WEAK:        return "w";
-			default:                 return ".";
+			default:                 return "n";
 		}
 	}
 }

--- a/src/tool-metweight.cpp
+++ b/src/tool-metweight.cpp
@@ -34,6 +34,7 @@ Tool_metweight::Tool_metweight(void) {
 	define("k|kern-tracks=s",  "process only the specified kern spines");
 	define("s|spine|spines=s", "process only the specified spines");
 	define("n|null=b",         "always use the null token . for unclassified positions");
+	define("t|tied=b",         "label secondary tied notes instead of giving them the null token .");
 }
 
 
@@ -90,6 +91,7 @@ void Tool_metweight::initialize(void) {
 	m_integerQ = getBoolean("integer");
 	m_cdataQ   = getBoolean("cdata");
 	m_nullQ    = getBoolean("null");
+	m_tiedQ    = getBoolean("tied");
 
 	if (getBoolean("spine")) {
 		m_spineTracks = getString("spine");
@@ -219,6 +221,12 @@ string Tool_metweight::getWeightToken(HumdrumFile& infile, int line, int track) 
 	}
 
 	if (token->isNull()) {
+		return ".";
+	}
+
+	if (!m_tiedQ && token->isSecondaryTiedNote()) {
+		// The continuation of a tie is not a new attack, so it has no
+		// metric weight of its own (-t restores labeling it anyway).
 		return ".";
 	}
 

--- a/src/tool-metweight.cpp
+++ b/src/tool-metweight.cpp
@@ -38,7 +38,8 @@ Tool_metweight::Tool_metweight(void) {
 	define("s|spine|spines=s", "process only the specified spines");
 	define("n|null=b",         "always use the null token . for unclassified positions");
 	define("t|tied=b",         "label secondary tied notes instead of giving them the null token .");
-	define("c|composite=b",    "add a **kern-comp spine (composite rhythm of all voices) below the voices and label only that spine");
+	define("c|color=b",        "add a **color spine with a color for each weight class after every **metweight spine");
+	define("C|composite=b",    "add a **kern-comp spine (composite rhythm of all voices) below the voices and label only that spine");
 }
 
 
@@ -96,6 +97,7 @@ void Tool_metweight::initialize(void) {
 	m_cdataQ     = getBoolean("cdata");
 	m_nullQ      = getBoolean("null");
 	m_tiedQ      = getBoolean("tied");
+	m_colorQ     = getBoolean("color");
 	m_compositeQ = getBoolean("composite");
 
 	if (getBoolean("spine")) {
@@ -111,7 +113,7 @@ void Tool_metweight::initialize(void) {
 //
 // Tool_metweight::processFile -- Insert a **metweight spine after every
 //    processed **kern spine, containing the metric weight of the current
-//    note/rest attack.  With -c only a composite spine is added below the
+//    note/rest attack.  With -C only a composite spine is added below the
 //    voices, and only that spine gets a **metweight spine.
 //
 
@@ -135,16 +137,31 @@ void Tool_metweight::processFile(HumdrumFile& infile) {
 	meterTool.process("-r");
 	meterTool.run(infile);
 
-	vector<vector<string>> results;
+	vector<vector<int>> results;
 	fillVoiceResults(results, infile, voices);
+
+	int format = FORMAT_ABBREVIATION;
+	if (m_integerQ) {
+		format = FORMAT_INTEGER;
+	} else if (m_fullQ) {
+		format = FORMAT_FULL;
+	}
 
 	// Insert each voice's spine right after its own track, processing from
 	// last to first so that earlier (not-yet-processed) voices' track
 	// numbers are not shifted by a later insertion.
 	string exinterp = m_cdataQ ? "**cdata-metweight" : "**metweight";
+	vector<string> tokens;
 	for (int i = (int)voices.size() - 1; i >= 0; i--) {
 		int track = voices[i]->getTrack();
-		infile.insertDataSpineAfter(track, results[i], ".", exinterp);
+		if (m_colorQ) {
+			// Inserted first so that the **metweight spine inserted below
+			// ends up between the voice and its **color spine.
+			formatWeights(tokens, results[i], FORMAT_COLOR);
+			infile.insertDataSpineAfter(track, tokens, ".", "**color");
+		}
+		formatWeights(tokens, results[i], format);
+		infile.insertDataSpineAfter(track, tokens, ".", exinterp);
 	}
 	infile.createLinesFromTokens();
 
@@ -156,7 +173,7 @@ void Tool_metweight::processFile(HumdrumFile& infile) {
 
 //////////////////////////////
 //
-// Tool_metweight::addCompositeSpine -- -c option: replace the input with the
+// Tool_metweight::addCompositeSpine -- -C option: replace the input with the
 //    output of the composite tool, which adds a **kern-comp spine (the merged
 //    rhythm of all voices) below the existing voices.  Without "-a" the
 //    composite spine is prepended, which places it below the input voices in
@@ -179,7 +196,7 @@ void Tool_metweight::addCompositeSpine(HumdrumFile& infile) {
 
 //////////////////////////////
 //
-// Tool_metweight::getVoices -- The spines to label: with -c only the
+// Tool_metweight::getVoices -- The spines to label: with -C only the
 //    composite spine, otherwise the **kern spines selected by -k or -s (all
 //    of them when neither option is given).  The composite rhythm is always
 //    built from all **kern spines, so -k/-s do not apply in that mode.
@@ -233,19 +250,20 @@ void Tool_metweight::getVoices(vector<HTp>& voices, HumdrumFile& infile) {
 
 //////////////////////////////
 //
-// Tool_metweight::fillVoiceResults -- Calculate the **metweight tokens for
-//    each selected **kern spine, one value per line, for
-//    appendDataSpine()/insertDataSpineBefore() to consume.
+// Tool_metweight::fillVoiceResults -- Calculate the metric weight class of
+//    each selected **kern spine, one value per line.  Lines without a weight
+//    (non-data lines, null tokens, tie continuations) get 0, which is not a
+//    weight class; formatWeights() turns the classes into spine tokens.
 //
 
-void Tool_metweight::fillVoiceResults(vector<vector<string>>& results, HumdrumFile& infile,
+void Tool_metweight::fillVoiceResults(vector<vector<int>>& results, HumdrumFile& infile,
 		const vector<HTp>& voices) {
 
 	int lineCount = infile.getLineCount();
 	results.clear();
 	results.resize(voices.size());
 	for (int v = 0; v < (int)voices.size(); v++) {
-		results[v].resize(lineCount, ".");
+		results[v].resize(lineCount, 0);
 	}
 
 	for (int i = 0; i < lineCount; i++) {
@@ -253,7 +271,7 @@ void Tool_metweight::fillVoiceResults(vector<vector<string>>& results, HumdrumFi
 			continue;
 		}
 		for (int v = 0; v < (int)voices.size(); v++) {
-			results[v][i] = getWeightToken(infile, i, voices[v]->getTrack());
+			results[v][i] = getTokenWeightClass(infile, i, voices[v]->getTrack());
 		}
 	}
 }
@@ -262,13 +280,41 @@ void Tool_metweight::fillVoiceResults(vector<vector<string>>& results, HumdrumFi
 
 //////////////////////////////
 //
-// Tool_metweight::getWeightToken -- Metric weight token for the track's
-//    **kern token on this line, using the position Tool_meter annotated.
-//    Null tokens return "."; non-attacks/unrecognized meters return
-//    WEIGHT_UNCLASSIFIED.
+// Tool_metweight::formatWeights -- Convert a voice's weight classes into the
+//    tokens of one data spine.  Positions without a weight get the null
+//    token ".", and so do unclassified positions when -n is given -- except
+//    in the **color spine, where a null token would make a note keep the
+//    color of the previous one instead of leaving it uncolored.
 //
 
-string Tool_metweight::getWeightToken(HumdrumFile& infile, int line, int track) {
+void Tool_metweight::formatWeights(vector<string>& tokens, const vector<int>& weightClasses,
+		int format) {
+
+	bool nullUnclassifiedQ = m_nullQ && (format != FORMAT_COLOR);
+
+	tokens.clear();
+	tokens.resize(weightClasses.size());
+	for (int i = 0; i < (int)weightClasses.size(); i++) {
+		int weightClass = weightClasses[i];
+		if ((weightClass == 0) || (nullUnclassifiedQ && (weightClass == WEIGHT_UNCLASSIFIED))) {
+			tokens[i] = ".";
+		} else {
+			tokens[i] = formatWeightClass(weightClass, format);
+		}
+	}
+}
+
+
+
+//////////////////////////////
+//
+// Tool_metweight::getTokenWeightClass -- Metric weight class of the track's
+//    **kern token on this line, using the position Tool_meter annotated.
+//    Null tokens and tie continuations have no weight at all (0);
+//    non-attacks/unrecognized meters are WEIGHT_UNCLASSIFIED.
+//
+
+int Tool_metweight::getTokenWeightClass(HumdrumFile& infile, int line, int track) {
 	HTp token = NULL;
 	for (int j = 0; j < infile[line].getFieldCount(); j++) {
 		HTp tok = infile.token(line, j);
@@ -278,11 +324,11 @@ string Tool_metweight::getWeightToken(HumdrumFile& infile, int line, int track) 
 		}
 	}
 	if (!token) {
-		return ".";
+		return 0;
 	}
 
 	if (token->isNull()) {
-		return ".";
+		return 0;
 	}
 
 	// The continuation of a tie is not a new attack, so it has no metric
@@ -290,7 +336,7 @@ string Tool_metweight::getWeightToken(HumdrumFile& infile, int line, int track) 
 	// isSecondaryTiedNote() only accepts plain **kern, so test the token
 	// text directly to cover **kern-comp spines as well.
 	if (!m_tiedQ && Convert::isKernSecondaryTiedNote(*token)) {
-		return ".";
+		return 0;
 	}
 
 	HTp position = token;
@@ -302,14 +348,14 @@ string Tool_metweight::getWeightToken(HumdrumFile& infile, int line, int track) 
 		position = getMeterToken(infile, line);
 	}
 	if (!position || !position->getValueBool("auto", "hasData")) {
-		return formatWeightClass(WEIGHT_UNCLASSIFIED);
+		return WEIGHT_UNCLASSIFIED;
 	}
 
 	int top = position->getValueInt("auto", "numerator");
 	int bot = position->getValueInt("auto", "denominator");
 	HumNum beat(position->getValue("auto", "zeroBeat"));
 
-	return formatWeightClass(getWeightClass(top, bot, beat));
+	return getWeightClass(top, bot, beat);
 }
 
 
@@ -427,32 +473,41 @@ int Tool_metweight::getWeightClass(int top, int bot, HumNum beat) {
 
 //////////////////////////////
 //
-// Tool_metweight::formatWeightClass -- Convert a weight class into the
-//    token representation selected by the -f/-i options (abbreviated
-//    strong/half-strong/weak codes by default); -n forces the null
-//    token "." for unclassified positions in all three modes.
+// Tool_metweight::formatWeightClass -- Convert a weight class into one of
+//    its token representations: the abbreviations used by the **metweight
+//    spine by default, the full labels of -f, the integer ranks of -i, or
+//    the colors of the **color spine added by -c.
 //
 
-string Tool_metweight::formatWeightClass(int weightClass) {
-	if (m_nullQ && (weightClass == WEIGHT_UNCLASSIFIED)) {
-		return ".";
-	}
-	if (m_integerQ) {
-		return to_string(weightClass);
-	} else if (m_fullQ) {
-		switch (weightClass) {
-			case WEIGHT_STRONG:      return "strong";
-			case WEIGHT_HALF_STRONG: return "half-strong";
-			case WEIGHT_WEAK:        return "weak";
-			default:                 return "unclassified";
-		}
-	} else {
-		switch (weightClass) {
-			case WEIGHT_STRONG:      return "s";
-			case WEIGHT_HALF_STRONG: return "hs";
-			case WEIGHT_WEAK:        return "w";
-			default:                 return "u";
-		}
+string Tool_metweight::formatWeightClass(int weightClass, int format) {
+	switch (format) {
+
+		case FORMAT_INTEGER:
+			return to_string(weightClass);
+
+		case FORMAT_FULL:
+			switch (weightClass) {
+				case WEIGHT_STRONG:      return "strong";
+				case WEIGHT_HALF_STRONG: return "half-strong";
+				case WEIGHT_WEAK:        return "weak";
+				default:                 return "unclassified";
+			}
+
+		case FORMAT_COLOR:
+			switch (weightClass) {
+				case WEIGHT_STRONG:      return "crimson";
+				case WEIGHT_HALF_STRONG: return "orange";
+				case WEIGHT_WEAK:        return "limegreen";
+				default:                 return "black";
+			}
+
+		default:
+			switch (weightClass) {
+				case WEIGHT_STRONG:      return "s";
+				case WEIGHT_HALF_STRONG: return "hs";
+				case WEIGHT_WEAK:        return "w";
+				default:                 return "u";
+			}
 	}
 }
 

--- a/src/tool-metweight.cpp
+++ b/src/tool-metweight.cpp
@@ -12,8 +12,11 @@
 //
 
 #include "tool-metweight.h"
+#include "tool-composite.h"
 #include "tool-meter.h"
 #include "Convert.h"
+
+#include <sstream>
 
 using namespace std;
 
@@ -35,6 +38,7 @@ Tool_metweight::Tool_metweight(void) {
 	define("s|spine|spines=s", "process only the specified spines");
 	define("n|null=b",         "always use the null token . for unclassified positions");
 	define("t|tied=b",         "label secondary tied notes instead of giving them the null token .");
+	define("c|composite=b",    "add a **kern-comp spine (composite rhythm of all voices) below the voices and label only that spine");
 }
 
 
@@ -87,11 +91,12 @@ bool Tool_metweight::run(HumdrumFile& infile) {
 //
 
 void Tool_metweight::initialize(void) {
-	m_fullQ    = getBoolean("full");
-	m_integerQ = getBoolean("integer");
-	m_cdataQ   = getBoolean("cdata");
-	m_nullQ    = getBoolean("null");
-	m_tiedQ    = getBoolean("tied");
+	m_fullQ      = getBoolean("full");
+	m_integerQ   = getBoolean("integer");
+	m_cdataQ     = getBoolean("cdata");
+	m_nullQ      = getBoolean("null");
+	m_tiedQ      = getBoolean("tied");
+	m_compositeQ = getBoolean("composite");
 
 	if (getBoolean("spine")) {
 		m_spineTracks = getString("spine");
@@ -106,41 +111,20 @@ void Tool_metweight::initialize(void) {
 //
 // Tool_metweight::processFile -- Insert a **metweight spine after every
 //    processed **kern spine, containing the metric weight of the current
-//    note/rest attack.
+//    note/rest attack.  With -c only a composite spine is added below the
+//    voices, and only that spine gets a **metweight spine.
 //
 
 void Tool_metweight::processFile(HumdrumFile& infile) {
-	int maxTrack = infile.getMaxTrack();
-
-	m_selectedKernSpines.resize(maxTrack + 1); // +1 since track=0 is not used
-	fill(m_selectedKernSpines.begin(), m_selectedKernSpines.end(), true);
-
-	vector<HTp> kernspines = infile.getKernSpineStartList();
-
-	// Calculate which input spines to process based on -k or -s option:
-	if (!m_kernTracks.empty()) {
-		vector<int> ktracks = Convert::extractIntegerList(m_kernTracks, maxTrack);
-		fill(m_selectedKernSpines.begin(), m_selectedKernSpines.end(), false);
-		for (int i = 0; i < (int)ktracks.size(); i++) {
-			int index = ktracks[i] - 1;
-			if ((index < 0) || (index >= (int)kernspines.size())) {
-				continue;
-			}
-			int track = kernspines.at(index)->getTrack();
-			m_selectedKernSpines.at(track) = true;
-		}
-	} else if (!m_spineTracks.empty()) {
-		fill(m_selectedKernSpines.begin(), m_selectedKernSpines.end(), false);
-		infile.makeBooleanTrackList(m_selectedKernSpines, m_spineTracks);
+	if (m_compositeQ) {
+		addCompositeSpine(infile);
 	}
 
 	vector<HTp> voices;
-	for (int i = 0; i < (int)kernspines.size(); i++) {
-		if (m_selectedKernSpines.at(kernspines[i]->getTrack())) {
-			voices.push_back(kernspines[i]);
-		}
-	}
+	getVoices(voices, infile);
 	if (voices.empty()) {
+		// Nothing to label, but pass the input on unchanged.
+		m_humdrum_text << infile;
 		return;
 	}
 
@@ -166,6 +150,83 @@ void Tool_metweight::processFile(HumdrumFile& infile) {
 
 	// Enable usage in verovio (`!!!filter: metweight`)
 	m_humdrum_text << infile;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_metweight::addCompositeSpine -- -c option: replace the input with the
+//    output of the composite tool, which adds a **kern-comp spine (the merged
+//    rhythm of all voices) below the existing voices.  Without "-a" the
+//    composite spine is prepended, which places it below the input voices in
+//    the rendered score.
+//
+
+void Tool_metweight::addCompositeSpine(HumdrumFile& infile) {
+	if (infile.getKernSpineStartList().empty()) {
+		return;
+	}
+
+	stringstream composite;
+	Tool_composite compositeTool;
+	compositeTool.process("");
+	compositeTool.run(infile, composite);
+	infile.readString(composite.str());
+}
+
+
+
+//////////////////////////////
+//
+// Tool_metweight::getVoices -- The spines to label: with -c only the
+//    composite spine, otherwise the **kern spines selected by -k or -s (all
+//    of them when neither option is given).  The composite rhythm is always
+//    built from all **kern spines, so -k/-s do not apply in that mode.
+//
+
+void Tool_metweight::getVoices(vector<HTp>& voices, HumdrumFile& infile) {
+	voices.clear();
+
+	if (m_compositeQ) {
+		vector<HTp> spinestarts = infile.getKernLikeSpineStartList();
+		for (int i = 0; i < (int)spinestarts.size(); i++) {
+			if (*spinestarts[i] == "**kern-comp") {
+				voices.push_back(spinestarts[i]);
+			}
+		}
+		return;
+	}
+
+	int maxTrack = infile.getMaxTrack();
+
+	m_selectedKernSpines.resize(maxTrack + 1); // +1 since track=0 is not used
+	fill(m_selectedKernSpines.begin(), m_selectedKernSpines.end(), true);
+
+	vector<HTp> kernspines = infile.getKernSpineStartList();
+
+	// Calculate which input spines to process based on -k or -s option:
+	if (!m_kernTracks.empty()) {
+		vector<int> ktracks = Convert::extractIntegerList(m_kernTracks, maxTrack);
+		fill(m_selectedKernSpines.begin(), m_selectedKernSpines.end(), false);
+		for (int i = 0; i < (int)ktracks.size(); i++) {
+			int index = ktracks[i] - 1;
+			if ((index < 0) || (index >= (int)kernspines.size())) {
+				continue;
+			}
+			int track = kernspines.at(index)->getTrack();
+			m_selectedKernSpines.at(track) = true;
+		}
+	} else if (!m_spineTracks.empty()) {
+		fill(m_selectedKernSpines.begin(), m_selectedKernSpines.end(), false);
+		infile.makeBooleanTrackList(m_selectedKernSpines, m_spineTracks);
+	}
+
+	for (int i = 0; i < (int)kernspines.size(); i++) {
+		if (m_selectedKernSpines.at(kernspines[i]->getTrack())) {
+			voices.push_back(kernspines[i]);
+		}
+	}
 }
 
 
@@ -224,21 +285,50 @@ string Tool_metweight::getWeightToken(HumdrumFile& infile, int line, int track) 
 		return ".";
 	}
 
-	if (!m_tiedQ && token->isSecondaryTiedNote()) {
-		// The continuation of a tie is not a new attack, so it has no
-		// metric weight of its own (-t restores labeling it anyway).
+	// The continuation of a tie is not a new attack, so it has no metric
+	// weight of its own (-t restores labeling it anyway).  HumdrumToken::
+	// isSecondaryTiedNote() only accepts plain **kern, so test the token
+	// text directly to cover **kern-comp spines as well.
+	if (!m_tiedQ && Convert::isKernSecondaryTiedNote(*token)) {
 		return ".";
 	}
 
-	if (!token->getValueBool("auto", "hasData")) {
+	HTp position = token;
+	if (m_compositeQ && !position->getValueBool("auto", "hasData")) {
+		// The meter tool only analyzes **kern spines, so a **kern-comp
+		// token is never annotated itself.  The metric position is a
+		// property of the line rather than of a particular voice, so read
+		// it from a **kern attack on the same line instead.
+		position = getMeterToken(infile, line);
+	}
+	if (!position || !position->getValueBool("auto", "hasData")) {
 		return formatWeightClass(WEIGHT_UNCLASSIFIED);
 	}
 
-	int top = token->getValueInt("auto", "numerator");
-	int bot = token->getValueInt("auto", "denominator");
-	HumNum beat(token->getValue("auto", "zeroBeat"));
+	int top = position->getValueInt("auto", "numerator");
+	int bot = position->getValueInt("auto", "denominator");
+	HumNum beat(position->getValue("auto", "zeroBeat"));
 
 	return formatWeightClass(getWeightClass(top, bot, beat));
+}
+
+
+
+//////////////////////////////
+//
+// Tool_metweight::getMeterToken -- First token on the line that the meter
+//    tool annotated with a metric position, or NULL if there is none (for
+//    example when every voice is sustaining a note across this line).
+//
+
+HTp Tool_metweight::getMeterToken(HumdrumFile& infile, int line) {
+	for (int j = 0; j < infile[line].getFieldCount(); j++) {
+		HTp token = infile.token(line, j);
+		if (token->getValueBool("auto", "hasData")) {
+			return token;
+		}
+	}
+	return NULL;
 }
 
 


### PR DESCRIPTION
I added a `metweight` tool that analyzes kern files with `Tool_meter` and creates a new spine for each selected voice (`-k` or `-s`) that outputs the meter weight of every token.

Generated data tokens are as follows:

| Weight class | Abbreviation | Full word        | Number |
|--------------|--------------|------------------|--------|
| strong       | `"s"`        | `"strong"`       | `"1"`  |
| half-strong  | `"hs"`       | `"half-strong"`  | `"2"`  |
| weak         | `"w"`        | `"weak"`         | `"3"`  |
| unclassified | `"u"`        | `"unclassified"` | `"4"`  |

These options are available:

```c++
define("f|full=b",         "print full text labels (strong/half-strong/weak) instead of abbreviations");
define("i|integer=b",      "print integer rank labels (1/2/3) instead of abbreviations");
define("x|cdata=b",        "label the spine **cdata-metweight instead of **metweight");
define("k|kern-tracks=s",  "process only the specified kern spines");
define("s|spine|spines=s", "process only the specified spines");
define("n|null=b",         "always use the null token . for unclassified positions");
```

### Example usage:

Command:

```
metweight -nx -k1,$ ./bach-370-chorales/kern/chor029.krn | myank -m 1-4 | ridxx -LG
```

Output:

```tsv
**kern	**cdata-metweight	**kern	**kern	**kern	**cdata-metweight
*clefF4	*	*clefGv2	*clefG2	*clefG2	*
*k[f#]	*	*k[f#]	*k[f#]	*k[f#]	*
*G:	*	*G:	*G:	*G:	*
*M4/4	*	*M4/4	*M4/4	*M4/4	*
*met(c)	*	*met(c)	*met(c)	*met(c)	*
*MM100	*	*MM100	*MM100	*MM100	*
=1-	=1-	=1-	=1-	=1-	=1-
4G	s	4B	4d	4g	s
4F#	w	4A	4d	4a	w
4G	hs	[4G	4d	4b	hs
4D	w	8GL]	4d	4a	w
.	.	8F#J	.	.	.
=2	=2	=2	=2	=2	=2
4E	s	4G	8dL	4g	s
.	.	.	8c#J	.	.
8F#L	w	4A	4d	4f#	w
8GJ	.	.	.	.	.
4A	hs	8AL	4c#	4e	hs
.	.	8GJ	.	.	.
4D;	w	4F#;	4A;	4d;	w
=3	=3	=3	=3	=3	=3
4E	s	4B	4e	4g	s
4F#	w	4A	4d	4a	w
4G	hs	8GL	4d	4b	hs
.	.	8F#J	.	.	.
4AA	w	8EL	4a	4cc	w
.	.	8F#J	.	.	.
=4	=4	=4	=4	=4	=4
8BBL	s	4.G	4d	4b	s
8CJ	.	.	.	.	.
4D	w	.	4d	4a	w
.	.	8F#	.	.	.
2GG;	hs	2B;	2d;	2g;	hs
=	=	=	=	=	=
*-	*-	*-	*-	*-	*-
```