### PR TITLE
Add pliner and textract tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,11 +175,13 @@ set(HDRS
 add_library(humlib STATIC ${SRCS} ${HDRS})
 
 # Create a WebAssembly-compatible executable
-#add_executable(humlib-wasm main.cpp ${SRCS})
+if(EMSCRIPTEN)
+    add_executable(humlib-wasm main.cpp ${SRCS})
 
-# Link the static library and set properties for Emscripten
-target_link_libraries(humlib-wasm humlib)
-set_target_properties(humlib-wasm PROPERTIES LINK_FLAGS "-s MODULARIZE=1 -s EXPORT_NAME=humlib -s EXPORTED_RUNTIME_METHODS=ccall,cwrap -s ENVIRONMENT=web")
+    # Link the static library and set properties for Emscripten
+    target_link_libraries(humlib-wasm humlib)
+    set_target_properties(humlib-wasm PROPERTIES LINK_FLAGS "-s MODULARIZE=1 -s EXPORT_NAME=humlib -s EXPORTED_RUNTIME_METHODS=ccall,cwrap -s ENVIRONMENT=web")
+endif()
 
 
 ##############################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.15)
 
 project(humlib C CXX)
 #set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 #set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 

--- a/Makefile
+++ b/Makefile
@@ -1201,7 +1201,7 @@ tool-filter.o: tool-filter.cpp tool-filter.h \
   tool-meter.h tool-metlev.h tool-modori.h \
   tool-msearch.h Convert.h tool-myank.h \
   tool-nproof.h tool-ordergps.h tool-phrase.h \
-  tool-pline.h tool-recip.h tool-restfill.h \
+  tool-pline.h tool-pliner.h tool-recip.h tool-restfill.h \
   tool-rid.h tool-sab2gs.h tool-satb2gs.h \
   tool-scordatura.h HumTransposer.h HumPitch.h \
   tool-semitones.h tool-shed.h tool-sic.h \

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,10 +26,6 @@ after_build:
       $git_hash = $env:APPVEYOR_REPO_COMMIT.Substring(0, 8)
       $my_version = "$($env:APPVEYOR_BUILD_VERSION)-$git_hash"
       $env:PACKAGE_NAME = "humlib-$my_version-$($env:arch)"
-  - mkdir lib
-  - mkdir -p include/pugixml
-  - mkdir -p arc/pugixml
-  - copy "build\\%config%\\humlib.lib" lib
   - if not exist lib mkdir lib
   - if not exist include\\pugixml mkdir include\\pugixml
   - if not exist arc\\pugixml mkdir arc\\pugixml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,6 +30,10 @@ after_build:
   - mkdir -p include/pugixml
   - mkdir -p arc/pugixml
   - copy "build\\%config%\\humlib.lib" lib
+  - if not exist lib mkdir lib
+  - if not exist include\\pugixml mkdir include\\pugixml
+  - if not exist arc\\pugixml mkdir arc\\pugixml
+  - copy "build\\%config%\\humlib.lib" lib
   - 7z a "%PACKAGE_NAME%.zip" include include/pugixml arc/pugixml lib README.md LICENSE.txt
 
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,11 @@ init:
   - git config --global core.autocrlf input
 
 build_script:
-  - cmake -G"%generator%" -A "%arch%" -H. -Bbuild -DCMAKE_BUILD_TYPE="%config%"
+  - if "%arch%"=="x64" (
+      cmake -G"%generator%" -A x64 -H. -Bbuild -DCMAKE_BUILD_TYPE="%config%"
+    ) else (
+      cmake -G"%generator%" -H. -Bbuild -DCMAKE_BUILD_TYPE="%config%"
+    )
   - cmake --build build --config "%config%" --parallel
 
 after_build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,12 +4,12 @@ image: Visual Studio 2019
 
 environment:
   matrix:
-  - generator: "Visual Studio 16"
+  - generator: "Visual Studio 16 2019"
     config: Release
     arch: x86
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
 
-  - generator: "Visual Studio 16 Win64"
+  - generator: "Visual Studio 16 2019"
     config: Release
     arch: x64
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
@@ -18,7 +18,7 @@ init:
   - git config --global core.autocrlf input
 
 build_script:
-  - cmake -G"%generator%" -H. -Bbuild -DCMAKE_BUILD_TYPE="%config%"
+  - cmake -G"%generator%" -A "%arch%" -H. -Bbuild -DCMAKE_BUILD_TYPE="%config%"
   - cmake --build build --config "%config%" --parallel
 
 after_build:

--- a/cli/pliner.cpp
+++ b/cli/pliner.cpp
@@ -1,0 +1,13 @@
+//
+// Programmer:    Alexander Morgan
+// Creation Date: Wed Jul 15 2026
+// Filename:      cli/pliner.cpp
+// Syntax:        C++11
+// vim:           ts=3 noexpandtab nowrap
+//
+// Description:   Insert *pline poetic-line annotations into a kern score.
+//
+
+#include "humlib.h"
+
+STREAM_INTERFACE(Tool_pliner)

--- a/cli/pliner.cpp
+++ b/cli/pliner.cpp
@@ -5,7 +5,7 @@
 // Syntax:        C++11
 // vim:           ts=3 noexpandtab nowrap
 //
-// Description:   Insert *pline poetic-line annotations into a kern score.
+// Description:   Insert *pline annotations using textract-reconstructed text.
 //
 
 #include "humlib.h"

--- a/cli/textract.cpp
+++ b/cli/textract.cpp
@@ -1,0 +1,13 @@
+//
+// Programmer:    Alexander Morgan
+// Creation Date: Fri Jul 24 2026
+// Filename:      cli/textract.cpp
+// Syntax:        C++11
+// vim:           ts=3 noexpandtab nowrap
+//
+// Description:   Reconstruct the poetic text set in a kern score.
+//
+
+#include "humlib.h"
+
+STREAM_INTERFACE(Tool_textract)

--- a/include/humlib.h
+++ b/include/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mon Nov 13 08:17:24 JST 2023
+// Last Modified: Thu Jul 16 11:57:52 CEST 2026
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11
@@ -54,6 +54,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <list>
 #include <locale>
 #include <map>
+#include <numeric>
+#include <random>
 #include <regex>
 #include <set>
 #include <sstream>
@@ -121,6 +123,7 @@ class MuseRecord;
 class MuseData;
 class MuseDataSet;
 class GridVoice;
+class GotScore;
 
 
 class HumParameter : public std::string {
@@ -829,6 +832,7 @@ class HumAddress {
 		int                 getLineNumber     (void) const;
 		int                 getFieldIndex     (void) const;
 		const HumdrumToken& getDataType       (void) const;
+		HTp                 getExclusiveInterpretation(void);
 		const std::string&  getSpineInfo      (void) const;
 		int                 getTrack          (void) const;
 		int                 getSubtrack       (void) const;
@@ -961,9 +965,9 @@ class HumInstrument {
 		int         setGM               (const std::string& Hname, int aValue);
 
 	private:
-		int                            index;
-		static std::vector<_HumInstrument>  data;
-		static int                     classcount;
+		int                            m_index;
+		static std::vector<_HumInstrument>  m_data;
+		static int                     m_classcount;
 
 	protected:
 		void       initialize          (void);
@@ -1257,6 +1261,14 @@ class HumdrumLine : public std::string, public HumHash {
 		bool        isManipulator          (void) const;
 		bool        hasSpines              (void) const;
 		bool        isGlobal               (void) const;
+
+		int         isKeySignature         (int startTrack = 0, int stopTrack = 0);
+		int         isKeyDesignation       (int startTrack = 0, int stopTrack = 0);
+		int         isTempo                (int startTrack = 0, int stopTrack = 0);
+		int         isTimeSignature        (int startTrack = 0, int stopTrack = 0);
+		int         isExpansionLabel       (int startTrack = 0, int stopTrack = 0);
+		int         isExpansionList        (int startTrack = 0, int stopTrack = 0);
+
 		bool        equalFieldsQ           (const std::string& exinterp, const std::string& value);
 		HTp         token                  (int index) const;
 		void        getTokens              (std::vector<HTp>& list);
@@ -1283,6 +1295,7 @@ class HumdrumLine : public std::string, public HumHash {
 		std::string   getXmlIdPrefix       (void) const;
 		void          clearTokenLinkInfo   (void);
 		void          createLineFromTokens (void);
+		void          generateLineFromTokens (void) { createLineFromTokens(); }
 		void          removeExtraTabs      (void);
 		void          addExtraTabs         (std::vector<int>& trackWidths);
 		int           getLineIndex         (void) const;
@@ -1320,6 +1333,9 @@ class HumdrumLine : public std::string, public HumHash {
 
 		// pitch-related functions, defined in HumdrumLine-kern.cpp:
 
+		std::string getTriadicQuality(HumdrumFile& infile, int index,
+	 	                              std::string& quality, std::string& root, std::string& inversion,
+		                              std::map<std::string,bool>& options);
 		void             getMidiPitches       (std::vector<int>& output);
 		std::vector<int> getMidiPitches       (void);
 		void             getMidiPitchesSortHL (std::vector<int>& output);
@@ -1469,7 +1485,9 @@ class HumdrumToken : public std::string, public HumHash {
 		        ~HumdrumToken              ();
 
 		bool     isNull                    (void) const;
+		bool     isNullToken               (void) const { return isNull(); }
 		bool     isManipulator             (void) const;
+		bool     isSpineManipulator        (void) const { return isManipulator(); }
 
 		bool     isExclusiveInterpretation (void) const;
 		bool     isSplitInterpretation     (void) const;
@@ -1508,6 +1526,7 @@ class HumdrumToken : public std::string, public HumHash {
 		bool     isNullData                (void) const;
 		bool     isChord                   (const std::string& separator = " ");
 		bool     isLabel                   (void) const;
+		bool     isExpansionLabel          (void) const { return isLabel(); };
 		bool     isExpansionList           (void) const;
 		bool     hasRhythm                 (void) const;
 		bool     hasBeam                   (void) const;
@@ -1551,6 +1570,7 @@ class HumdrumToken : public std::string, public HumHash {
 		bool     isInstrumentCode          (void) { return isInstrumentDesignation(); }
 		bool     isInstrumentClass         (void);
 		bool     isInstrumentGroup         (void);
+		bool     isInstrumentNumber        (void);
 		bool     isModernInstrumentName    (void);
 		bool     isModernInstrumentAbbreviation(void);
 		bool     isOriginalInstrumentName    (void);
@@ -1638,11 +1658,15 @@ class HumdrumToken : public std::string, public HumHash {
 		HumNum   getBarlineDuration        (void);
 		HumNum   getBarlineDuration        (HumNum scale);
 
+		// metric-related functions:
+		HumNum   getBeat                   (HumNum scale = 1);
+
 		HLp      getOwner                  (void) const;
 		HLp      getLine                   (void) const { return getOwner(); }
 		bool     equalChar                 (int index, char ch) const;
 
 		HTp      resolveNull               (void);
+		HTp      resolveNullToken          (void) { return resolveNull(); }
 		void     setNullResolution         (HTp resolution);
 		int      getLineIndex              (void) const;
 		int      getLineNumber             (void) const;
@@ -1661,6 +1685,7 @@ class HumdrumToken : public std::string, public HumHash {
 		bool     isStaffLike               (void) const { return isKernLike() || isMensLike(); }
 		std::string   getSpineInfo         (void) const;
 		int      getTrack                  (void) const;
+		int      getSpineIndex             (void) const;
 		int      getSubtrack               (void) const;
 		bool     noteInLowerSubtrack       (void);
 		std::string   getTrackString       (void) const;
@@ -1699,6 +1724,7 @@ class HumdrumToken : public std::string, public HumHash {
 		std::string   getXmlIdPrefix       (void) const;
 		void     setText                   (const std::string& text);
 		std::string   getText              (void) const;
+		HTp      getExclusiveInterpretation(void);
 		int      addLinkedParameterSet     (HTp token);
 		int      getLinkedParameterSetCount(void);
 		HumParamSet* getLinkedParameterSet (int index);
@@ -2024,6 +2050,7 @@ class HumdrumFileBase : public HumHash {
 		bool          isRhythmAnalyzed         (void);
 		bool          areStrandsAnalyzed       (void);
 		bool          areStrophesAnalyzed      (void);
+		void          setFilenameFromSegment   (void);
 
     	template <class TYPE>
 		   void       initializeArray          (std::vector<std::vector<TYPE>>& array, TYPE value);
@@ -2138,8 +2165,6 @@ class HumdrumFileBase : public HumHash {
 		HLp           back                     (void);
 		void          makeBooleanTrackList     (std::vector<bool>& spinelist,
 		                                        const std::string& spinestring);
-		bool          analyzeBaseFromLines     (void);
-		bool          analyzeBaseFromTokens    (void);
 
 
 		std::vector<HLp> getReferenceRecords(void);
@@ -2180,6 +2205,15 @@ class HumdrumFileBase : public HumHash {
 		static void   readStringFromHttpUri     (std::stringstream& inputdata,
 		                                         const std::string& webaddress);
 
+		bool          analyzeBaseFromLines     (void);
+		bool          analyzeBaseFromTokens    (void);
+
+		bool          analyzeTokens             (void);
+		bool          analyzeSpines             (void);
+		bool          analyzeLinks              (void);
+		bool          analyzeTracks             (void);
+		bool          analyzeLines              (void);
+
 	protected:
 		static int    getChunk                  (int socket_id,
 		                                         std::stringstream& inputdata,
@@ -2195,10 +2229,6 @@ class HumdrumFileBase : public HumHash {
 		                                         unsigned short int port);
 
 	protected:
-		bool          analyzeTokens             (void);
-		bool          analyzeSpines             (void);
-		bool          analyzeLinks              (void);
-		bool          analyzeTracks             (void);
 		bool          adjustSpines              (HumdrumLine& line,
 		                                         std::vector<std::string>& datatype,
 		                                         std::vector<std::string>& sinfo);
@@ -2216,7 +2246,6 @@ class HumdrumFileBase : public HumHash {
 		bool          setParseError             (std::stringstream& err);
 		bool          setParseError             (const std::string& err);
 		bool          setParseError             (const char* format, ...);
-		bool          analyzeLines              (void);
 //		void          fixMerges                 (int linei);
 
 	protected:
@@ -2443,6 +2472,7 @@ class HumdrumFileStructure : public HumdrumFileBase {
 		std::string   getKernLinkSignifier         (void);
 		std::string   getKernAboveSignifier        (void);
 		std::string   getKernBelowSignifier        (void);
+		std::string   getPartName                  (HTp sstart);
 
 
 	protected:
@@ -2487,6 +2517,7 @@ class HumdrumFileStructure : public HumdrumFileBase {
 
 
 
+
 class HumdrumFileContent : public HumdrumFileStructure {
 	public:
 		       HumdrumFileContent         (void);
@@ -2499,8 +2530,21 @@ class HumdrumFileContent : public HumdrumFileStructure {
 		bool   analyzePhrasings           (void);
 		bool   analyzeTextRepetition      (void);
 		bool   analyzeKernTies            (void);
-		bool   analyzeKernAccidentals     (void);
+		bool   analyzeAccidentals         (void);
+		bool   analyzeKernAccidentals     (const std::string& dataType = "**kern");
+		bool   analyzeMensAccidentals     (void);
 		bool   analyzeRScale              (void);
+
+		// in HumdrumFileContent-hand.cpp
+		bool   doHandAnalysis             (bool attacksOnlyQ = false);
+		bool   doHandAnalysis             (HTp startSpine, bool attacksOnlyQ = false);
+
+		// in HumdrumFileContent-kern.cpp
+		std::vector<int> getTrackToKernIndex (void);
+
+		// in HumdrumFileContent-midi.cpp
+		void fillMidiInfo(std::vector<std::vector<std::vector<std::pair<HTp, int>>>>& trackMidi);
+		void processStrandNotesForMidi(HTp sstart, HTp send, std::vector<std::vector<std::pair<HTp, int>>>& trackInfo);
 
 		// in HumdrumFileContent-rest.cpp
 		void  analyzeRestPositions                  (void);
@@ -2996,7 +3040,11 @@ class HumdrumFile : public HUMDRUMFILE_PARENT {
 
 
 
-// Reference:     Beyond Midi, page 410.
+//////////////////////////////
+//
+// MuseData line types, reference: Beyond Midi, page 410.
+//
+
 #define E_muserec_note_regular       'N'
 	//                                'A' --> use type E_muserec_note_regular
 	//                                'B' --> use type E_muserec_note_regular
@@ -3026,33 +3074,46 @@ class HumdrumFile : public HUMDRUMFILE_PARENT {
 #define E_muserec_comment_toggle     '&'
 #define E_muserec_comment_line       '@'
 #define E_muserec_musical_directions '*'
+
 #define E_muserec_copyright          '1'  // reserved for copyright notice
 #define E_muserec_header_1           '1'  // reserved for copyright notice
+
 #define E_muserec_header_2           '2'  // reserved for identification
 #define E_muserec_id                 '2'  // reserved for identification
+
 #define E_muserec_header_3           '3'  // reserved
+
 #define E_muserec_header_4           '4'  // <date> <name of encoder>
 #define E_muserec_encoder            '4'  // <date> <name of encoder>
+
 #define E_muserec_header_5           '5'  // WK#:<work number> MV#:<mvmt num>
 #define E_muserec_work_info          '5'  // WK#:<work number> MV#:<mvmt num>
+
 #define E_muserec_header_6           '6'  // <source>
 #define E_muserec_source             '6'  // <source>
+
 #define E_muserec_header_7           '7'  // <work title>
 #define E_muserec_work_title         '7'  // <work title>
+
 #define E_muserec_header_8           '8'  // <movement title>
 #define E_muserec_movement_title     '8'  // <movement title>
+
 #define E_muserec_header_9           '9'  // <name of part>
 #define E_muserec_header_part_name   '9'  // <name of part>
+
 #define E_muserec_header_10          '0'  // misc designations
+
 #define E_muserec_header_11          'A'  // group memberships
 #define E_muserec_group_memberships  'A'  // group memberships
-// multiple musered_head_12 lines can occur:
+
+// multiple muserec_head_12 lines can occur:
 #define E_muserec_header_12          'B'  // <name1>: part <x> of <num in group>
 #define E_muserec_group              'B'  // <name1>: part <x> of <num in group>
+
 #define E_muserec_unknown            'U'  // unknown record type
-#define E_muserec_empty              'E'  // nothing on line and not header
-	                                       // or multi-line comment
+#define E_muserec_empty              'E'  // nothing on line and not header or multi-line comment
 #define E_muserec_deleted            'D'  // deleted line
+
 // non-standard record types for MuseDataSet
 #define E_muserec_filemarker         '+'
 #define E_muserec_filename           'F'
@@ -3108,10 +3169,12 @@ class MuseRecordBasic {
 		void              append             (const char* format, ...);
 
 		// mark-up accessor functions:
-
 		void              setAbsBeat         (HumNum value);
+		void              setQStamp          (HumNum value);
 		void              setAbsBeat         (int topval, int botval = 1);
+		void              setQStamp          (int topval, int botval = 1);
 		HumNum            getAbsBeat         (void);
+		HumNum            getQStamp          (void);
 
 		void              setLineDuration    (HumNum value);
 		void              setLineDuration    (int topval, int botval = 1);
@@ -3134,27 +3197,34 @@ class MuseRecordBasic {
 		int               getNextTiedNoteLineIndex(void);
 		void              setLastTiedNoteLineIndex(int index);
 		void              setNextTiedNoteLineIndex(int index);
+		int               hasTieGroupStart        (void);
+		int               isNoteAttack            (void);
+		/* HumNum            getTiedNoteDuration     (void); */
 
 		std::string       getLayoutVis       (void);
 
 		// boolean type fuctions:
 		bool              isAnyNote          (void);
+		bool              isRest             (void);
 		bool              isAnyNoteOrRest    (void);
-		bool              isAttributes       (void);
+		bool              isAttributes       (void); // starts with $
+		bool              isAttribute        (void) { return isAttributes(); }
 		bool              isBackup           (void);
 		bool              isBarline          (void);
+		bool              isMeasure          (void) { return isBarline(); }
 		bool              isBodyRecord       (void);
 		bool              isChordGraceNote   (void);
 		bool              isChordNote        (void);
-		bool              isDirection        (void);
-		bool              isAnyComment       (void);
-		bool              isLineComment      (void);
-		bool              isBlockComment     (void);
-		bool              isCopyright        (void);
-		bool              isCueNote          (void);
-		bool              isEncoder          (void);
-		bool              isFiguredHarmony   (void);
-		bool              isGraceNote        (void);
+		bool              isDirection        (void); // starts with "*"
+		bool              isMusicalDirection (void); // starts with "*"
+		bool              isAnyComment       (void); // starts with "@" or between lines starting with &.
+		bool              isLineComment      (void); // starts with "@"
+		bool              isBlockComment     (void); // lines between lines starting with &.
+		bool              isCopyright        (void); // 1st non-comment line in file
+		bool              isCueNote          (void); // starts with "c"
+		bool              isEncoder          (void); // 4th non-comment line in file
+		bool              isFiguredHarmony   (void); // starts with "f"
+		bool              isGraceNote        (void); // starts with "g"
 		bool              isGroup            (void);
 		bool              isGroupMembership  (void);
 		bool              isHeaderRecord     (void);
@@ -3165,7 +3235,7 @@ class MuseRecordBasic {
 		bool              isAnyRest          (void);
 		bool              isRegularRest      (void);
 		bool              isInvisibleRest    (void);
-		bool              isPrintSuggestion  (void);
+		bool              isPrintSuggestion  (void);  // starts with "P"
 		bool              isSource           (void);
 		bool              isWorkInfo         (void);
 		bool              isWorkTitle        (void);
@@ -3174,27 +3244,42 @@ class MuseRecordBasic {
 		void              setTpq             (int value);
 		static std::string musedataToUtf8    (std::string& input);
 
+
 	protected:
-		std::string       m_recordString;    // actual characters on line
+		std::string       m_recordString;     // actual characters on line
+
+		std::vector<int>  m_printSuggestions; // print suggestions for this line (if applicable)
+		                                      // print suggestions start with the letter "P" and
+                                            // follow a note/rest line, as well as musical
+		                                      // direction lines that start with "*".  The value
+		                                      // int the difference in indexes between the current
+		                                      //  line and the print suggestion (typically +1).
+
+      std::vector<int> m_musicalDirections; // Musical directions associated with this line
+		                                      // (if applicable) stored as delta indexes.  Musical
+		                                      // direction lines start with "*" and are used for
+		                                      // dynamics, hairpins, etc.  Typically -1 from a note
+		                                      // or -2 if there is a print suggestion for the musical
+		                                      // direction.
 
 		// mark-up data for the line:
-		int               m_lineindex;       // index into original file
-		int               m_type;            // category of MuseRecordBasic record
-		HumNum            m_absbeat;         // dur in quarter notes from start
-		HumNum            m_lineduration;    // duration of line
-		HumNum            m_noteduration;    // duration of note
+		int               m_lineindex;        // index into original file
+		int               m_type;             // category of MuseRecordBasic record
+		HumNum            m_qstamp;           // dur in quarter notes from start
+		HumNum            m_lineduration;     // duration of line
+		HumNum            m_noteduration;     // duration of note
 
-		int               m_b40pitch;        // base 40 pitch
-		int               m_nexttiednote;    // line number of next note tied to
-		                                     // this one (-1 if no tied note)
-		int               m_lasttiednote;    // line number of previous note tied
-		                                     // to this one (-1 if no tied note)
+		int               m_b40pitch;         // base 40 pitch
+		int               m_nexttiednote;     // line number of next note tied to
+		                                      // this one (-1 if no tied note)
+		int               m_lasttiednote;     // line number of previous note tied
+		                                      // to this one (-1 if no tied note)
 		int               m_roundBreve;
-		int               m_header = -1;     // -1 = undefined, 0 = no, 1 = yes
-		int               m_layer = 0;       // voice/layer (track info but may be analyzed)
-		int               m_tpq = 0;         // ticks-per-quarter for durations
-		std::string       m_graphicrecip;    // graphical duration of note/rest
-		GridVoice*			m_voice = NULL;    // conversion structure that token is stored in.
+		int               m_header = -1;      // -1 = undefined, 0 = no, 1 = yes
+		int               m_layer = 0;        // voice/layer (track info but may be analyzed)
+		int               m_tpq = 0;          // ticks-per-quarter for durations
+		std::string       m_graphicrecip;     // graphical duration of note/rest
+		GridVoice*			m_voice = NULL;     // conversion structure that token is stored in.
 		MuseData*         m_owner = NULL;
 
 		void              setOwner    (MuseData* owner);
@@ -3202,6 +3287,7 @@ class MuseRecordBasic {
 	public:
 		static std::string       trimSpaces         (std::string input);
 
+		friend class MuseRecord;
 		friend class MuseData;
 };
 
@@ -3215,18 +3301,24 @@ std::ostream& operator<<(std::ostream& out, MuseRecordBasic* aRecord);
 
 class MuseRecord : public MuseRecordBasic {
 	public:
-		                  MuseRecord                  (void);
-		                  MuseRecord                  (const std::string& aLine);
-		                  MuseRecord                  (MuseRecord& aRecord);
-		                 ~MuseRecord                  ();
+		            MuseRecord                  (void);
+		            MuseRecord                  (const std::string& aLine);
+		            MuseRecord                  (MuseRecord& aRecord);
+		           ~MuseRecord                  ();
 
-		MuseRecord& operator=(MuseRecord& aRecord);
+		MuseRecord& operator=                   (MuseRecord& aRecord);
+
+
+	// MuseData part header information:
+		std::string getPartName();
+
 
 	//////////////////////////////
-	// functions which work with regular note, cue note, and grace note records
-	// (A..G, c, g)
-
-		// columns 1 -- 5: pitch field information
+	//
+	// functions which process regular notes (A-G), cue notes (c), grace notes (g),
+	//     and chords (" ").  Definitions stored in MuseRecord-note.cpp.
+	//
+		// columns 1-5: pitch field information
 		std::string      getNoteField                 (void);
 		int              getOctave                    (void);
 		std::string      getOctaveString              (void);
@@ -3249,7 +3341,7 @@ class MuseRecord : public MuseRecordBasic {
 		void             setStemDown                  (void);
 		void             setStemUp                    (void);
 
-		// columns 6 -- 9: duration field information
+		// columns 6-9: duration field information
 		std::string      getTickDurationField         (void);
 		std::string      getTickDurationString        (void);
 		int              getTickDuration              (void);
@@ -3293,9 +3385,9 @@ class MuseRecord : public MuseRecordBasic {
 		void             setNotehead128thMensural     (void);
 		void             setNotehead256thMensural     (void);
 
-		// columns 10 -- 12 ---> blank
+		// columns 10-12 ---> blank
 
-		// columns 13 -- 80: graphical and interpretive information
+		// columns 13-80: graphical and interpretive information
 
 		// column 13: footnote flag
 		std::string      getFootnoteFlagField         (void);
@@ -3332,40 +3424,41 @@ class MuseRecord : public MuseRecordBasic {
 		std::string      getStringProlongation        (void);
 		int              prolongationQ                (void);
 
-		// column 19: actual notated accidentals
+		// column 19: notated accidentals
 		std::string      getNotatedAccidentalField    (void);
 		std::string      getNotatedAccidentalString   (void);
 		int              getNotatedAccidental         (void);
 		int              notatedAccidentalQ           (void);
 
-		// columns 20 -- 22: time modification
+		// columns 20-22: time modification
 		std::string      getTimeModificationField     (void);
-		std::string      getTimeModification          (void);
+		std::string      getTimeModificationString    (void);
+		HumNum           getTimeModification          (void);
 		std::string      getTimeModificationLeftField (void);
 		std::string      getTimeModificationLeftString(void);
 		int              getTimeModificationLeft      (void);
 		std::string      getTimeModificationRightField(void);
 		std::string      getTimeModificationRightString(void);
 		int              getTimeModificationRight     (void);
-		int              timeModificationQ            (void);
-		int              timeModificationLeftQ        (void);
-		int              timeModificationRightQ       (void);
+		bool             timeModificationQ            (void);
+		bool             timeModificationLeftQ        (void);
+		bool             timeModificationRightQ       (void);
 
-		// column 23
+		// column 23: stem direction
 		std::string      getStemDirectionField        (void);
 		std::string      getStemDirectionString       (void);
 		int              getStemDirection             (void);
 		int              stemDirectionQ               (void);
 
-		// column 24
+		// column 24: staff number for multi-staff parts
 		std::string      getStaffField                (void);
 		std::string      getStaffString               (void);
 		int              getStaff                     (void);
 		int              staffQ                       (void);
 
-		// column 25 ---> blank
+		// column 25: blank
 
-		// columns 26 - 31: beam codes
+		// columns 26-31: beaming
 		std::string      getBeamField                 (void);
 		int              beamQ                        (void);
 		char             getBeam8                     (void);
@@ -3380,11 +3473,12 @@ class MuseRecord : public MuseRecordBasic {
 		int              beam64Q                      (void);
 		int              beam128Q                     (void);
 		int              beam256Q                     (void);
-		std::string      getKernBeamStyle             (void);
 		void             setBeamInfo                  (std::string& strang);
 
-		// columns 32 -- 43: additional notation
-		std::string      getAdditionalNotationsField  (void);
+		// columns 32-43: additional notation
+		std::string      getAdditionalNotationsField  (void); // merge with below
+		std::string      getOtherNotations            (void); // merge with above
+		int              hasFermata                   (void);
 		int              additionalNotationsQ         (void);
 		int              getAddCount                  (void);
 		std::string      getAddItem                   (int elementIndex);
@@ -3400,78 +3494,87 @@ class MuseRecord : public MuseRecordBasic {
 		// int           getNotationLevel
 		int              getSlurStartColumn           (void);
 		std::string      getSlurParameterRegion       (void);
-		void             getSlurInfo                  (std::string& slurstarts,
-		                                               std::string& slurends);
+		void             getSlurInfo                  (std::string& slurstarts, std::string& slurends);
 
-		// columns 44 -- 80: text underlay
+
+		// columns 44-80: text underlay
 		std::string      getTextUnderlayField         (void);
 		int              textUnderlayQ                (void);
 		int              getVerseCount                (void);
 		std::string      getVerse                     (int index);
 		std::string      getVerseUtf8                 (int index);
 
-		// general functions for note records:
-		std::string      getKernNoteStyle             (int beams = 0, int stems = 0);
-		std::string      getKernNoteAccents           (void);
 
 
 	//////////////////////////////
-	// functions which work with basso continuo figuration records ('f'):
-
+	//
+	// functions which work with basso continuo figuration records ('f'), definitions
+	//     stored in MuseRecord-figure.cpp
+	//
 		// column 2: number of figure fields
 		std::string      getFigureCountField          (void);
 		std::string      getFigureCountString         (void);
 		int              getFigureCount               (void);
 
-		// columns 3 -- 5 ---> blank
-		
-		// columns 6 -- 8: figure division pointer advancement (duration)
+		// columns 3-5: blank
+
+		// columns 6-8: figure division pointer advancement (duration)
+		// this is the offset to the next figure and is not part
+		// of the note pointer advancement
 		std::string      getFigurePointerField        (void);
+		std::string      getFigurePointer             (void);
 		int              figurePointerQ               (void);
-		// same as note records: getDuration
+		int              getFigureDuration            (void);
 
-		// columns 9 -- 12 ---> blank
 
-		// columns 13 -- 15: footnote and level information
-		// column 13 --> footnote: uses same functions as note records in col 13.
-		// column 14 --> level: uses same functions as note records on column 14.
-		// column 15 ---> blank
+		// columns 9-12: blank
 
-		// columns 17 -- 80: figure fields
+		// columns 13-15: footnote and level information
+		// column 13: footnote: uses same functions as note records in col 13.
+		// column 14: level: uses same functions as note records on column 14.
+		// column 15: blank
+
+		// columns 17-80: figure fields
 		std::string      getFigureFields              (void);
 		std::string      getFigureString              (void);
 		int              figureFieldsQ                (void);
 		std::string      getFigure                    (int index = 0);
 
 
-	//////////////////////////////
-	// functions which work with combined records ('b', 'i'):
-
 
 	//////////////////////////////
-	// functions which work with measure records ('m'):
+	//
+	// functions that work with combined records ('b', 'i'):
+	//
 
-		// columns 1 -- 7: measure style information
-		std::string      getMeasureTypeField          (void);
 
-		// columns 9 -- 12: measure number (left justified)
+
+	//////////////////////////////
+	//
+	// functions which work with measure records ('m'), definitions stored
+	//    in MuseRecord-measure.cpp.
+	//
+		// columns 1-7: measure style information
+		std::string      getMeasureType               (void);
+
+		// columns 9-12: measure number (left justified)
 		std::string      getMeasureNumberField        (void);
-		std::string      getMeasureNumberString       (void);
-		int              getMeasureNumber             (void);
-		int              measureNumberQ               (void);
+		std::string      getMeasureNumber             (void);
+		bool             measureNumberQ               (void);
 
-		// columns 17 -- 80: measure flags
-		std::string      getMeasureFlagsString        (void);
+		// columns 17-80: measure flags
+		std::string      getMeasureFlags              (void);
 		int              measureFermataQ              (void);
-		int              measureFlagQ                 (const std::string& key);
+		bool             measureFlagEqual             (const std::string& key);
 		void             addMeasureFlag               (const std::string& strang);
 
-		// general functions for measure records:
-		std::string      getKernMeasureStyle          (void);
 
 
 	//////////////////////////////
-	// functions which work with musical attributes records ('$'):
+	//
+	// Notation Attributes: functions which process musical attributes records ('$'),
+	//    definitions stored in MuseRecord-attributes.cpp.
+	//
 
 		std::string      getAttributes                (void);
 		void             getAttributeMap              (std::map<std::string, std::string>& amap);
@@ -3479,36 +3582,73 @@ class MuseRecord : public MuseRecordBasic {
 		int              getAttributeInt              (char attribute);
 		int              getAttributeField            (std::string& output, const std::string& attribute);
 
-	//////////////////////////////
-	// functions which work with musical direction records ('$'):
 
+
+	//////////////////////////////
+	//
+	// functions which work with musical direction records ('*'),
+	//     definitions stored in MuseRecord-directions.cpp.
+	//
 		// columns 17-18: type of direction
 		std::string      getDirectionTypeField        (void);
 		std::string      getDirectionTypeString       (void);
-		bool             isTextDirection              (void);
+		bool             isDashStart                  (void);
+		bool             isDashStop                   (void);
+		bool             isDynamic                    (void);
 		bool             isHairpin                    (void);
 		bool             isHairpinStart               (void);
 		bool             isHairpinStop                (void);
-		bool             isDashStart                  (void);
-		bool             isDashStop                   (void);
-		bool             isPedalStart                 (void);
-		bool             isPedalEnd                   (void);
-		bool             isRehearsal                  (void);
 		bool             isOctaveUpStart              (void);
 		bool             isOctaveDownStart            (void);
 		bool             isOctaveStop                 (void);
+		bool             isPedalStart                 (void);
+		bool             isPedalEnd                   (void);
+		bool             isRehearsal                  (void);
+		bool             isTextDirection              (void);
 
 		std::string      getDirectionText             (void);
 		std::string      getTextDirection             (void) { return getDirectionText(); }
 
-	//
+		// Musical Directions: Lines starting with *
+		// Functions stored in src/MuseRecordBasic-directions.cpp
+		void             addMusicDirection           (int deltaIndex);
+		std::string      getDirectionAsciiCharacters (void);
+		bool             hasMusicalDirection         (void);
+		MuseRecord*      getMusicalDirection         (int index = 0);
+		std::string      getDynamicText              (void);
+		MuseRecord*      getDirectionRecord          (int deltaIndex);
+		std::string      getDirectionType            (void);
+
+
+
 	//////////////////////////////
+	//
+	// Print Suggestings: Lines starting with "P".  Definititions stored
+	//     in MuseRecord-suggestions.cpp.
+	//
 
-		std::string      getKernRestStyle             (void);
-
+		void             addPrintSuggestion           (int deltaIndex);
 		bool             hasPrintSuggestions          (void);
 		void             getAllPrintSuggestions       (std::vector<std::string>& suggestions);
 		void             getPrintSuggestions          (std::vector<std::string>& suggestions, int column);
+
+
+
+	//////////////////////////////
+	//
+	// Humdrum conversion related functions, store in MuseRecord-humdrum.cpp:
+	//
+
+		std::string      getKernMeasure               (void);
+		std::string      getKernBeamStyle             (void);
+		std::string      getKernNoteStyle             (int beams = 0, int stems = 0);
+		std::string      getKernNoteAccents           (void);
+		std::string      getKernNoteOtherNotations    (void);
+		std::string      getKernRestStyle             (void);
+
+
+	//
+	//////////////////////////////
 
 	protected:
 		void             allowNotesOnly               (const std::string& functionName);
@@ -3560,7 +3700,6 @@ class MuseData {
 
 		void              setFilename         (const std::string& filename);
 		std::string       getFilename         (void);
-		std::string       getPartName         (void);
 		int               isMember            (const std::string& mstring);
 		int               getMembershipPartNumber(const std::string& mstring);
 		void              selectMembership    (const std::string& selectstring);
@@ -3581,6 +3720,10 @@ class MuseData {
 		int               readFile            (const std::string& filename);
 		void              analyzeLayers       (void);
 		int               analyzeLayersInMeasure(int startindex);
+		std::string       getMeasureNumber    (int index);
+		bool              measureHasData      (int index);
+		bool              hasMeasureData      (int index) { return measureHasData(index); }
+		int               getNextMeasureIndex (int index);
 
 		// aliases for access to MuseRecord objects based on line indexes:
 		std::string       getLine             (int index);
@@ -3605,6 +3748,7 @@ class MuseData {
 		std::string       getEncoder          (void);
 		std::string       getEncoderDate      (void);
 		std::string       getEncoderName      (void);
+		std::string       getPartName         (void);
 		std::string       getId               (void);
 		std::string       getMovementTitle    (void);
 		std::string       getSource           (void);
@@ -3625,9 +3769,11 @@ class MuseData {
 		// line-based (file-order indexing) accessor functions:
 		MuseRecord&       operator[]          (int lindex);
 		MuseRecord&       getRecord           (int lindex);
+		MuseRecord*       getRecordPointer    (int lindex);
 		HumNum            getTiedDuration     (int lindex);
 
 		HumNum            getAbsBeat         (int lindex);
+		HumNum            getQStamp          (int lindex);
 		HumNum            getFileDuration    (void);
 
 		int               getLineTickDuration (int lindex);
@@ -3648,7 +3794,6 @@ class MuseData {
 		std::string       getError            (void);
 		bool              hasError            (void);
 
-
 	private:
 		std::vector<MuseRecord*>    m_data;
 		std::vector<MuseEventSet*>  m_sequence;
@@ -3665,8 +3810,9 @@ class MuseData {
 		void         constructTimeSequence(void);
 		void         insertEventBackwards (HumNum atime, MuseRecord* arecord);
 		int          getPartNameIndex     (void);
-		std::string  getPartName          (int index);
 		void         assignHeaderBodyState(void);
+		void         linkPrintSuggestions (void);
+		void         linkMusicDirections  (void);
 
 	public:
 		static std::string  trimSpaces    (const std::string& input);
@@ -3692,12 +3838,15 @@ class MuseDataSet {
 		int               readPart            (std::istream& input);
 		int               readFile            (const std::string& filename);
 		int               readString          (const std::string& data);
+		int               readString          (std::istream& input);
+		int               readString          (std::stringstream& input);
 		int               read                (std::istream& input);
 		MuseData&         operator[]          (int index);
 		int               getFileCount        (void);
 		void              deletePart          (int index);
 		void              cleanLineEndings    (void);
 		std::vector<int>  getGroupIndexList   (const std::string& group);
+		int               appendPart          (MuseData* musedata);
 
 		std::string       getError            (void);
 		bool              hasError            (void);
@@ -3712,7 +3861,6 @@ class MuseDataSet {
 		std::string             m_error;
 
 	protected:
-		int               appendPart          (MuseData* musedata);
 		void              analyzeSetType      (std::vector<int>& types,
 		                                       std::vector<std::string>& lines);
 		void              analyzePartSegments (std::vector<int>& startindex,
@@ -3957,6 +4105,9 @@ class Convert {
 				{ return kernToBase7          ((std::string)*token); }
 		static std::string  kernToRecip     (const std::string& kerndata);
 		static std::string  kernToRecip     (HTp token);
+      static std::string base12ToKern     (int aPitch);
+      static std::string base12ToPitch    (int aPitch);
+      static int         base12ToBase40   (int aPitch);
 		static int     kernToMidiNoteNumber (const std::string& kerndata);
 		static int     kernToMidiNoteNumber(HTp token)
 				{ return kernToMidiNoteNumber((std::string)*token); }
@@ -3984,9 +4135,16 @@ class Convert {
 		static int     transToBase40        (const std::string& input);
 		static int     base40IntervalToLineOfFifths(int trans);
 		static std::string  keyNumberToKern (int number);
-		static int     base7ToBase40        (int base7);
-		static int     base40IntervalToDiatonic(int base40interval);
+      static int     kernKeyToNumber      (const std::string& aKernString);
 
+		static int     base7ToBase40        (int base7);
+      static int     base7ToBase12        (int aPitch, int alter = 0);
+		static int     base40IntervalToDiatonic(int base40interval);
+      static HumNum  kernToDuration       (const std::string& aKernString);
+
+		// Serial: defined in Convert-serial.cpp
+		static std::vector<int> pitchToClass(const std::vector<int>& notes, int octave, int modulo);
+		static std::string getMidiPCTriadAbbr(const std::vector<int>& pcs);
 
 		// **mens, mensual notation, defiend in Convert-mens.cpp
 		static bool    isMensRest           (const std::string& mensdata);
@@ -4013,39 +4171,36 @@ class Convert {
 		static HumNum mensToDuration        (HTp menstok);
 
 		// older functions to enhance or remove:
-		static HumNum  mensToDuration       (const std::string& mensdata,
-		                                     HumNum scale = 4,
+		static HumNum  mensToDuration       (const std::string& mensdata, HumNum scale = 4,
 		                                     const std::string& separator = " ");
-		static std::string  mensToRecip     (const std::string& mensdata,
-		                                     HumNum scale = 4,
+		static std::string  mensToRecip     (const std::string& mensdata, HumNum scale = 4,
 		                                     const std::string& separator = " ");
-		static HumNum  mensToDurationNoDots(const std::string& mensdata,
-		                                     HumNum scale = 4,
+		static HumNum  mensToDurationNoDots (const std::string& mensdata, HumNum scale = 4,
 		                                     const std::string& separator = " ");
 
 		// MuseData conversions in Convert-musedata.cpp
-      static int       museToBase40        (const std::string& pitchString);
-      static std::string musePitchToKernPitch(const std::string& museInput);
-		static std::string museClefToKernClef(const std::string& mclef);
-		static std::string museKeySigToKernKeySig(const std::string& mkeysig);
-		static std::string museTimeSigToKernTimeSig(const std::string& mtimesig);
-		static std::string museMeterSigToKernMeterSig(const std::string& mtimesig);
+      static int         museToBase40                    (const std::string& pitchString);
+      static std::string musePitchToKernPitch            (const std::string& museInput);
+		static std::string museClefToKernClef              (const std::string& mclef);
+		static std::string museKeySigToKernKeySig          (const std::string& mkeysig);
+		static std::string museTimeSigToKernTimeSig        (const std::string& mtimesig);
+		static std::string museMeterSigToKernMeterSig      (const std::string& mtimesig);
 		static std::string museFiguredBassToKernFiguredBass(const std::string& mfb);
 
 		// Harmony processing, defined in Convert-harmony.cpp
 		static std::vector<int> minorHScaleBase40(void);
 		static std::vector<int> majorScaleBase40 (void);
-		static int         keyToInversion   (const std::string& harm);
-		static int         keyToBase40      (const std::string& key);
+		static int              keyToInversion   (const std::string& harm);
+		static int              keyToBase40      (const std::string& key);
 		static std::vector<int> harmToBase40     (HTp harm, const std::string& key) {
-		                                        return harmToBase40(*harm, key); }
+		                                          return harmToBase40(*harm, key); }
 		static std::vector<int> harmToBase40     (HTp harm, HTp key) {
-		                                        return harmToBase40(*harm, *key); }
+		                                          return harmToBase40(*harm, *key); }
 		static std::vector<int> harmToBase40     (const std::string& harm, const std::string& key);
 		static std::vector<int> harmToBase40     (const std::string& harm, int keyroot, int keymode);
-		static void        makeAdjustedKeyRootAndMode(const std::string& secondary,
-		                                     int& keyroot, int& keymode);
-		static int         chromaticAlteration(const std::string& content);
+		static void             makeAdjustedKeyRootAndMode(const std::string& secondary,
+		                                          int& keyroot, int& keymode);
+		static int              chromaticAlteration(const std::string& content);
 
 		// data-type specific (other than pitch/rhythm),
 		// defined in Convert-kern.cpp
@@ -4059,36 +4214,36 @@ class Convert {
 		static char hasKernStemDirection    (const std::string& kerndata);
 		static bool isKernSecondaryTiedNote (const std::string& kerndata);
 		static std::string getKernPitchAttributes(const std::string& kerndata);
+		static HumNum kernTimeSignatureBottomToDuration (const std::string& aKernString);
+		static int kernTimeSignatureTop (const std::string& aKernString);
 
-		static int  getKernSlurStartElisionLevel(const std::string& kerndata, int index);
-		static int  getKernSlurEndElisionLevel  (const std::string& kerndata, int index);
+		static int  getKernSlurStartElisionLevel  (const std::string& kerndata, int index);
+		static int  getKernSlurEndElisionLevel    (const std::string& kerndata, int index);
 		static int  getKernPhraseStartElisionLevel(const std::string& kerndata, int index);
-		static int  getKernPhraseEndElisionLevel(const std::string& kerndata, int index);
-
-		static int  getKernBeamStartElisionLevel(const std::string& kerndata, int index);
-		static int  getKernBeamEndElisionLevel  (const std::string& kerndata, int index);
-
-
+		static int  getKernPhraseEndElisionLevel  (const std::string& kerndata, int index);
+		static int  getKernBeamStartElisionLevel  (const std::string& kerndata, int index);
+		static int  getKernBeamEndElisionLevel    (const std::string& kerndata, int index);
 
 		// String processing, defined in Convert-string.cpp
 		static std::vector<std::string> splitString   (const std::string& data,
-		                                     char separator = ' ');
-		static void    replaceOccurrences   (std::string& source,
-		                                     const std::string& search,
-		                                     const std::string& replace);
+		                                               char separator = ' ');
+		static void    replaceOccurrences        (std::string& source,
+		                                          const std::string& search,
+		                                          const std::string& replace);
 		static std::string  repeatString         (const std::string& pattern, int count);
 		static std::string  encodeXml            (const std::string& input);
 		static std::string  getHumNumAttributes  (const HumNum& num);
 		static std::string  trimWhiteSpace       (const std::string& input);
-		static bool    startsWith           (const std::string& input,
-		                                     const std::string& searchstring);
+		static std::string  generateRandomId     (int length);
+		static bool    startsWith                (const std::string& input,
+		                                          const std::string& searchstring);
 		static bool    contains(const std::string& input, const std::string& pattern);
 		static bool    contains(const std::string& input, char pattern);
 		static bool    contains(std::string* input, const std::string& pattern);
 		static bool    contains(std::string* input, char pattern);
-		static void    makeBooleanTrackList(std::vector<bool>& spinelist,
-		                                     const std::string& spinestring,
-		                                     int maxtrack);
+		static void    makeBooleanTrackList      (std::vector<bool>& spinelist,
+		                                          const std::string& spinestring,
+		                                          int maxtrack);
 		static std::vector<int> extractIntegerList(const std::string& input, int maximum);
 		// private functions for extractIntegerList:
 		static void processSegmentEntry(std::vector<int>& field, const std::string& astring, int maximum);
@@ -4204,6 +4359,213 @@ std::ostream& operator<<(std::ostream& out, PixelColor apixel);
 
 
 
+
+class GotScore {
+
+	public:
+		struct EventAtTime {
+			double timestamp;
+			std::vector<std::string> rhythms;
+			std::vector<std::string> pitches;
+		};
+
+		class Measure {
+			public:
+				Measure(void) {};
+				~Measure() {};
+				std::ostream& print(std::ostream& out);
+
+				void printKernBarline(std::ostream& out, bool textQ);
+				void printTempoLine(std::ostream& out, const std::string& met, bool textQ);
+
+				// Each rhythm+pitch pairing with computed start time and duration
+				class TimedEvent {
+					public:
+						double timestamp;
+						double duration;
+						std::string rhythm;
+						std::string pitch;
+						bool isInterpretation = false;  // true if rhythm starts with '*'
+				};
+
+			public:
+				// m_parent: A pointer to the GotScore object that the measure belongs to.
+				GotScore* m_owner = NULL;
+
+				// m_barnum: The measure number for the measure.
+				std::string m_barnum;
+
+				// m_linebreak: The linebreak group to add to end of measure
+				// when converting to **got or **kern  There are two labels:
+				//    half = linebreak at the half-system at the binding between
+				//           physical pages (each system takes up two pages width).
+				//    original = linebreak at the end of a system.
+				//    and empty m_linebreak means that there are no breaks after
+				//    this measure.
+				// To encode half breaks, add the letter "p" to the end of the 
+				// current measure number.  This will be removed from the text of
+				// m_barline, and the "p" will convert to "half" in m_linebreak.
+				// The end of the system will be inferred from the system number in
+				// the GOT TSV data.
+				std::string m_linebreak;
+
+				// m_text: the text content for the measure.
+				std::string m_text;
+
+				// m_error: Any parsing error message when converting to **kern
+				std::vector<std::string> m_error;
+
+				// m_rhythms: First dimension is voice (highest to lowest)
+				// Second dimension is rhythm "word" first to last in measure
+				std::vector<std::vector<std::string>> m_rhythms;
+
+				// m_pitches: First dimension is voice (highest to lowest)
+				// Second dimension is pitch "word" first to last in measure
+				std::vector<std::vector<std::string>> m_pitches;
+
+				// m_splitRhythms: First dimension is voice (highest to lowest)
+				// Second dimension is rhythm "word" first to last in measure
+				// Third dimension is rhythm "token" first to last in word
+				std::vector<std::vector<std::vector<std::string>>> m_splitRhythms;
+
+				// m_splitPitches: First dimension is voice (highest to lowest)
+				// Second dimension is pitch "word" first to last in measure
+				// Third dimension is pitch "token" first to last in word
+				std::vector<std::vector<std::vector<std::string>>> m_splitPitches;
+
+				// m_kerns: First dimension is the voice (highest to lowest),
+				// second dimension is flattening of the 2nd and 3rd dimensions
+				// of m_splitPitches.
+				std::vector<std::vector<std::string*>> m_kerns;
+
+				// m_diatonic: linearized pitch by voice for marking editorial accidentals.
+				std::vector<std::vector<int>> m_diatonic;
+
+				// m_accid: chromatic alterations of m_diatonic pitches.
+				std::vector<std::vector<int>> m_accid;
+
+				// m_accidState: The diatonic accidental state at the end of the
+				// measure.  This is used to create editorial accidentals and 
+				// cautionary natural accidentals.  First dimension is voice number,
+				// second dimension is CDEFGAB accidental states, 0 = natural 1=sharp, -1=flat.
+				std::vector<std::vector<int>> m_accidState;
+
+				// m_voiceEvents: events per voice
+				std::vector<std::vector<TimedEvent>> m_voiceEvents;
+
+		};
+
+	public:
+		         GotScore        (void);
+		         GotScore        (std::stringstream& ss);
+		         GotScore        (const std::string& s);
+		        ~GotScore        ();
+
+		void     loadLines       (std::stringstream& ss);
+		void     loadLines       (const std::string& s);
+		bool     prepareMeasures (std::ostream& out);
+		void     clear           (void);
+
+		std::ostream& printInputFile  (std::ostream& out);
+		std::ostream& printCells      (std::ostream& out);
+		std::ostream& printMeasures   (std::ostream& out);
+
+		std::string getGotHumdrum         (void);
+		std::string getGotHumdrumMeasure  (GotScore::Measure& mdata);
+
+		std::string getKernHumdrum        (void);
+		std::string getKernHumdrumMeasure (GotScore::Measure& mdata);
+
+		void        processUnderscoreTies(std::vector<std::string*>& pitches);
+		void        processRhythmTies(std::vector<std::string*>& rhythms, std::vector<std::string*>& pitches);
+		std::string mergeRhythmAndPitchIntoNote(const std::string& r, const std::string& p);
+
+		std::string getHeaderInfo(int index);
+		std::string getFooterInfo(void);
+		void        getDiatonicAccid(const std::string& pitch, int& d, int& a);
+		void        prepareAccidentals(void);
+		void        markEditorialAccidentals(GotScore::Measure& measure, int voice);
+		void        checkForCautionaryAccidentals(int mindex, int vindex);
+		void        cleanRhythmValues(std::vector<std::vector<std::string>>& rhythms);
+
+		void        setNoEditorial(void);
+		void        setCautionary(void);
+		void        setNoForcedAccidentals(void);
+
+	protected:
+		void     parse                    (void);
+		void     prepareCells             (void);
+		bool     processSystemMeasures    (int barIndex, int system, std::ostream& out);
+		void     splitMeasureTokens       (void);
+		void     splitMeasureTokens       (GotScore::Measure& mdata);
+		void     pairLeadingDots          (void);
+		void     processDotsForMeasure    (GotScore::Measure& mdata);
+		void     processPitchDotsByVoice  (std::vector<std::string*>& pitches);
+		void     processDotTiedNotes      (void);
+		void     buildVoiceEvents         (void);
+		double   durationFromRhythmToken  (const std::string& token);
+		std::vector<GotScore::EventAtTime> alignEventsByTimestamp(const GotScore::Measure& mdata);
+		std::vector<std::string> convertGotToKernPitches (std::vector<std::string>& gotpitch);
+		std::string convertGotToKernPitch (const std::string& gotpitch);
+		void     storePitchHistograms     (std::vector<std::vector<std::string*>>& P);
+		std::vector<std::string> generateVoiceClefs(void);
+		std::string chooseClef(double mean, double min, double max);
+		void     trimSpaces(std::string& s);
+
+		static int kernToBase40PC       (const std::string& kerndata);
+		static int kernToAccidentalCount(const std::string& kerndata);
+		static int kernToBase12PC       (const std::string& kerndata);
+		static int kernToOctaveNumber   (const std::string& kerndata);
+		static int kernToMidiNoteNumber (const std::string& kerndata);
+		static int kernToDiatonicPC     (const std::string& kerndata);
+
+		std::vector<std::string> tokenizeRhythmString (const std::string& input);
+		std::vector<std::string> tokenizePitchString  (const std::string& input);
+		std::vector<std::string> splitBySpaces        (const std::string& input);
+
+	private:
+		// m_voices == number of voices in score
+		int m_voices = 0;
+
+		// m_pitch_hist == used to calculate the clef for each voice.
+		std::vector<std::vector<int>> m_pitch_hist;
+
+		// m_textQ == true if input data has lyric text.
+		bool m_textQ = false;
+
+		// m_lines == input text lines, with whitespace removed from ends of lines.
+		std::vector<std::string> m_lines;
+
+		// m_cells == m_lines split by tab characters (i.e., TSV data):
+		std::vector<std::vector<std::string>> m_cells;
+
+		// m_measures == data organized by measure.
+		std::vector<GotScore::Measure> m_measures;
+
+		// m_debugQ == for printing debug statements
+		bool m_debugQ = false;
+
+		// m_error == for reporting errors.
+		std::stringstream m_error;
+
+		// m_got == for storing **got conversion.
+		std::string m_got;
+
+		// m_cautionary == add !!!RDF**kern: i = editorial accidental, paren
+		bool m_cautionary;
+
+		// m_kern == for storing **kern conversion.
+		std::string m_kern;
+
+		// conversion options:
+		bool m_no_editorialQ = false;
+		bool m_cautionaryQ   = false;
+		bool m_modern_accQ   = false;
+
+};
+
+
+
 // SliceType is a list of various Humdrum line types.  Groupings are
 // segmented by categories which are prefixed with an underscore.
 // For example Notes are in the _Duration group, since they have
@@ -4301,6 +4663,9 @@ class MxmlPart {
 		string        getPartAbbr          (void) const;
 		string        cleanSpaces          (const string& input);
 		bool          hasOrnaments         (void) const;
+
+		vector<pair<int, int>> getVoiceMapping (void) { return m_voicemapping; };
+		vector<vector<int>> getStaffVoiceHist (void) { return m_staffvoicehist; };
 
 
 	private:
@@ -4474,6 +4839,7 @@ class GridMeasure : public std::list<GridSlice*> {
 		MeasureStyle getBarStyle    (void) { return getStyle(); }
 		void         setStyle       (MeasureStyle style) { m_style = style; }
 		void         setBarStyle    (MeasureStyle style) { setStyle(style); }
+		void         setKernBar     (const std::string& tok);
 		void         setInvisibleBarline(void) { setStyle(MeasureStyle::Invisible); }
 		void         setFinalBarlineStyle(void) { setStyle(MeasureStyle::Final); }
 		void         setRepeatEndStyle(void) { setStyle(MeasureStyle::RepeatBackward); }
@@ -4516,6 +4882,7 @@ class GridMeasure : public std::list<GridSlice*> {
 		HumNum       m_timestamp;
 		HumNum       m_timesigdur;
 		MeasureStyle m_style;
+		std::string  m_kernBar;
 		int          m_barnum = -1;
 };
 
@@ -4847,6 +5214,7 @@ class MxmlEvent {
 		void               setVoiceNumber     (int value);
 		int                getStaffNumber     (void) const;
 		int                getStaffIndex      (void) const;
+		int                getCrossStaffOffset(void) const;
 		int                getVoiceIndex      (int maxvoice = 4) const;
 		void               setStaffNumber     (int value);
 		measure_event_type getType            (void) const;
@@ -5047,39 +5415,39 @@ class MxmlMeasure {
 
 class Option_register {
 	public:
-		         Option_register     (void);
-		         Option_register     (const string& aDefinition, char aType,
-		                                  const string& aDefaultOption);
-		         Option_register     (const string& aDefinition, char aType,
-		                                  const string& aDefaultOption,
-		                                  const string& aModifiedOption);
-		         Option_register     (const Option_register& reg);
-		        ~Option_register     ();
+		                 Option_register (void);
+		                 Option_register (const std::string& aDefinition, char aType,
+		                                  const std::string& aDefaultOption);
+		                 Option_register (const std::string& aDefinition, char aType,
+		                                  const std::string& aDefaultOption,
+		                                  const std::string& aModifiedOption);
+		                 Option_register (const Option_register& reg);
+		                ~Option_register ();
 
-		Option_register& operator=(const Option_register& reg);
-		void     clearModified      (void);
-		string   getDefinition      (void);
-		string   getDefault         (void);
-		string   getOption          (void);
-		string   getModified        (void);
-		string   getDescription     (void);
-		bool     isModified         (void);
-		char     getType            (void);
-		void     reset              (void);
-		void     setDefault         (const string& aString);
-		void     setDefinition      (const string& aString);
-		void     setDescription     (const string& aString);
-		void     setModified        (const string& aString);
-		void     setType            (char aType);
-		ostream& print              (ostream& out);
+		Option_register& operator=       (const Option_register& reg);
+		void             clearModified   (void);
+		std::string      getDefinition   (void);
+		std::string      getDefault      (void);
+		std::string      getOption       (void);
+		std::string      getModified     (void);
+		std::string      getDescription  (void);
+		bool             isModified      (void);
+		char             getType         (void);
+		void             reset           (void);
+		void             setDefault      (const std::string& aString);
+		void             setDefinition   (const std::string& aString);
+		void             setDescription  (const std::string& aString);
+		void             setModified     (const std::string& aString);
+		void             setType         (char aType);
+		std::ostream&    print           (std::ostream& out);
 
 	protected:
-		string       m_definition;
-		string       m_description;
-		string       m_defaultOption;
-		string       m_modifiedOption;
-		bool         m_modifiedQ;
-		char         m_type;
+		std::string      m_definition;
+		std::string      m_description;
+		std::string      m_defaultOption;
+		std::string      m_modifiedOption;
+		bool             m_modifiedQ;
+		char             m_type;
 };
 
 
@@ -5092,81 +5460,82 @@ class Options {
 
 		Options&        operator=         (const Options& options);
 		int             argc              (void) const;
-		const vector<string>& argv        (void) const;
-		int             define            (const string& aDefinition);
-		int             define            (const string& aDefinition,
-		                                   const string& description);
-		string          getArg            (int index);
-		string          getArgument       (int index);
+		const std::vector<std::string>& argv (void) const;
+		int             define            (const std::string& aDefinition);
+		int             define            (const std::string& aDefinition,
+		                                   const std::string& description);
+		std::string     getArg            (int index);
+		std::string     getArgument       (int index);
 		int             getArgCount       (void);
 		int             getArgumentCount  (void);
-		vector<string>& getArgList        (vector<string>& output);
-		vector<string>& getArgumentList   (vector<string>& output);
-		bool            getBoolean        (const string& optionName);
-		string          getCommand        (void);
-		string          getCommandLine    (void);
-		string          getDefinition     (const string& optionName);
-		double          getDouble         (const string& optionName);
+		std::vector<std::string>& getArgList        (std::vector<std::string>& output);
+		std::vector<std::string>& getArgumentList   (std::vector<std::string>& output);
+		bool            getBoolean        (const std::string& optionName);
+		std::string     getCommand        (void);
+		std::string     getCommandLine    (void);
+		std::string     getDefinition     (const std::string& optionName);
+		double          getDouble         (const std::string& optionName);
 		char            getFlag           (void);
-		char            getChar           (const string& optionName);
-		float           getFloat          (const string& optionName);
-		int             getInt            (const string& optionName);
-		int             getInteger        (const string& optionName);
-		string          getString         (const string& optionName);
-		char            getType           (const string& optionName);
+		char            getChar           (const std::string& optionName);
+		float           getFloat          (const std::string& optionName);
+		int             getInt            (const std::string& optionName);
+		int             getInteger        (const std::string& optionName);
+		std::string     getString         (const std::string& optionName);
+		char            getType           (const std::string& optionName);
 		int             optionsArg        (void);
-		ostream&        print             (ostream& out);
-		ostream&        printOptionList   (ostream& out);
-		ostream&        printOptionListBooleanState(ostream& out);
+		std::ostream&   print             (std::ostream& out);
+		std::ostream&   printEmscripten   (std::ostream& out);
+		std::ostream&   printOptionList   (std::ostream& out);
+		std::ostream&   printOptionListBooleanState(std::ostream& out);
 		bool            process           (int error_check = 1, int suppress = 0);
 		bool            process           (int argc, char** argv,
-		                                      int error_check = 1,
-		                                      int suppress = 0);
-		bool            process           (const vector<string>& argv,
-		                                      int error_check = 1,
-		                                      int suppress = 0);
-		bool            process           (const string& argv, int error_check = 1,
-		                                      int suppress = 0);
+		                                   int error_check = 1,
+		                                   int suppress = 0);
+		bool            process           (const std::vector<std::string>& argv,
+		                                   int error_check = 1,
+		                                   int suppress = 0);
+		bool            process           (const std::string& argv, int error_check = 1,
+		                                   int suppress = 0);
 		void            reset             (void);
 		void            xverify           (int argc, char** argv,
-		                                      int error_check = 1,
-		                                      int suppress = 0);
+		                                   int error_check = 1,
+		                                   int suppress = 0);
 		void            xverify           (int error_check = 1,
-		                                      int suppress = 0);
+		                                   int suppress = 0);
 		void            setFlag           (char aFlag);
-		void            setModified       (const string& optionName,
-		                                   const string& optionValue);
+		void            setModified       (const std::string& optionName,
+		                                   const std::string& optionValue);
 		void            setOptions        (int argc, char** argv);
-		void            setOptions        (const vector<string>& argv);
-		void            setOptions        (const string& args);
+		void            setOptions        (const std::vector<std::string>& argv);
+		void            setOptions        (const std::string& args);
 		void            appendOptions     (int argc, char** argv);
-		void            appendOptions     (string& args);
-		void            appendOptions     (vector<string>& argv);
-		ostream&        printRegister     (ostream& out);
-		int             isDefined         (const string& name);
-		static vector<string> tokenizeCommandLine(const string& args);
+		void            appendOptions     (std::string& args);
+		void            appendOptions     (std::vector<std::string>& argv);
+		std::ostream&   printRegister     (std::ostream& out);
+		int             isDefined         (const std::string& name);
+		static std::vector<std::string> tokenizeCommandLine(const std::string& args);
 		bool            hasParseError     (void);
-		string          getParseError     (void);
-		ostream&        getParseError     (ostream& out);
+		std::string     getParseError     (void);
+		std::ostream&   getParseError     (std::ostream& out);
 
 	protected:
 		// m_argv: the list of raw command line strings including
 		// a mix of options and non-option argument.
-		vector<string> m_argv;
+		std::vector<std::string> m_argv;
 
 		// m_arguments: list of parsed command-line arguments which
 		// are not options, or the command (argv[0]);
-		vector<string> m_arguments;
+		std::vector<std::string> m_arguments;
 
 		// m_optionRegister: store for the states/values of each option.
-		vector<Option_register*> m_optionRegister;
+		std::vector<Option_register*> m_optionRegister;
 
 		// m_optionFlag: the character which indicates an option.
 		// Generally a dash, but could be made a slash for Windows environments.
 		char m_optionFlag = '-';
 
 		// m_optionList:
-		map<string, int> m_optionList;
+		std::map<std::string, int> m_optionList;
 
 		//
 		// boolern options for object:
@@ -5188,12 +5557,13 @@ class Options {
 		bool m_optionsArgQ = false;
 
 		// m_error: used to store errors in parsing command-line options.
-		stringstream m_error;
+		std::stringstream m_error;
 
-	private:
-		int     getRegIndex    (const string& optionName);
-		bool    isOption       (const string& aString, int& argp);
+	protected:
+		int     getRegIndex    (const std::string& optionName);
+		bool    isOption       (const std::string& aString, int& argp);
 		int     storeOption    (int gargp, int& position, int& running);
+
 };
 
 #define OPTION_BOOLEAN_TYPE   'b'
@@ -5215,29 +5585,29 @@ class HumTool : public Options {
 
 		bool          hasAnyText      (void);
 		std::string   getAllText      (void);
-		ostream&      getAllText      (ostream& out);
+		std::ostream& getAllText      (std::ostream& out);
 
 		bool          hasHumdrumText  (void);
 		std::string   getHumdrumText  (void);
-		ostream&      getHumdrumText  (ostream& out);
+		std::ostream& getHumdrumText  (std::ostream& out);
 		void          suppressHumdrumFileOutput(void);
 
 		bool          hasJsonText     (void);
 		std::string   getJsonText     (void);
-		ostream&      getJsonText     (ostream& out);
+		std::ostream& getJsonText     (std::ostream& out);
 
 		bool          hasFreeText     (void);
 		std::string   getFreeText     (void);
-		ostream&      getFreeText     (ostream& out);
+		std::ostream& getFreeText     (std::ostream& out);
 
 		bool          hasWarning      (void);
 		std::string   getWarning      (void);
-		ostream&      getWarning      (ostream& out);
+		std::ostream& getWarning      (std::ostream& out);
 
 		bool          hasError        (void);
 		std::string   getError        (void);
-		ostream&      getError        (ostream& out);
-		void          setError        (const string& message);
+		std::ostream& getError        (std::ostream& out);
+		void          setError        (const std::string& message);
 
 		virtual void  finally         (void) { };
 
@@ -5257,6 +5627,53 @@ class HumTool : public Options {
 //
 // common command-line Interfaces
 //
+
+//////////////////////////////
+//
+// TEXT_INTERFACE -- Expects one text file, either from the
+//    first command-line argument (left over after options have been
+//    parsed out), or from standard input.
+//
+// function call that the interface must implement:
+//  .run(const string& instring, ostream& out)
+//
+//
+
+#define TEXT_INTERFACE(CLASS)                          \
+int main(int argc, char** argv) {                      \
+	hum::CLASS interface;                               \
+	if (!interface.process(argc, argv)) {               \
+		interface.getError(std::cerr);                   \
+		return -1;                                       \
+	}                                                   \
+	string instring;                                    \
+	if (interface.getArgCount() > 0) {                  \
+		ifstream input(interface.getArgument(1));        \
+		if (!input) {                                    \
+			throw std::runtime_error("Could not open file: " + interface.getArgument(1)); \
+		}                                                \
+		stringstream buf;                                \
+		buf << input.rdbuf();                            \
+		instring = buf.str();                            \
+	} else {                                            \
+		stringstream buf;                                \
+		buf << cin.rdbuf();                              \
+		instring = buf.str();                            \
+	}                                                   \
+	int status = interface.run(instring, std::cout);    \
+	interface.finally();                                \
+	if (interface.hasWarning()) {                       \
+		interface.getWarning(std::cerr);                 \
+		return 0;                                        \
+	}                                                   \
+	if (interface.hasError()) {                         \
+		interface.getError(std::cerr);                   \
+		return -1;                                       \
+	}                                                   \
+	return !status;                                     \
+}
+
+
 
 //////////////////////////////
 //
@@ -5283,6 +5700,7 @@ int main(int argc, char** argv) {                      \
 		infile.readNoRhythm(std::cin);                   \
 	}                                                   \
 	int status = interface.run(infile, std::cout);      \
+	interface.finally();                                \
 	if (interface.hasWarning()) {                       \
 		interface.getWarning(std::cerr);                 \
 		return 0;                                        \
@@ -5291,7 +5709,6 @@ int main(int argc, char** argv) {                      \
 		interface.getError(std::cerr);                   \
 		return -1;                                       \
 	}                                                   \
-	interface.finally();                                \
 	return !status;                                     \
 }
 
@@ -5315,24 +5732,24 @@ int main(int argc, char** argv) {                                          \
 	bool status = true;                                                     \
 	while (instream.readSingleSegment(infiles)) {                           \
 		status &= interface.run(infiles);                                    \
-		if (interface.hasWarning()) {                                        \
-			interface.getWarning(std::cerr);                                  \
-		}                                                                    \
-		if (interface.hasAnyText()) {                                        \
-		   interface.getAllText(std::cout);                                  \
-		}                                                                    \
-		if (interface.hasError()) {                                          \
-			interface.getError(std::cerr);                                    \
-         return -1;                                                        \
-		}                                                                    \
-		if (!interface.hasAnyText()) {                                       \
-			for (int i=0; i<infiles.getCount(); i++) {                        \
-				cout << infiles[i];                                            \
-			}                                                                 \
-		}                                                                    \
-		interface.clearOutput();                                             \
 	}                                                                       \
 	interface.finally();                                                    \
+	if (interface.hasWarning()) {                                           \
+		interface.getWarning(std::cerr);                                     \
+	}                                                                       \
+	if (interface.hasAnyText()) {                                           \
+	   interface.getAllText(std::cout);                                     \
+	}                                                                       \
+	if (interface.hasError()) {                                             \
+		interface.getError(std::cerr);                                       \
+        return -1;                                                         \
+	}                                                                       \
+	if (!interface.hasAnyText()) {                                          \
+		for (int i=0; i<infiles.getCount(); i++) {                           \
+			cout << infiles[i];                                               \
+		}                                                                    \
+	}                                                                       \
+	interface.clearOutput();                                                \
 	return !status;                                                         \
 }
 
@@ -5354,6 +5771,7 @@ int main(int argc, char** argv) {                                          \
 	}                                                                       \
 	hum::HumdrumFileStream instream(static_cast<hum::Options&>(interface)); \
 	bool status = interface.run(instream);                                  \
+	interface.finally();                                                    \
 	if (interface.hasWarning()) {                                           \
 		interface.getWarning(std::cerr);                                     \
 	}                                                                       \
@@ -5364,7 +5782,6 @@ int main(int argc, char** argv) {                                          \
 		interface.getError(std::cerr);                                       \
         return -1;                                                         \
 	}                                                                       \
-	interface.finally();                                                    \
 	interface.clearOutput();                                                \
 	return !status;                                                         \
 }
@@ -5388,6 +5805,7 @@ int main(int argc, char** argv) {                                          \
 	hum::HumdrumFileSet infiles;                                            \
 	instream.read(infiles);                                                 \
 	bool status = interface.run(infiles);                                   \
+	interface.finally();                                                    \
 	if (interface.hasWarning()) {                                           \
 		interface.getWarning(std::cerr);                                     \
 	}                                                                       \
@@ -5403,7 +5821,6 @@ int main(int argc, char** argv) {                                          \
 			std::cout << infiles[i];                                          \
 		}                                                                    \
 	}                                                                       \
-	interface.finally();                                                    \
 	interface.clearOutput();                                                \
 	return !status;                                                         \
 }
@@ -5418,9 +5835,9 @@ class HumdrumFileStream {
 		                HumdrumFileStream  (char** list);
 		                HumdrumFileStream  (const std::vector<std::string>& list);
 		                HumdrumFileStream  (Options& options);
-		                HumdrumFileStream  (const string& datastream);
+		                HumdrumFileStream  (const std::string& datastream);
 
-		void            loadString         (const string& data);
+		void            loadString         (const std::string& data);
 
 		int             setFileList        (char** list);
 		int             setFileList        (const std::vector<std::string>& list);
@@ -5490,12 +5907,46 @@ class HumdrumFileSet {
 		int                   appendHumdrumPointer(HumdrumFile* infile);
 
    protected:
-      vector<HumdrumFile*>  m_data;
+      std::vector<HumdrumFile*>  m_data;
 
       void                  appendHumdrumFileContent(const std::string& filename,
                                                std::stringstream& inbuffer);
 };
 
+
+
+class Tool_1520ify : public HumTool {
+	public:
+		            Tool_1520ify       (void);
+		           ~Tool_1520ify       () {};
+
+		bool        run                (HumdrumFileSet& infiles);
+		bool        run                (HumdrumFile& infile);
+		bool        run                (const std::string& indata, std::ostream& out);
+		bool        run                (HumdrumFile& infile, std::ostream& out);
+
+	protected:
+		void        initialize         (HumdrumFile& infile);
+		void        processFile        (HumdrumFile& infile);
+		void        updateKeySignatures(HumdrumFile& infile, int lineindex);
+		void        checkDataLine      (HumdrumFile& infile, int lineindex);
+		void        clearStates        (void);
+		void        addBibliographicRecords(HumdrumFile& infile);
+		void        deleteBreaks       (HumdrumFile& infile);
+		void        fixEditorialAccidentals(HumdrumFile& infile);
+		void        fixInstrumentAbbreviations(HumdrumFile& infile);
+		void        addTerminalLongs   (HumdrumFile& infile);
+		void        deleteDummyTranspositions(HumdrumFile& infile);
+		std::string getDate            (void);
+		int         getYear            (void);
+		void        adjustSystemDecoration(HumdrumFile& infile);
+
+	private:
+		std::vector<std::vector<int>>  m_pstates;
+		std::vector<std::vector<int>>  m_kstates;
+		std::vector<std::vector<bool>> m_estates;
+
+};
 
 
 class Tool_addic : public HumTool {
@@ -5505,14 +5956,14 @@ class Tool_addic : public HumTool {
 
 		bool     run               (HumdrumFileSet& infiles);
 		bool     run               (HumdrumFile& infile);
-		bool     run               (const string& indata, ostream& out);
-		bool     run               (HumdrumFile& infile, ostream& out);
+		bool     run               (const std::string& indata, std::ostream& out);
+		bool     run               (HumdrumFile& infile, std::ostream& out);
 
 		int      getInstrumentCodeIndex(HumdrumFile& infile);
 		int      getInstrumentClassIndex(HumdrumFile& infile);
 		void     updateInstrumentClassLine(HumdrumFile& infile, int codeIndex, int classIndex);
 		std::string makeClassLine(HumdrumFile& infile, int codeIndex);
-		std::string getInstrumentClass(const string& code);
+		std::string getInstrumentClass(const std::string& code);
 
 
 	protected:
@@ -5527,29 +5978,115 @@ class Tool_addic : public HumTool {
 };
 
 
-class Tool_autoaccid : public HumTool {
+class Tool_addkey : public HumTool {
 	public:
-		         Tool_autoaccid    (void);
-		        ~Tool_autoaccid    () {};
+		         Tool_addkey     (void);
+		        ~Tool_addkey     () {};
 
 		bool     run               (HumdrumFileSet& infiles);
 		bool     run               (HumdrumFile& infile);
-		bool     run               (const string& indata, ostream& out);
-		bool     run               (HumdrumFile& infile, ostream& out);
+		bool     run               (const std::string& indata, std::ostream& out);
+		bool     run               (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void    processFile        (HumdrumFile& infile);
 		void    initialize         (void);
-		void    addAccidentalInfo  (HTp token);
-		void    removeAccidentalQualifications(HumdrumFile& infile);
-		void    addAccidentalQualifications(HumdrumFile& infile);
-		string  setVisualState     (const string& input, bool state);
+		void    getLineIndexes     (HumdrumFile& infile);
+		void    insertReferenceKey (HumdrumFile& infile);
+		void    addInputKey        (HumdrumFile& infile);
+		void    insertKeyDesig     (HumdrumFile& infile, const std::string& keyDesig);
+		void    printKeyDesig      (HumdrumFile& infile, int index, const std::string& desig, int direction);
 
 	private:
-		bool    m_visualQ;
-		bool    m_hiddenQ;
-		bool    m_removeQ;
-		bool    m_cautionQ;
+		std::string m_key;
+		bool        m_keyQ           = false;
+		bool        m_addKeyRefQ     = false;
+
+		int         m_exinterpIndex  = -1;
+		int         m_refKeyIndex    = -1;
+		int         m_keyDesigIndex  = -1;
+		int         m_keySigIndex    = -1;
+		int         m_dataStartIndex = -1;
+
+};
+
+
+class Tool_addlabels : public HumTool {
+	public:
+		         Tool_addlabels     (void);
+		        ~Tool_addlabels     () {};
+
+		bool     run               (HumdrumFileSet& infiles);
+		bool     run               (HumdrumFile& infile);
+		bool     run               (const std::string& indata, std::ostream& out);
+		bool     run               (HumdrumFile& infile, std::ostream& out);
+
+	protected:
+		void    processFile        (HumdrumFile& infile);
+		void    initialize         (void);
+		int     getExpansionIndex  (HumdrumFile& infile);
+		void    printExpansionLists(HumdrumFile& infile, int index);
+		void    assignLabels       (std::vector<std::string>& llist, HumdrumFile& infile);
+		void    addLabel           (std::vector<std::string>& llist, HumdrumFile& infile,
+		                            int barnum, int subbarnum, const std::string& label);
+	private:
+		std::string m_default;             // set with the -d option
+		std::string m_norep;               // set with the -r option
+		std::string m_zeroth;              // m0 label (right after default and norep expansion lists)
+		int m_defaultIndex = -1;           // line to place default expansions list above (and then norep)
+		std::vector<int> m_barnums;        // set with -l option
+		std::vector<int> m_subbarnums;     // set with -l option
+		std::vector<std::string> m_labels; // set with -l option
+};
+
+
+class Tool_addtempo : public HumTool {
+	public:
+		         Tool_addtempo     (void);
+		        ~Tool_addtempo     () {};
+
+		bool     run               (HumdrumFileSet& infiles);
+		bool     run               (HumdrumFile& infile);
+		bool     run               (const std::string& indata, std::ostream& out);
+		bool     run               (HumdrumFile& infile, std::ostream& out);
+
+	protected:
+		void    processFile        (HumdrumFile& infile);
+		void    initialize         (void);
+		void    assignTempoChanges (std::vector<double>& tlist, HumdrumFile& infile);
+		void    addTempo           (std::vector<double>& tlist, HumdrumFile& infile, int measure, double tempo, int offset);
+		void    addTempoToStart    (std::vector<double>& tlist, HumdrumFile& infile, double tempo);
+
+	private:
+		// tuple<measure, tempo, mesure offset>
+		std::vector<std::tuple<int, double, int>> m_tempos;
+
+};
+
+
+class Tool_autoaccid : public HumTool {
+	public:
+		             Tool_autoaccid    (void);
+		            ~Tool_autoaccid    () {};
+
+		bool         run               (HumdrumFileSet& infiles);
+		bool         run               (HumdrumFile& infile);
+		bool         run               (const std::string& indata, std::ostream& out);
+		bool         run               (HumdrumFile& infile, std::ostream& out);
+
+	protected:
+		void        processFile        (HumdrumFile& infile);
+		void        initialize         (void);
+		void        addAccidentalInfo  (HTp token);
+		void        removeAccidentalQualifications(HumdrumFile& infile);
+		void        addAccidentalQualifications(HumdrumFile& infile);
+		std::string setVisualState     (const std::string& input, bool state);
+
+	private:
+		bool         m_visualQ;
+		bool         m_hiddenQ;
+		bool         m_removeQ;
+		bool         m_cautionQ;
 
 };
 
@@ -5557,45 +6094,250 @@ class Tool_autoaccid : public HumTool {
 
 class Tool_autobeam : public HumTool {
 	public:
-		         Tool_autobeam   (void);
-		        ~Tool_autobeam   () {};
+		             Tool_autobeam       (void);
+		            ~Tool_autobeam       () {};
 
-		bool     run             (HumdrumFile& infile);
-		bool     run             (HumdrumFileSet& infiles);
-		bool     run             (const string& indata, ostream& out);
-		bool     run             (HumdrumFile& infile, ostream& out);
+		bool         run                 (HumdrumFile& infile);
+		bool         run                 (HumdrumFileSet& infiles);
+		bool         run                 (const std::string& indata, std::ostream& out);
+		bool         run                 (HumdrumFile& infile, std::ostream& out);
 
 	protected:
-		void     initialize      (HumdrumFile& infile);
-		void     processStrand   (HTp strandstart, HTp strandend);
-		void     processMeasure  (vector<HTp>& measure);
-		void     addBeam         (HTp startnote, HTp endnote);
-		void     addBeams        (HumdrumFile& infile);
-		void     beamGraceNotes  (HumdrumFile& infile);
-		string   getBeamFromDur  (HTp token, const string& text);
-		void     removeQqMarks   (HTp stok, HTp etok);
-		void     removeQqMarks   (HTp tok);
-		void     removeBeams     (HumdrumFile& infile);
-		void     removeEdgeRests (HTp& startnote, HTp& endnote);
-		void     breakBeamsByLyrics(HumdrumFile& infile);
-		void     processStrandForLyrics(HTp stok, HTp etok);
-		bool     hasSyllable     (HTp token);
-		void     splitBeam       (HTp tok, HTp stok, HTp etok);
-		void     splitBeam2      (vector<HTp>& group, HTp tok);
-		void     getBeamedNotes(vector<HTp>& toks, HTp tok, HTp stok, HTp etok);
-		bool     isLazy          (vector<HTp>& group);
-		void     splitBeamLazy   (vector<HTp>& group, HTp tok);
-		void     splitBeamNotLazy(vector<HTp>& group, HTp tok);
-		void     removeBeamCharacters(HTp token);
+		void         initialize          (HumdrumFile& infile);
+		void         processStrand       (HTp strandstart, HTp strandend);
+		void         processMeasure      (std::vector<HTp>& measure);
+		void         addBeam             (HTp startnote, HTp endnote);
+		void         addBeams            (HumdrumFile& infile);
+		void         beamGraceNotes      (HumdrumFile& infile);
+		std::string  getBeamFromDur      (HTp token, const std::string& text);
+		void         removeQqMarks       (HTp stok, HTp etok);
+		void         removeQqMarks       (HTp tok);
+		void         removeBeams         (HumdrumFile& infile);
+		void         removeEdgeRests     (HTp& startnote, HTp& endnote);
+		void         breakBeamsByLyrics  (HumdrumFile& infile);
+		void         processStrandForLyrics(HTp stok, HTp etok);
+		bool         hasSyllable         (HTp token);
+		void         splitBeam           (HTp tok, HTp stok, HTp etok);
+		void         splitBeam2          (std::vector<HTp>& group, HTp tok);
+		void         getBeamedNotes      (std::vector<HTp>& toks, HTp tok, HTp stok, HTp etok);
+		bool         isLazy              (std::vector<HTp>& group);
+		void         splitBeamLazy       (std::vector<HTp>& group, HTp tok);
+		void         splitBeamNotLazy    (std::vector<HTp>& group, HTp tok);
+		void         removeBeamCharacters(HTp token);
 
 	private:
-		std::vector<std::vector<pair<int, HumNum> > > m_timesigs;
+		std::vector<std::vector<std::pair<int, HumNum> > > m_timesigs;
 		std::vector<HTp> m_kernspines;
 		bool        m_overwriteQ = false;
 		std::vector<bool> m_tracks;
 		bool        m_includerests = false;
 		int         m_splitcount = 0;
+		HumNum      m_duration = 0;
 
+};
+
+
+class Tool_autocadence : public HumTool {
+	class CadenceDefinition {
+		public:
+			std::string m_funcL;
+			std::string m_funcU;
+			std::string m_name;
+			std::string m_regex;
+			void setDefinition(const std::string& funcL, const std::string& funcU,
+					const std::string& name, const std::string& regex) {
+				m_funcL = funcL;
+				m_funcU = funcU;
+				m_name = name;
+				m_regex = regex;
+				// int count = std::count(text.begin(), text.end(), target);
+			}
+	};
+
+	public:
+		            Tool_autocadence           (void);
+		           ~Tool_autocadence           () {};
+
+		bool        run                 (HumdrumFileSet& infiles);
+		bool        run                 (HumdrumFile& infile);
+		bool        run                 (const std::string& indata, std::ostream& out);
+		bool        run                 (HumdrumFile& infile, std::ostream& out);
+		void        initialize          (void);
+
+	protected:
+		void        processFile         (HumdrumFile& infile);
+		void        fillInLastMelodicInterval(HumdrumFile& infile);
+		void        getTokenList        (HTp start, std::vector<HTp>& holder);
+		void        calculateVoiceIntervals(const std::vector<HTp>& contents,
+		                                    std::vector<int>& diatonic,
+		                                    std::vector<std::string>& interval);
+		void        generateCounterpointStrings(std::vector<HTp>& kspines, int indexL, int indexU);
+		std::string generateCounterpointString(std::vector<std::vector<HTp>>& pairings, int index);
+      void        printModules        (std::vector<std::string>& modules, int lowerPart, int upperPart);
+		void        fillNotes           (std::vector<HTp>& voice, HTp exinterp);
+		std::string getDiatonicIntervalString  (int lower, int upper);
+		int         getDiatonicInterval        (int lower, int upper);
+		void        prepareCadenceDefinitions  (void);
+		void        prepareCadenceLabels       (void);
+		void        addCadenceLabel            (std::string definition, std::string label);
+		void        addCadenceDefinition       (const std::string& funcL, const std::string& funcU,
+		                                        const std::string& name, const std::string& regex);
+		void        prepareLowestPitches       (void);
+		void        preparePitchInfo           (HumdrumFile& infile);
+		void        prepareDiatonicPitches     (HumdrumFile& infile);
+		void        printExtractedPitchInfo    (HumdrumFile& infile);
+		void        printExtractedIntervalInfo (HumdrumFile& infile);
+		void        prepareIntervalInfo        (HumdrumFile& infile);
+		int         getPairIndex               (HTp lowerExInterp, HTp upperExInterp);
+		void        prepareTrackToVoiceIndex   (HumdrumFile& infile, std::vector<HTp> kspines);
+		void        printIntervalManipulatorLine(HumdrumFile& infile, int index, int kcount);
+		void        printIntervalDataLine      (HumdrumFile& infile, int index, int kcount);
+		void        printIntervalDataLineScore (HumdrumFile& infile, int index, int kcount);
+		void        printIntervalLine          (HumdrumFile& infile, int index, int kcount, const std::string& tok);
+		void        prepareAbbreviations       (HumdrumFile& infile);
+		void        prepareIntervalSequences   (HumdrumFile& infile);
+		void        prepareSinglePairSequences (HumdrumFile& infile, int vindex, int pindex);
+		std::string generateSequenceString     (HumdrumFile& infile, int lindex, int vindex, int pindex);
+		void        printSequenceInfo          (void);
+		void        printSequenceMatches       (void);
+		void        printSequenceMatches2      (void);
+		void        searchIntervalSequences    (void);
+		void        printScore                 (HumdrumFile& infile);
+		void        printMatchCount            (void);
+		void        markupScore                (HumdrumFile& infile);
+		void        addMatchToScore            (HumdrumFile& infile, int matchIndex);
+		int         getRegexSliceCount         (const std::string& regex);
+		void        colorNotes                 (HTp startTok, HTp endTok);
+		void        prepareDefinitionList      (std::set<int>& list);
+		void        printRegexTable            (void);
+		void        printDefinitionRow         (int index);
+		void        prepareCvfNames            (void);
+		void        prepareDissonanceNames     (void);
+		std::string getFunctionNames           (const std::string& input);
+		std::string getDissonanceNames         (const std::string& input);
+		void        highlightNoteAttack        (HTp startTok);
+		bool        getCadenceEndSliceNotes    (HTp& endL, HTp& endU, int count, HumdrumFile& infile,
+		                                        int lindex, int vindex, int pindex);
+		void        prepareDissonances         (HumdrumFile& infile);
+		void        prepareDissonancesForLine  (HumdrumLine& iline, HumdrumLine& dline);
+		void        identifySuspensionsAndAgents(HumdrumFile& infile);
+		std::string sortUniqueChars            (const std::string& input);
+		void        fillInMajorMinor           (HumdrumFile& infile);
+		bool        getPhrygian                (HumdrumFile& infile, int index);
+		std::string getIntervalName            (const std::string& b40);
+		std::string getTriadData               (HumdrumFile& infile, int line);
+
+	private:
+
+		// m_definitions: A list of the cadence regular expression definitions.
+		std::vector<Tool_autocadence::CadenceDefinition> m_definitions;
+
+		// m_pitches: A list of the diatonic pitches for the score, organized
+		// in a 2-D array that matches the line/field number of the notes.
+		// Middle C is 28, rests are 0, and negative values are sustained
+		// pitches.
+		std::vector<std::vector<int>> m_pitches;
+
+		// m_lowestPitch: the lowest sounding pitch at every instance in the score.
+		// the pitch is stored as an absolute diatonic pitch, middle C is 28, 0 is a rest
+		std::vector<int> m_lowestPitch;
+
+		// m_intervals: The counterpoint intervals for each pair of notes.
+		// The data is store in a 3-D vector, where the first dimension is the
+		// line in the score, the second dimension is the voice (kern spine) index in
+		// the score for the lower voice.  For example, if the score has four **kern
+		// spines, the second dimension size will be four, and the third dimensions
+		// will be 3, 2, 1 and 0.  
+		// Dimensions:
+		//     0: line index in the Humdrum data
+		//     1: voice index of the lower voice
+		//     2: pairing interval of two voice generating the interval
+		// Parameters for tuple:
+		//     0: interval string for the note pair (or empty if no interval.
+		//     1: the token for the lower voice note
+		//     2: the token for the upper voice note
+		std::vector<std::vector<std::vector<std::tuple<std::string, HTp, HTp>>>> m_intervals;
+
+		// m_sequences: The counterpoint interval strings which are searched
+		// with the regular expressions in m_definitions.
+		// Dimensions:
+		//    0: voice index
+		//    1: voice pair index
+		//    2: an array of tuples, only one which is used.  zero length means no sequence.
+		// Parameters for tuple:
+		//    0: sequence to search
+		//    1: first note of sequence in score (lower voice)
+		//    2: first note of sequence in score (upper voice)
+		//    3: vector of ints listing matches where int is the m_definitions index(es) that match.
+		std::vector<std::vector<std::vector<std::tuple<std::string, HTp, HTp, std::vector<int>>>>> m_sequences;
+
+		// m_matches: List of sequences that match to a cadence formula.  The list contains
+		// the vindex, pindex, and nth sequence in m_sequences.
+		std::vector<std::vector<int>> m_matches;
+
+		// m_trackToVoiceIndex: Mapping from track to voice index (starting with 0)
+		// for the lowest voice).
+		std::vector<int> m_trackToVoiceIndex;
+
+		// m_abbr: voice abbreviations to prefix interval data in score for voices.
+		// Indexed by voice (lowest = 0).
+		std::vector<std::string> m_abbr;
+
+		// m_functionNames: mapping from CVF abbreviation to full name of CFV.
+		std::map<std::string, std::string> m_functionNames;
+
+		// m_dissonanceNames: mapping from dissonance abbreviation to full name of dissonance.
+		std::map<std::string, std::string> m_dissonanceNames;
+
+		// m_cadenceLabels: mapping from part function to full name of cadence.
+		std::map<std::string, std::string> m_cadenceLabels;
+
+		// m_barnum: mapping from line to measure number (of fist spine);
+		std::vector<int> m_barnum;
+
+		// m_lastmel: The last melodic interval (diatonic)
+		std::vector<std::vector<std::string>> m_lastmel;
+
+		bool m_hasSuspensionMarkersQ = false;
+
+		// options:
+		bool m_intervalsQ               = false; // -i: show counterpoint interval infomation
+		bool m_intervalsOnlyQ           = false; // -I: show counterpoint interval infomation but
+		                                         //     do not do cadence analysis
+		bool m_printRawDiatonicPitchesQ = false; // -p: display m_pitches after filling
+		int  m_sequenceLength           = 7;     // maximum regex interval sequence length
+		bool m_matchesQ                 = false; // -m: display sequences that match to cadence formula(s)
+		bool m_printSequenceInfoQ       = false; // -s: print list of interval sequences
+		bool m_countQ                   = false; // --count: print number of cadences found
+		bool m_colorQ                   = false; // -c: color matched cadence formula
+		std::string m_triadColor        = "salmon"; // -C: color triad analysis
+		std::string m_color             = "dodgerblue"; // --color "string" to set matched notes to a specific color
+		bool m_showFormulaIndexQ        = false; // -f: show formulation index after CVF label
+		bool m_evenNoteSpacingQ         = false; // -e: compress notation (verovio option evenNoteSpacing)
+		bool m_regexQ                   = false; // -r: show table of matched regular expressions
+		bool m_popupQ                   = true;  // --pop: show popup when hoving over CFV lables (to be implemented)
+		bool m_nobackQ                  = false; // -B: don't highlight start of sustain at start of cadence definition
+		bool m_showSuspensionsQ         = true;  // !-S: show suspension/agent labels in output score
+		bool m_lowestQ                  = false; // -l: use lowest note to define suspensions instead of dissonance analysis
+		bool m_repeatQ                  = false; // -r: allow repeated notes
+		bool m_infoQ                    = false; // -i print info only
+		bool m_fileQ                    = false; // -f print filename info
+		bool m_lastQ                    = false;  // -L
+		bool m_markupQ                  = false; // -M
+		bool m_rootQ                    = false; // --root
+		bool m_qualityQ                 = false; // -q
+		bool m_triadQ                   = false; // -q|--root
+
+		int         m_cadenceCount = 0;
+		std::string m_marker = "@";
+		std::string m_suspensionMarker = "N";
+		std::string m_suspensionColor  = "crimson";
+		std::stringstream m_info;
+		std::string m_lastMelColor     = "limegreen";
+		std::vector<std::string> m_quality;
+		std::vector<std::string> m_root;
+		bool m_foundEmpytTriad = false;
+		bool m_hasTriadColor = false;
 };
 
 
@@ -5616,61 +6358,61 @@ class Tool_autostem : public HumTool {
 
 		bool     run                   (HumdrumFileSet& infiles);
 		bool     run                   (HumdrumFile& infile);
-		bool     run                   (const string& indata, ostream& out);
-		bool     run                   (HumdrumFile& infile, ostream& out);
+		bool     run                   (const std::string& indata, std::ostream& out);
+		bool     run                   (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void     initialize            (HumdrumFile& infile);
 		void      example              (void);
 		void      usage                (void);
 		bool      autostem             (HumdrumFile& infile);
-		void      getClefInfo          (vector<vector<int> >& baseline,
+		void      getClefInfo          (std::vector<std::vector<int>>& baseline,
 		                                HumdrumFile& infile);
-		void      addStem              (string& input, const string& piece);
+		void      addStem              (std::string& input, const std::string& piece);
 		void      processKernTokenStemsSimpleModel(HumdrumFile& infile,
-		                                vector<vector<int> >& baseline,
+		                                std::vector<std::vector<int>>& baseline,
 		                                int row, int col);
 		void      removeStems          (HumdrumFile& infile);
 		void      removeStem2          (HumdrumFile& infile, int row, int col);
 		int       getVoice             (HumdrumFile& infile, int row, int col);
-		void      getNotePositions     (vector<vector<vector<int> > >& notepos,
-		                                vector<vector<int> >& baseline,
+		void      getNotePositions     (std::vector<std::vector<std::vector<int>>>& notepos,
+		                                std::vector<std::vector<int>>& baseline,
 		                                HumdrumFile& infile);
 		void      printNotePositions   (HumdrumFile& infile,
-		                                vector<vector<vector<int> > >& notepos);
-		void      getVoiceInfo         (vector<vector<int> >& voice, HumdrumFile& infile);
-		void      printVoiceInfo       (HumdrumFile& infile, vector<vector<int> >& voice);
+		                                std::vector<std::vector<std::vector<int>>>& notepos);
+		void      getVoiceInfo         (std::vector<std::vector<int>>& voice, HumdrumFile& infile);
+		void      printVoiceInfo       (HumdrumFile& infile, std::vector<std::vector<int>>& voice);
 		void      processKernTokenStems(HumdrumFile& infile,
-		                                vector<vector<int> >& baseline, int row, int col);
-		void      getMaxLayers         (vector<int>& maxlayer, vector<vector<int> >& voice,
+		                                std::vector<std::vector<int>>& baseline, int row, int col);
+		void      getMaxLayers         (std::vector<int>& maxlayer, std::vector<std::vector<int>>& voice,
 		                                HumdrumFile& infile);
-		bool      assignStemDirections (vector<vector<int> >& stemdir,
-		                                vector<vector<int> > & voice,
-		                                vector<vector<vector<int> > >& notepos,
+		bool      assignStemDirections (std::vector<std::vector<int>>& stemdir,
+		                                std::vector<std::vector<int>> & voice,
+		                                std::vector<std::vector<std::vector<int>>>& notepos,
 		                                HumdrumFile& infile);
-		void      assignBasicStemDirections(vector<vector<int> >& stemdir,
-		                                vector<vector<int> >& voice,
-		                                vector<vector<vector<int> > >& notepos,
+		void      assignBasicStemDirections(std::vector<std::vector<int>>& stemdir,
+		                                std::vector<std::vector<int>>& voice,
+		                                std::vector<std::vector<std::vector<int>>>& notepos,
 		                                HumdrumFile& infile);
-		int       determineChordStem   (vector<vector<int> >& voice,
-		                                vector<vector<vector<int> > >& notepos,
+		int       determineChordStem   (std::vector<std::vector<int>>& voice,
+		                                std::vector<std::vector<std::vector<int>>>& notepos,
 		                                HumdrumFile& infile, int row, int col);
 		void      insertStems          (HumdrumFile& infile,
-		                                vector<vector<int> >& stemdir);
+		                                std::vector<std::vector<int>>& stemdir);
 		void      setStemDirection     (HumdrumFile& infile, int row, int col,
 		                                int direction);
-		bool      getBeamState         (vector<vector<string > >& beams,
+		bool      getBeamState         (std::vector<std::vector<std::string >>& beams,
 		                                HumdrumFile& infile);
-		void      countBeamStuff       (const string& token, int& start, int& stop,
+		void      countBeamStuff       (const std::string& token, int& start, int& stop,
 		                                int& flagr, int& flagl);
-		void      getBeamSegments      (vector<vector<Coord> >& beamednotes,
-		                                vector<vector<string > >& beamstates,
-		                                HumdrumFile& infile, vector<int> maxlayer);
-		int       getBeamDirection     (vector<Coord>& coords,
-		                                vector<vector<int> >& voice,
-		                                vector<vector<vector<int> > >& notepos);
-		void      setBeamDirection     (vector<vector<int> >& stemdir,
-		                                vector<Coord>& bnote, int direction);
+		void      getBeamSegments      (std::vector<std::vector<Coord>>& beamednotes,
+		                                std::vector<std::vector<std::string >>& beamstates,
+		                                HumdrumFile& infile, std::vector<int> maxlayer);
+		int       getBeamDirection     (std::vector<Coord>& coords,
+		                                std::vector<std::vector<int>>& voice,
+		                                std::vector<std::vector<std::vector<int>>>& notepos);
+		void      setBeamDirection     (std::vector<std::vector<int>>& stemdir,
+		                                std::vector<Coord>& bnote, int direction);
 
 	private:
 		int    debugQ        = 0;       // used with --debug option
@@ -5688,6 +6430,36 @@ class Tool_autostem : public HumTool {
 };
 
 
+class Tool_barnum : public HumTool {
+	public:
+		         Tool_barnum          (void);
+		        ~Tool_barnum          () {};
+
+		bool     run               (HumdrumFileSet& infiles);
+		bool     run               (HumdrumFile& infile);
+		bool     run               (const std::string& indata, std::ostream& out);
+		bool     run               (HumdrumFile& infile, std::ostream& out);
+
+	protected:
+
+		void     processFile             (HumdrumFile& infile);
+		void     initialize              (void);
+		void     removeBarNumbers        (HumdrumFile& infile);
+		void     printWithoutBarNumbers  (HumdrumLine& humline);
+		void     printWithBarNumbers     (HumdrumLine& humline, int measurenum);
+		void     printSingleBarNumber    (const std::string& astring, int measurenum);
+		int      getEndingBarline        (HumdrumFile& infile);
+
+
+	private:
+   	bool m_removeQ;
+   	int m_startnum;
+   	bool m_debugQ;
+   	bool m_allQ;
+
+};
+
+
 class Tool_binroll : public HumTool {
 	public:
 		         Tool_binroll      (void);
@@ -5695,15 +6467,15 @@ class Tool_binroll : public HumTool {
 
 		bool     run               (HumdrumFileSet& infiles);
 		bool     run               (HumdrumFile& infile);
-		bool     run               (const string& indata, ostream& out);
-		bool     run               (HumdrumFile& infile, ostream& out);
+		bool     run               (const std::string& indata, std::ostream& out);
+		bool     run               (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void     processFile       (HumdrumFile& infile);
-		void     processStrand     (vector<vector<char>>& roll, HTp starting,
+		void     processStrand     (std::vector<std::vector<char>>& roll, HTp starting,
 		                            HTp ending);
 		void     printAnalysis     (HumdrumFile& infile,
-		                            vector<vector<char>>& roll);
+		                            std::vector<std::vector<char>>& roll);
 
 	private:
 		HumNum    m_duration;
@@ -5711,37 +6483,121 @@ class Tool_binroll : public HumTool {
 };
 
 
-class Tool_chantize : public HumTool {
-	public:
-		         Tool_chantize      (void);
-		        ~Tool_chantize      () {};
+class Tool_bstyle : public HumTool {
 
-		bool     run                (HumdrumFileSet& infiles);
-		bool     run                (HumdrumFile& infile);
-		bool     run                (const string& indata, ostream& out);
-		bool     run                (HumdrumFile& infile, ostream& out);
+	public:
+		     Tool_bstyle (void);
+		     ~Tool_bstyle() {};
+
+		bool run     (HumdrumFileSet& infiles);
+		bool run     (HumdrumFile& infile);
+		bool run     (const std::string& indata, std::ostream& out);
+		bool run     (HumdrumFile& infile, std::ostream& out);
 
 	protected:
-		void     initialize         (HumdrumFile& infile);
-		void     processFile        (HumdrumFile& infile);
-		void     outputFile         (HumdrumFile& infile);
-		void     updateKeySignatures(HumdrumFile& infile, int lineindex);
-		void     checkDataLine      (HumdrumFile& infile, int lineindex);
-		void     clearStates        (void);
-		void     addBibliographicRecords(HumdrumFile& infile);
-		void     deleteBreaks       (HumdrumFile& infile);
-		void     fixEditorialAccidentals(HumdrumFile& infile);
-		void     fixInstrumentAbbreviations(HumdrumFile& infile);
-		void     deleteDummyTranspositions(HumdrumFile& infile);
-		string   getDate            (void);
-		vector<bool> getTerminalRestStates(HumdrumFile& infile);
-		bool     hasDiamondNotes    (HumdrumFile& infile);
+		void         initialize   (void);
+      void         processFile  (HumdrumFile& infile);
+		void         removeBarStylings(HumdrumFile& infile);
+		void         removeBarStylings(HTp spine);
+		void         applyBarStylings(HumdrumFile& infile);
+		void         applyBarStylings(HTp spine);
 
 	private:
-		vector<vector<int>> m_pstates;
-		vector<vector<int>> m_kstates;
-		vector<vector<bool>> m_estates;
+		bool  m_removeQ = false;  // used with -r option
+
+};
+
+
+class Tool_chantize : public HumTool {
+	public:
+		                  Tool_chantize             (void);
+		                 ~Tool_chantize             () {};
+
+		bool              run                       (HumdrumFileSet& infiles);
+		bool              run                       (HumdrumFile& infile);
+		bool              run                       (const std::string& indata, std::ostream& out);
+		bool              run                       (HumdrumFile& infile, std::ostream& out);
+
+	protected:
+		void              initialize                (HumdrumFile& infile);
+		void              processFile               (HumdrumFile& infile);
+		void              outputFile                (HumdrumFile& infile);
+		void              updateKeySignatures       (HumdrumFile& infile, int lineindex);
+		void              checkDataLine             (HumdrumFile& infile, int lineindex);
+		void              clearStates               (void);
+		void              addBibliographicRecords   (HumdrumFile& infile);
+		void              deleteBreaks              (HumdrumFile& infile);
+		void              fixEditorialAccidentals   (HumdrumFile& infile);
+		void              fixInstrumentAbbreviations(HumdrumFile& infile);
+		void              deleteDummyTranspositions (HumdrumFile& infile);
+		std::string       getDate                   (void);
+		std::vector<bool> getTerminalRestStates      (HumdrumFile& infile);
+		bool              hasDiamondNotes           (HumdrumFile& infile);
+
+	private:
+		std::vector<std::vector<int>>  m_pstates;
+		std::vector<std::vector<int>>  m_kstates;
+		std::vector<std::vector<bool>> m_estates;
 		bool m_diamondQ = false;
+};
+
+
+class Tool_chint : public HumTool {
+	public:
+		         Tool_chint          (void);
+		        ~Tool_chint          () {};
+
+		bool     run                 (HumdrumFileSet& infiles);
+		bool     run                 (HumdrumFile& infile);
+		bool     run                 (const std::string& indata, std::ostream& out);
+		bool     run                 (HumdrumFile& infile, std::ostream& out);
+
+	protected:
+		void    processFile          (HumdrumFile& infile);
+		void    initialize           (void);
+		void    fillIntervalNames    (void);
+		void    fillIntervalNamesDiatonic(void);
+		void    chromaticColoring    (void);
+		void    dissonanceColoring   (void);
+		void    getPartIntervals     (std::vector<int>& topInterval,
+		                              std::vector<int>& botInterval,
+		                              HTp botSpine, HTp topSpine, HumdrumFile& infile);
+		void    insertPartColors     (HumdrumFile& infile, std::vector<int>& botInterval,
+		                              std::vector<int>& topInterval, int botTrack, int topTrack);
+		std::string getColorToken    (int interval, HumdrumFile& infile, int line, HTp token);
+		std::string getIntervalToken (int interval, HumdrumFile& infile, int line);
+
+	private:
+		// m_color: Color mapping for notes, indexed by base-40:
+		std::vector<std::string> m_color;
+
+		// m_intervals: Names of intervals indexed by base-40:
+		std::vector<std::string> m_intervals;
+
+		// Used in particular to avoid adding interval when both
+		// staves have tied notes:
+		std::vector<std::string>  m_botPitch;
+		std::vector<std::string>  m_topPitch;
+
+		// m_intervalQ: Show interval numbers
+		bool m_intervalQ = false;
+
+		// m_octaveQ: Do not collapse octaves to unisons.
+		bool m_octaveQ = false;
+
+		// m_noColorBotQ: Do not colorize bottom analysis staff
+		bool m_noColorBotQ = false;
+
+		// m_noColortopQ: Do not colorize top analysis staff
+		bool m_noColorTopQ = false;
+
+		// m_negativeQ: Add minus sign to intervals
+		// when staff notes are crossed.
+		bool m_negativeQ = false;
+
+		// m_middle: Add intervals between analysis staves, or actually
+		// below top staff. (Only effective in JavaScript compiled code.)
+		bool m_middleQ = true;
 
 };
 
@@ -5752,18 +6608,18 @@ class Tool_chooser : public HumTool {
 		       	  ~Tool_chooser       () {};
 
 		bool        run                (HumdrumFileSet& infiles);
-		bool        run                (const string& indata);
+		bool        run                (const std::string& indata);
 		bool        run                (HumdrumFileStream& instream);
 
 	protected:
 		void        processFiles       (HumdrumFileSet& infiles);
 		void        initialize         (void);
 
-		void        expandSegmentList  (vector<int>& field, string& fieldstring,
+		void        expandSegmentList  (std::vector<int>& field, std::string& fieldstring,
 		                                int maximum);
-		void        processSegmentEntry(vector<int>& field,
-		                                const string& astring, int maximum);
-		void        removeDollarsFromString(string& buffer, int maximum);
+		void        processSegmentEntry(std::vector<int>& field,
+		                                const std::string& astring, int maximum);
+		void        removeDollarsFromString(std::string& buffer, int maximum);
 
 	private:
 
@@ -5777,15 +6633,15 @@ class Tool_chord : public HumTool {
 
 		bool     run               (HumdrumFileSet& infiles);
 		bool     run               (HumdrumFile& infile);
-		bool     run               (const string& indata, ostream& out);
-		bool     run               (HumdrumFile& infile, ostream& out);
+		bool     run               (const std::string& indata, std::ostream& out);
+		bool     run               (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void     processFile       (HumdrumFile& infile, int direction);
 		void     processChord      (HTp tok, int direction);
 		void     initialize        (void);
-		void     minimizeChordPitches(vector<string>& notes, vector<pair<int,int>>& pitches);
-		void     maximizeChordPitches(vector<string>& notes, vector<pair<int,int>>& pitches);
+		void     minimizeChordPitches(std::vector<std::string>& notes, std::vector<std::pair<int, int>>& pitches);
+		void     maximizeChordPitches(std::vector<std::string>& notes, std::vector<std::pair<int, int>>& pitches);
 
 	private:
 		int       m_direction = 0;
@@ -5999,7 +6855,7 @@ class cmr_note_info {
 		HumNum   getStartTime     (void);
 		HumNum   getEndTime       (void);
 		int      getMidiPitch     (void);
-		string   getPitch         (void);
+		std::string   getPitch         (void);
 		HTp      getToken         (void);
 		int      getLineIndex     (void);
 		double   getNoteStrength  (void);
@@ -6064,7 +6920,7 @@ class cmr_group_info {
 		int     getSyncopationCount(void);
 		void    makeInvalid        (void);
 		bool    isValid            (void);
-		string  getPitch           (void);
+		std::string  getPitch      (void);
 		HumNum  getEndTime         (void);
 		HumNum  getGroupDuration   (void);
 		HumNum  getStartTime       (void);
@@ -6133,7 +6989,7 @@ class Tool_cmr : public HumTool {
 		int              getGroupNoteCount       (void);
 		int 						 getStrengthScore        (void);
 		void             printStatistics         (HumdrumFile& infile);
-		string           getComposer             (HumdrumFile& infile);
+		std::string           getComposer             (HumdrumFile& infile);
 		void             printSummaryStatistics  (HumdrumFile& infile);
 		void             storeVegaData           (HumdrumFile& infile);
 		void             printVegaPlot           (void);
@@ -6246,8 +7102,8 @@ class Tool_colorgroups : public HumTool {
 
 		bool     run               (HumdrumFileSet& infiles);
 		bool     run               (HumdrumFile& infile);
-		bool     run               (const string& indata, ostream& out);
-		bool     run               (HumdrumFile& infile, ostream& out);
+		bool     run               (const std::string& indata, std::ostream& out);
+		bool     run               (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void     processFile       (HumdrumFile& infile);
@@ -6263,8 +7119,8 @@ class Tool_colortriads : public HumTool {
 
 		bool     run               (HumdrumFileSet& infiles);
 		bool     run               (HumdrumFile& infile);
-		bool     run               (const string& indata, ostream& out);
-		bool     run               (HumdrumFile& infile, ostream& out);
+		bool     run               (const std::string& indata, std::ostream& out);
+		bool     run               (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void     processFile       (HumdrumFile& infile);
@@ -6272,7 +7128,7 @@ class Tool_colortriads : public HumTool {
 		int      getDiatonicTransposition(HumdrumFile& infile);
 
 	private:
-		std::vector<bool> m_colorState;
+		std::vector<int> m_colorState;
 		std::vector<std::string> m_color;
 		std::vector<std::string> m_searches;
 		std::vector<std::string> m_marks;
@@ -6306,12 +7162,12 @@ class Tool_composite : public HumTool {
 		void        assignGroups              (HumdrumFile& infile);
 		void        analyzeLineGroups         (HumdrumFile& infile);
 		void        analyzeLineGroup          (HumdrumFile& infile, int line,
-		                                       const string& target);
+		                                       const std::string& target);
 		void        extractGroup              (HumdrumFile& infile, const std::string &target);
 		void        getNumericGroupStates     (std::vector<int>& states, HumdrumFile& infile, const std::string& tgroup);
 		int         getGroupNoteType          (HumdrumFile& infile, int line, const std::string& group);
 		HumNum      getLineDuration           (HumdrumFile& infile, int index,
-		                                       std::vector<bool>& isNull);
+		                                       std::vector<int>& isNull);
 		void        backfillGroup             (std::vector<std::vector<std::string>>& curgroup,
 		                                       HumdrumFile& infile, int line, int track,
 		                                       int subtrack, const std::string& group);
@@ -6337,8 +7193,8 @@ class Tool_composite : public HumTool {
 		void        getGroupRhythms           (std::vector<std::string>& rhythms,
 		                                       std::vector<HumNum>& durs, std::vector<int>& states,
 		                                       HumdrumFile& infile);
-		int         typeStringToInt           (const string& value);
-		void        addNumericAnalyses        (ostream& output, HumdrumFile& infile, int line,
+		int         typeStringToInt           (const std::string& value);
+		void        addNumericAnalyses        (std::ostream& output, HumdrumFile& infile, int line,
 		                                       std::vector<std::vector<double>>&  rhythmIndex);
 		void        analyzeOutputVariables(HumdrumFile& infile);
 		std::string getTimeSignature          (HumdrumFile& infile, int line, const std::string& group);
@@ -6350,13 +7206,13 @@ class Tool_composite : public HumTool {
 		void        addTimeSignatureChanges   (HumdrumFile& output, HumdrumFile& infile);
 		void        addMeterSignatureChanges  (HumdrumFile& output, HumdrumFile& infile);
 		void        adjustBadCoincidenceRests (HumdrumFile& output, HumdrumFile& infile);
-		HTp         fixBadRestRhythm          (HTp token, string& rhythm, HumNum tstop, HumNum tsbot);
+		HTp         fixBadRestRhythm          (HTp token, std::string& rhythm, HumNum tstop, HumNum tsbot);
 		std::string generateSizeLine          (HumdrumFile& output, HumdrumFile& input, int line);
 		void        convertNotesToRhythms     (HumdrumFile& infile);
-		int         getEventCount             (std::vector<string>& data);
-		void        fixTiedNotes              (std::vector<string>& data, HumdrumFile& infile);
-		void        doOnsetAnalysisCoincidence(vector<double>& output,
-		                                       vector<double>& inputA, vector<double>& inputB);
+		int         getEventCount             (std::vector<std::string>& data);
+		void        fixTiedNotes              (std::vector<std::string>& data, HumdrumFile& infile);
+		void        doOnsetAnalysisCoincidence(std::vector<double>& output,
+		                                       std::vector<double>& inputA, std::vector<double>& inputB);
 		void        checkForAutomaticGrouping (HumdrumFile& infile);
 
 		// Numeric analysis functions:
@@ -6364,7 +7220,7 @@ class Tool_composite : public HumTool {
 		void        doOnsetAnalyses           (HumdrumFile& infile);
 		void        doOnsetAnalysis           (std::vector<double>& analysis,
 		                                       HumdrumFile& infile,
-		                                       const string& targetGroup);
+		                                       const std::string& targetGroup);
 
 		void        doAccentAnalyses          (HumdrumFile& infile);
 
@@ -6413,7 +7269,7 @@ class Tool_composite : public HumTool {
 		bool        m_analysisOrnamentsQ = false;    // used with -O option
 		bool        m_analysisSlursQ     = false;    // used with -S option
 		bool        m_analysisTotalQ     = false;    // used with -T option
-		std::vector<bool> m_analysisIndex;           // -PAOST booleans in array
+		std::vector<int> m_analysisIndex;           // -PAOST booleans in array
 
 		bool        m_analysesQ          = false;    // union of -PAOST options
 		int         m_numericAnalysisSpineCount = 0; // sum of -PAOST options
@@ -6500,8 +7356,8 @@ class Tool_compositeold : public HumTool {
 
 		bool        run                  (HumdrumFileSet& infiles);
 		bool        run                  (HumdrumFile& infile);
-		bool        run                  (const std::string& indata, ostream& out);
-		bool        run                  (HumdrumFile& infile, ostream& out);
+		bool        run                  (const std::string& indata, std::ostream& out);
+		bool        run                  (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void        processFile          (HumdrumFile& infile);
@@ -6535,13 +7391,13 @@ class Tool_compositeold : public HumTool {
 		void        getBeamedNotes       (std::vector<HTp>& notes, HTp starting);
 		void        getPitches           (std::vector<int>& pitches, HTp token);
 		void        addLabelsAndStria    (HumdrumFile& infile);
-		void        addLabels            (HTp sstart, int labelIndex, const string& label,
-		                                  int abbrIndex, const string& abbr);
+		void        addLabels            (HTp sstart, int labelIndex, const std::string& label,
+		                                  int abbrIndex, const std::string& abbr);
 		void        addStria             (HumdrumFile& infile, HTp spinestart);
 		void        addVerseLabels       (HumdrumFile& infile, HTp spinestart);
 		void        addVerseLabels2      (HumdrumFile& infile, HTp spinestart);
-		bool        pitchesEqual         (vector<int>& pitches1, vector<int>& pitches2);
-		void        mergeTremoloGroup    (vector<HTp>& notes, vector<int> groups, int group);
+		bool        pitchesEqual         (std::vector<int>& pitches1, std::vector<int>& pitches2);
+		void        mergeTremoloGroup    (std::vector<HTp>& notes, std::vector<int> groups, int group);
 		bool        onlyAuxTremoloNotes  (HumdrumFile& infile, int line);
 		void        removeAuxTremolosFromCompositeRhythm(HumdrumFile& infile);
 		void        markTogether         (HumdrumFile& infile, int direction);
@@ -6552,41 +7408,41 @@ class Tool_compositeold : public HumTool {
 		void        analyzeNestingDataGroups(HumdrumFile& infile, int direction);
 		void        analyzeNestingDataAll(HumdrumFile& infile, int direction);
 		void        getNestData          (HTp spine, int& total, int& coincide);
-		void        getCoincidenceRhythms(vector<string>& rhythms, vector<int>& coincidences,
+		void        getCoincidenceRhythms(std::vector<std::string>& rhythms, std::vector<int>& coincidences,
 		                                  HumdrumFile& infile);
-		void        fillInCoincidenceRhythm(vector<int>& coincidences,
+		void        fillInCoincidenceRhythm(std::vector<int>& coincidences,
 		                                  HumdrumFile& infile, int direction);
 		void        processCoincidenceInterpretation(HumdrumFile& infile, HTp token);
 		bool        hasPipeRdf           (HumdrumFile& infile);
-		void        extractGroup         (HumdrumFile& infile, const string &target);
-		void        backfillGroup        (vector<vector<string>>& curgroup, HumdrumFile& infile,
-		                                  int line, int track, int subtrack, const string& group);
+		void        extractGroup         (HumdrumFile& infile, const std::string &target);
+		void        backfillGroup        (std::vector<std::vector<std::string>>& curgroup, HumdrumFile& infile,
+		                                  int line, int track, int subtrack, const std::string& group);
 
 		void        analyzeComposite      (HumdrumFile& infile);
-		void        analyzeCompositeOnsets(HumdrumFile& infile, vector<HTp>& groups, vector<bool>& tracks);
-		void        analyzeCompositeAccents(HumdrumFile& infile, vector<HTp>& groups, vector<bool>& tracks);
-		void        analyzeCompositeOrnaments(HumdrumFile& infile, vector<HTp>& groups, vector<bool>& tracks);
-		void        analyzeCompositeSlurs(HumdrumFile& infile, vector<HTp>& groups, vector<bool>& tracks);
-		void        analyzeCompositeTotal(HumdrumFile& infile, vector<HTp>& groups, vector<bool>& tracks);
+		void        analyzeCompositeOnsets(HumdrumFile& infile, std::vector<HTp>& groups, std::vector<bool>& tracks);
+		void        analyzeCompositeAccents(HumdrumFile& infile, std::vector<HTp>& groups, std::vector<bool>& tracks);
+		void        analyzeCompositeOrnaments(HumdrumFile& infile, std::vector<HTp>& groups, std::vector<bool>& tracks);
+		void        analyzeCompositeSlurs(HumdrumFile& infile, std::vector<HTp>& groups, std::vector<bool>& tracks);
+		void        analyzeCompositeTotal(HumdrumFile& infile, std::vector<HTp>& groups, std::vector<bool>& tracks);
 
 		void        getCompositeSpineStarts(std::vector<HTp>& groups, HumdrumFile& infile);
-		std::vector<int> getExpansionList(vector<bool>& tracks, int maxtrack, int count);
-		std::string makeExpansionString(vector<int>& tracks);
+		std::vector<int> getExpansionList(std::vector<bool>& tracks, int maxtrack, int count);
+		std::string makeExpansionString(std::vector<int>& tracks);
 		void        doCoincidenceAnalysis(HumdrumFile& outfile, HumdrumFile& infile,
 		                                  int ctrack, HTp compositeoldStart);
 		void        doTotalAnalysis(HumdrumFile& outfile, HumdrumFile& infile, int ctrack);
 		void        doGroupAnalyses(HumdrumFile& outfile, HumdrumFile& infile);
 		int         countNoteOnsets(HTp token);
-		void        doTotalOnsetAnalysis(vector<double>& analysis, HumdrumFile& infile,
-		                                  int track, vector<bool>& tracks);
-		void        doGroupOnsetAnalyses(vector<double>& analysisA,
-		                                  vector<double>& analysisB,
+		void        doTotalOnsetAnalysis(std::vector<double>& analysis, HumdrumFile& infile,
+		                                  int track, std::vector<bool>& tracks);
+		void        doGroupOnsetAnalyses(std::vector<double>& analysisA,
+		                                  std::vector<double>& analysisB,
 		                                  HumdrumFile& infile);
-		void        doCoincidenceOnsetAnalysis(vector<vector<double>>& analysis);
-		void        insertAnalysesIntoFile(HumdrumFile& outfile, vector<string>& spines,
-		                                   vector<int>& trackMap, vector<bool>& tracks);
-		void        assignAnalysesToVdataTracks(vector<vector<double>*>& data,
-		                                   vector<string>& spines, HumdrumFile& outfile);
+		void        doCoincidenceOnsetAnalysis(std::vector<std::vector<double>>& analysis);
+		void        insertAnalysesIntoFile(HumdrumFile& outfile, std::vector<std::string>& spines,
+		                                   std::vector<int>& trackMap, std::vector<bool>& tracks);
+		void        assignAnalysesToVdataTracks(std::vector<std::vector<double>*>& data,
+		                                   std::vector<std::string>& spines, HumdrumFile& outfile);
 
 	private:
 		std::string m_pitch       = "eR";   // pitch to display for compositeold rhythm
@@ -6618,11 +7474,11 @@ class Tool_compositeold : public HumTool {
 		bool        m_analysisTotalQ    = false;   // used with -T option
 		bool        m_analysisQ          = false;   // union of -paost options
 		bool        m_nozerosQ           = false;   // used with -Z option
-		vector<vector<double>> m_analysisOnsets;    // used with -P
-		vector<vector<double>> m_analysisAccents;   // used with -A
-		vector<vector<double>> m_analysisOrnaments; // used with -O
-		vector<vector<double>> m_analysisSlurs;     // used with -S
-		vector<vector<double>> m_analysisTotal;    // used with -T
+		std::vector<std::vector<double>> m_analysisOnsets;    // used with -P
+		std::vector<std::vector<double>> m_analysisAccents;   // used with -A
+		std::vector<std::vector<double>> m_analysisOrnaments; // used with -O
+		std::vector<std::vector<double>> m_analysisSlurs;     // used with -S
+		std::vector<std::vector<double>> m_analysisTotal;    // used with -T
 
 };
 
@@ -6672,7 +7528,7 @@ class Tool_deg : public HumTool {
 				static void     setShowTies    (bool state) { m_showTiesQ = state;  }
 				static void     setShowZeros   (bool state) { m_showZerosQ = state; }
 				static void     setShowOctaves (bool state) { m_octaveQ = state; }
-				static void     setForcedKey   (const string& key) { m_forcedKey = key; }
+				static void     setForcedKey   (const std::string& key) { m_forcedKey = key; }
 
 			protected:  // ScaleDegree class
 				std::string     generateDegDataToken     (void) const;
@@ -6776,16 +7632,16 @@ class Tool_deg : public HumTool {
 		void            initialize               (void);
 
 		bool            setupSpineInfo           (HumdrumFile& infile);
-		void            prepareDegSpine          (vector<vector<ScaleDegree>>& degspine, HTp kernstart, HumdrumFile& infil);
+		void            prepareDegSpine          (std::vector<std::vector<ScaleDegree>>& degspine, HTp kernstart, HumdrumFile& infil);
 		void            printDegScore            (HumdrumFile& infile);
 		void            printDegScoreInterleavedWithInputScore(HumdrumFile& infile);
 		std::string     createOutputHumdrumLine  (HumdrumFile& infile, int lineIndex);
       std::string     prepareMergerLine        (std::vector<std::vector<std::string>>& merge);
 		void            calculateManipulatorOutputForSpine(std::vector<std::string>& lineout, std::vector<std::string>& linein);
 		std::string     createRecipInterpretation(const std::string& starttok, int refLine);
-		std::string     createDegInterpretation  (const string& degtok, int refLine, bool addPreSpine);
-		std::string     printDegInterpretation   (const string& interp, HumdrumFile& infile, int lineIndex);
-		void            getModeAndTonic          (string& mode, int& b40tonic, const string& token);
+		std::string     createDegInterpretation  (const std::string& degtok, int refLine, bool addPreSpine);
+		std::string     printDegInterpretation   (const std::string& interp, HumdrumFile& infile, int lineIndex);
+		void            getModeAndTonic          (std::string& mode, int& b40tonic, const std::string& token);
 
 		bool            isDegAboveLine           (HumdrumFile& infile, int lineIndex);
 		bool            isDegArrowLine           (HumdrumFile& infile, int lineIndex);
@@ -6796,15 +7652,15 @@ class Tool_deg : public HumTool {
 		bool            isDegSolfegeLine         (HumdrumFile& infile, int lineIndex);
 		bool            isKeyDesignationLine     (HumdrumFile& infile, int lineIndex);
 
-		void            checkAboveStatus         (string& value, bool arrowStatus);
-		void            checkArrowStatus         (string& value, bool arrowStatus);
-		void            checkBoxStatus           (string& value, bool arrowStatus);
-		void            checkCircleStatus        (string& value, bool arrowStatus);
-		void            checkColorStatus         (string& value, bool arrowStatus);
-		void            checkHatStatus           (string& value, bool arrowStatus);
-		void            checkSolfegeStatus       (string& value, bool arrowStatus);
+		void            checkAboveStatus         (std::string& value, bool arrowStatus);
+		void            checkArrowStatus         (std::string& value, bool arrowStatus);
+		void            checkBoxStatus           (std::string& value, bool arrowStatus);
+		void            checkCircleStatus        (std::string& value, bool arrowStatus);
+		void            checkColorStatus         (std::string& value, bool arrowStatus);
+		void            checkHatStatus           (std::string& value, bool arrowStatus);
+		void            checkSolfegeStatus       (std::string& value, bool arrowStatus);
 
-		void            checkKeyDesignationStatus(string& value, int keyDesignationStatus);
+		void            checkKeyDesignationStatus(std::string& value, int keyDesignationStatus);
 
 	private: // Tool_deg class
 
@@ -7048,19 +7904,214 @@ class Tool_double : public HumTool {
 
 		bool     run                (HumdrumFileSet& infiles);
 		bool     run                (HumdrumFile& infile);
-		bool     run                (const string& indata, ostream& out);
-		bool     run                (HumdrumFile& infile, ostream& out);
+		bool     run                (const std::string& indata, std::ostream& out);
+		bool     run                (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void     initialize         (HumdrumFile& infile);
 		void     processFile        (HumdrumFile& infile);
 		void     doubleRhythms      (HumdrumFile& infile);
 		void     terminalBreveToTerminalLong(HumdrumFile& infile);
-		void     processBeamsForMeasure(vector<HTp>& notes);
+		void     processBeamsForMeasure(std::vector<HTp>& notes);
 		void     adjustBeams        (HumdrumFile& infile);
 		void     adjustBeams        (HTp sstart, HTp send);
 
 	private:
+
+};
+
+
+class Tool_esac2hum : public HumTool {
+	public:
+
+		class Note {
+			public:
+				std::vector<std::string> m_errors;
+				std::string esac;
+				int    m_dots        = 0;
+				int    m_underscores = 0;
+				int    m_octave      = 0;
+				int    m_degree      = 0;  // scale degree (wrt major key)
+				int    m_b40degree   = 0;  // scale degree as b40 interval
+				int    m_alter       = 0;  // chromatic alteration of degree (flats/sharp from major scale degrees)
+				double m_ticks       = 0.0;
+				bool   m_tieBegin    = false;
+				bool   m_tieEnd      = false;
+				bool   m_phraseBegin = false;
+				bool   m_phraseEnd   = false;
+				std::string m_humdrum; // **kern conversion of EsAC note
+				int    m_b40         = 0;  // absolute b40 pitch (-1000 = rest);
+				int    m_b12         = 0;  // MIDI note number (-1000 = rest);
+				HumNum m_factor      = 1;  // for triplet which is 2/3 duration
+
+				void calculateRhythms(int minrhy);
+				void calculatePitches(int tonic);
+				bool parseNote(const std::string& note, HumNum factor);
+				void generateHumdrum(int minrhy, int b40tonic);
+				bool isPitch(void);
+				bool isRest(void);
+				std::string getScaleDegree(void);
+		};
+
+		class Measure : public std::vector<Tool_esac2hum::Note> {
+			public:
+				std::vector<std::string> m_errors;
+				std::string esac;
+				int m_barnum = -1000; // -1000 == unassigned bar number for this measure
+				// m_barnum = -1 == invisible barline (between two partial measures)
+				// m_barnum =  0 == pickup measure (partial measure at start of music)
+				double m_ticks = 0.0;
+				double m_tsticks = 0.0;
+				// m_measureTimeSignature is a **kern time signature
+				// (change) to display in the converted score.
+				std::string m_measureTimeSignature = "";
+				bool m_partialBegin = false;  // start of an incomplete measure
+				bool m_partialEnd = false;    // end of an incomplete measure (pickup)
+				bool m_complete = false;      // a complste measure
+				void calculateRhythms(int minrhy);
+				void calculatePitches(int tonic);
+				bool parseMeasure(const std::string& measure);
+				bool isUnassigned(void);
+				void setComplete(void);
+				bool isComplete(void);
+				void setPartialBegin(void);
+				bool isPartialBegin(void);
+				void setPartialEnd(void);
+				bool isPartialEnd(void);
+		};
+
+		class Phrase : public std::vector<Tool_esac2hum::Measure> {
+			public:
+				std::vector<std::string> m_errors;
+				double m_ticks = 0.0;
+				std::string esac;
+				void calculateRhythms(int minrhy);
+				void calculatePitches(int tonic);
+				bool parsePhrase(const std::string& phrase);
+				std::string getLastScaleDegree();
+				void getNoteList(std::vector<Tool_esac2hum::Note*>& notelist);
+				std::string getNO_REP(void);
+				int getFullMeasureCount(void);
+		};
+
+		class Score : public std::vector<Tool_esac2hum::Phrase> {
+			public:
+				int m_b40tonic = 0;
+				int m_minrhy   = 0;
+				std::string m_clef;
+				std::string m_keysignature;
+				std::string m_keydesignation;
+				std::string m_timesig;
+				std::map<std::string, std::string> m_params;
+				std::vector<std::string> m_errors;
+				bool m_finalBarline = false;
+				bool hasFinalBarline(void) { return m_finalBarline; }
+				void calculateRhythms(int minrhy);
+				void calculatePitches(int tonic);
+				bool parseMel(const std::string& mel);
+				void analyzeTies(void);
+				void analyzePhrases(void);
+				void getNoteList(std::vector<Tool_esac2hum::Note*>& notelist);
+				void getMeasureList(std::vector<Tool_esac2hum::Measure*>& measurelist);
+				void getPhraseNoteList(std::vector<Tool_esac2hum::Note*>& notelist, int index);
+				void generateHumdrumNotes(void);
+				void calculateClef(void);
+				void calculateKeyInformation(void);
+				void calculateTimeSignatures(void);
+				void setAllTimesigTicks(double ticks);
+				void assignFreeMeasureNumbers(void);
+				void assignSingleMeasureNumbers(void);
+				void prepareMultipleTimeSignatures(const std::string& ts);
+
+				void doAnalyses(void);
+				void analyzeMEL_SEM(void);
+				void analyzeMEL_RAW(void);
+				void analyzeNO_REP(void);
+				void analyzeRTM(void);
+				void analyzeSCL_DEG(void);
+				void analyzeSCL_SEM(void);
+				void analyzePHR_NO(void);
+				void analyzePHR_BARS(void);
+				void analyzePHR_CAD(void);
+				void analyzeACC(void);
+		};
+
+		            Tool_esac2hum    (void);
+		           ~Tool_esac2hum    () {};
+
+		bool       convertFile          (std::ostream& out, const std::string& filename);
+		bool       convert              (std::ostream& out, const std::string& input);
+		bool       convert              (std::ostream& out, std::istream& input);
+
+
+	protected:
+		void        initialize          (void);
+
+		void        convertEsacToHumdrum(std::ostream& output, std::istream& infile);
+		bool        getSong             (std::vector<std::string>& song, std::istream& infile);
+		void        convertSong         (std::ostream& output, std::vector<std::string>& infile);
+		static std::string trimSpaces   (const std::string& input);
+		void        printHeader         (std::ostream& output);
+		void        printFooter         (std::ostream& output, std::vector<std::string>& infile);
+		void        printConversionDate (std::ostream& output);
+		void        printPdfLinks       (std::ostream& output);
+		void        printParameters     (void);
+		void        printPageNumbers    (std::ostream& output);
+		void        getParameters       (std::vector<std::string>& infile);
+		void        cleanText           (std::string& buffer);
+		std::string createFilename      (void);
+		void        printBemComment     (std::ostream& output);
+		void        processSong         (void);
+		void        printScoreContents  (std::ostream& output);
+		void        embedAnalyses       (std::ostream& output);
+		void        printPdfUrl         (std::ostream& output);
+		std::string getKolbergUrl       (int volume);
+      void        printKolbergPdfUrl  (std::ostream& output);
+
+	private:
+		bool        m_debugQ     = false;  // used with --debug option
+		bool        m_verboseQ   = false;  // used with --verbose option
+		std::string m_verbose;             //    p = print EsAC phrases, m = print measures, n = print notes.
+		                                   //    t after p, m, or n means print tick info
+		bool        m_embedEsacQ = true;   // used with -E option
+		bool        m_dwokQ      = false;  // true if source is Oskar Kolberg: Dzieła Wszystkie
+		                                   // (Oskar Kolberg: Complete Works)
+		                                   // determined automatically if header line or TRD source contains "DWOK" string.
+		bool        m_analysisQ  = false;  // used with -a option
+
+		int         m_inputline = 0;       // used to keep track if the EsAC input line.
+
+		std::string m_filePrefix;
+		std::string m_filePostfix = ".krn";
+		bool m_fileTitleQ = false;
+
+		std::string m_prevline;
+		std::string m_cutline;
+		std::vector<std::string> m_globalComments;
+
+		bool m_initialized = false;
+		int m_minrhy = 0;
+
+		Tool_esac2hum::Score m_score;
+
+		class KolbergInfo {
+			public:
+				std::string titlePL;
+				std::string titleEN;
+				int firstPrintPage;
+				int firstScanPage;
+				std::vector<int> plates;
+
+				KolbergInfo(void) { firstPrintPage = 0; firstScanPage = 0; }
+				KolbergInfo(
+					const std::string& pl, const std::string& en, int fpp, int fsp, const std::vector<int>& plts)
+        				: titlePL(pl), titleEN(en), firstPrintPage(fpp), firstScanPage(fsp), plates(plts) {}
+		};
+		std::map<int, KolbergInfo> m_kinfo;
+		KolbergInfo getKolbergInfo(int volume);
+		std::string getKolbergUrl(int volume, int printPage);
+		int calculateScanPage(int inputPrintPage, int printPage, int scanPage, const std::vector<int>& platePages);
+
 
 };
 
@@ -7089,72 +8140,74 @@ class NoteData {
 		int    phstart;   int    phend;    int phnum;
 		int    slstart;   int    slend;    int lyricnum;
 		int    tiestart;  int    tiecont;  int tieend;
-		string text;
+		std::string text;
 };
 
 
 
-class Tool_esac2hum : public HumTool {
+class Tool_esac2humold : public HumTool {
 	public:
-		         Tool_esac2hum         (void);
-		        ~Tool_esac2hum         () {};
+		        Tool_esac2humold    (void);
+		       ~Tool_esac2humold    () {};
 
-		bool    convertFile          (ostream& out, const string& filename);
-		bool    convert              (ostream& out, const string& input);
-		bool    convert              (ostream& out, istream& input);
+		bool    convertFile          (std::ostream& out, const std::string& filename);
+		bool    convert              (std::ostream& out, const std::string& input);
+		bool    convert              (std::ostream& out, std::istream& input);
 
 	protected:
 		bool      initialize            (void);
 		void      checkOptions          (Options& opts, int argc, char** argv);
 		void      example               (void);
-		void      usage                 (const string& command);
-		void      convertEsacToHumdrum  (ostream& out, istream& input);
-		bool      getSong               (vector<string>& song, istream& infile,
+		void      usage                 (const std::string& command);
+		void      convertEsacToHumdrum  (std::ostream& out, std::istream& input);
+		bool      getSong               (std::vector<std::string>& song, std::istream& infile,
 		                                int init);
-		void      convertSong           (vector<string>& song, ostream& out);
-		bool      getKeyInfo            (vector<string>& song, string& key,
-		                                 double& mindur, int& tonic, string& meter,
-		                                 ostream& out);
-		void      printNoteData         (NoteData& data, int textQ, ostream& out);
-		bool      getNoteList           (vector<string>& song,
-		                                 vector<NoteData>& songdata, double mindur,
+		void      convertSong           (std::vector<std::string>& song, std::ostream& out);
+		bool      getKeyInfo            (std::vector<std::string>& song, std::string& key,
+		                                 double& mindur, int& tonic, std::string& meter,
+		                                 std::ostream& out);
+		void      printNoteData         (NoteData& data, int textQ, std::ostream& out);
+		bool      getNoteList           (std::vector<std::string>& song,
+		                                 std::vector<NoteData>& songdata, double mindur,
 		                                 int tonic);
-		void      getMeterInfo          (string& meter, vector<int>& numerator,
-		                                 vector<int>& denominator);
-		void      postProcessSongData   (vector<NoteData>& songdata,
-		                                 vector<int>& numerator,vector<int>& denominator);
-		void      printKeyInfo          (vector<NoteData>& songdata, int tonic,
-		                                 int textQ, ostream& out);
+		void      getMeterInfo          (std::string& meter, std::vector<int>& numerator,
+		                                 std::vector<int>& denominator);
+		void      postProcessSongData   (std::vector<NoteData>& songdata,
+		                                 std::vector<int>& numerator,std::vector<int>& denominator);
+		void      printKeyInfo          (std::vector<NoteData>& songdata, int tonic,
+		                                 int textQ, std::ostream& out);
 		int       getAccidentalMax      (int a, int b, int c);
-		bool      printTitleInfo        (vector<string>& song, ostream& out);
-		void      getLineRange          (vector<string>& song, const string& field,
+		bool      printTitleInfo        (std::vector<std::string>& song, std::ostream& out);
+		void      getLineRange          (std::vector<std::string>& song, const std::string& field,
 		                                 int& start, int& stop);
-		void      printChar             (unsigned char c, ostream& out);
-		void      printBibInfo          (vector<string>& song, ostream& out);
-		void      printString           (const string& string, ostream& out);
-		void      printSpecialChars     (ostream& out);
-		bool      placeLyrics           (vector<string>& song,
-		                                 vector<NoteData>& songdata);
-		bool      placeLyricPhrase      (vector<NoteData>& songdata,
-		                                 vector<string>& lyrics, int line);
-		void      getLyrics             (vector<string>& lyrics, const string& buffer);
-		void      cleanupLyrics         (vector<string>& lyrics);
-		bool      getFileContents       (vector<string>& array, const string& filename);
-		void      chopExtraInfo         (string& buffer);
-		void      printHumdrumHeaderInfo(ostream& out, vector<string>& song);
-		void      printHumdrumFooterInfo(ostream& out, vector<string>& song);
+		void      printChar             (unsigned char c, std::ostream& out);
+		void      printBibInfo          (std::vector<std::string>& song, std::ostream& out);
+		void      printString           (const std::string& string, std::ostream& out);
+		void      printSpecialChars     (std::ostream& out);
+		bool      placeLyrics           (std::vector<std::string>& song,
+		                                 std::vector<NoteData>& songdata);
+		bool      placeLyricPhrase      (std::vector<NoteData>& songdata,
+		                                 std::vector<std::string>& lyrics, int line);
+		void      getLyrics             (std::vector<std::string>& lyrics, const std::string& buffer);
+		void      cleanupLyrics         (std::vector<std::string>& lyrics);
+		bool      getFileContents       (std::vector<std::string>& array, const std::string& filename);
+		void      chopExtraInfo         (std::string& buffer);
+		void      printHumdrumHeaderInfo(std::ostream& out, std::vector<std::string>& song);
+		void      printHumdrumFooterInfo(std::ostream& out, std::vector<std::string>& song);
 
 	private:
-		int            debugQ = 0;        // used with --debug option
-		int            verboseQ = 0;      // used with -v option
-		int            splitQ = 0;        // used with -s option
-		int            firstfilenum = 1;  // used with -f option
-		vector<string> header;            // used with -h option
-		vector<string> trailer;           // used with -t option
-		string         fileextension;     // used with -x option
-		string         namebase;          // used with -s option
+		int            debugQ = 0;         // used with --debug option
+		int            verboseQ = 0;       // used with -v option
+		int            splitQ = 0;         // used with -s option
+		int            firstfilenum = 1;   // used with -f option
+		std::vector<std::string> header;   // used with -h option
+		std::vector<std::string> trailer;  // used with -t option
+		std::string         fileextension; // used with -x option
+		std::string         namebase;      // used with -s option
 
-		vector<int>    chartable;  // used printChars() & printSpecialChars()
+		// Modern ESaC files use UTF-8 characters, older ESaC files use
+		//  ASCII encodings of non-UTF7 characters:
+		std::vector<int>    chartable;  // used in printChars() & printSpecialChars()
 		int inputline = 0;
 
 };
@@ -7243,27 +8296,28 @@ class Tool_extract : public HumTool {
 		void fillFieldDataByNoRest      (std::vector<int>& field, std::vector<int>& subfield,
 		                                 std::vector<int>& model, const std::string& searchstring,
 		                                 HumdrumFile& infile, int state);
+		void printInterpretationForKernSpine(HumdrumFile& infile, int index);
 
 	private:
 
 		// global variables
-		int         excludeQ = 0;        // used with -x option
-		int         expandQ  = 0;        // used with -e option
-		std::string expandInterp = "";   // used with -E option
-		int         interpQ  = 0;        // used with -i option
-		std::string interps  = "";       // used with -i option
-		int         debugQ   = 0;        // used with --debug option
-		int         kernQ    = 0;        // used with -k option
-		int         rkernQ  = 0;         // used with -K option
-		int         fieldQ   = 0;        // used with -f or -p option
-		std::string fieldstring = "";    // used with -f or -p option
+		bool        excludeQ     = false;     // used with -x option
+		bool        expandQ      = false;     // used with -e option
+		std::string expandInterp = "";        // used with -E option
+		bool        interpQ      = false;     // used with -i option
+		std::string interps      = "";        // used with -i option
+		bool        debugQ       = false;     // used with --debug option
+		bool        kernQ        = false;     // used with -k option
+		bool        rkernQ       = false;     // used with -K option
+		bool        fieldQ       = false;     // used with -f or -p option
+		std::string fieldstring  = "";        // used with -f or -p option
 		std::vector<int> field;               // used with -f or -p option
 		std::vector<int> subfield;            // used with -f or -p option
 		std::vector<int> model;               // used with -p, or -e options and similar
-		int         countQ   = 0;        // used with -C option
-		int         traceQ   = 0;        // used with -t option
-		std::string tracefile = "";      // used with -t option
-		int         reverseQ = 0;        // used with -r option
+		bool        countQ        = false;    // used with -C option
+		bool        traceQ        = false;    // used with -t option
+		std::string tracefile     = "";       // used with -t option
+		bool        reverseQ      = false;    // used with -r option
 		std::string reverseInterp = "**kern"; // used with -r and -R options.
 		// sub-spine "b" expansion model: how to generate data for a secondary
 		// spine if the primary spine is not divided.  Models are:
@@ -7273,20 +8327,85 @@ class Tool_extract : public HumTool {
 		//         data.  'n' will be used for non-kern spines when 'r' is used.
 		int          submodel = 'd';       // used with -m option
 		std::string editorialInterpretation = "yy";
-		std::string cointerp = "**kern";   // used with -c option
-		int         comodel  = 0;          // used with -M option
+		std::string cointerp    = "**kern";  // used with -c option
+		int         comodel     = 0;         // used with -M option
 		std::string subtokenseparator = " "; // used with a future option
-		int         interpstate = 0;       // used -I or with -i
-		int         grepQ       = 0;       // used with -g option
-		std::string grepString  = "";      // used with -g option
+		int         interpstate = 0;         // used -I or with -i
+		bool        grepQ       = false;     // used with -g option
+		std::string grepString  = "";        // used with -g option
 		std::string blankName   = "**blank"; // used with -n option
-		int         noEmptyQ    = 0;       // used with --no-empty option
-		int         emptyQ      = 0;       // used with --empty option
-		int         spineListQ  = 0;       // used with --spine option
-		int         removerestQ = 0;       // used with --no-rest option
+ 		bool        addRestsQ   = false;     // used with -n option
+		bool        noEmptyQ    = false;     // used with --no-empty option
+		bool        emptyQ      = false;     // used with --empty option
+		bool        spineListQ  = false;     // used with --spine option
+		bool        removerestQ = false;     // used with --no-rest option
 
 };
 
+
+
+class Tool_extremis : public HumTool {
+	public:
+		            Tool_extremis    (void);
+		           ~Tool_extremis    () {};
+
+		bool        run              (HumdrumFileSet& infiles);
+		bool        run              (HumdrumFile& infile);
+		bool        run              (const std::string& indata, std::ostream& out);
+		bool        run              (HumdrumFile& infile, std::ostream& out);
+
+	protected:
+
+		// SynthEvent describes a single note (or rest) of the synthetic
+		// extreme-pitch spine.  Each event spans a range of input data
+		// lines that share the same extreme pitch, and which together
+		// represent a single sustained occurrence of that pitch (i.e.,
+		// without rearticulation by the source voice or a crossing of
+		// a barline).
+		struct SynthEvent {
+			int    startLine = 0; // first input data line of the event
+			int    endLine   = 0; // last input data line (inclusive)
+			HumNum duration  = 0; // total duration of the event (in quarter notes)
+			int    b40       = 0; // base-40 pitch (0 means rest)
+			bool   isRest    = true;
+		};
+
+		void        initialize          (void);
+		void        processFile         (HumdrumFile& infile);
+
+		void        buildEvents         (HumdrumFile& infile,
+		                                 std::vector<SynthEvent>& events,
+		                                 bool wantHigh);
+		void        computePitchAndAttack(HumdrumLine& line, bool wantHigh,
+		                                 int& outB40, bool& outAttack);
+
+		void        renderEvents        (HumdrumFile& infile,
+		                                 const std::vector<SynthEvent>& events,
+		                                 std::vector<std::string>& lineTokens);
+		void        chunkEvent          (HumdrumFile& infile,
+		                                 const SynthEvent& event,
+		                                 std::vector<int>& chunkStartLines,
+		                                 std::vector<HumNum>& chunkDurations);
+		bool        isCleanKernDuration (HumNum dur);
+		bool        lineHasMatchingBeamMarker(HumdrumFile& infile, int line,
+		                                 int b40);
+		std::string getSourceMarkers    (HumdrumFile& infile, int line,
+		                                 int b40, std::string& outPitch);
+		std::string stripRhythmAndTies  (const std::string& subtoken);
+
+		std::string getBarlineToken     (HumdrumLine& line);
+		std::string getKeySignature     (HumdrumLine& line);
+		std::string getTimeSignature    (HumdrumLine& line);
+		std::string getMeterSymbol      (HumdrumLine& line);
+		std::string getKeyDesignation   (HumdrumLine& line);
+		HTp         getFirstKernToken   (HumdrumLine& line);
+
+	private:
+		bool        m_lowQ   = true;   // -l option (default behavior)
+		bool        m_highQ  = false;  // -h option
+		bool        m_bothQ  = false;  // -b option
+
+};
 
 
 class FiguredBassNumber {
@@ -7386,22 +8505,22 @@ class Tool_filter : public HumTool {
 
 		bool     run                (HumdrumFileSet& infiles);
 		bool     run                (HumdrumFile& infile);
-		bool     run                (const string& indata);
+		bool     run                (const std::string& indata);
 
 		bool     runUniversal       (HumdrumFileSet& infiles);
 
 	protected:
-		void     getCommandList     (vector<pair<string, string> >& commands,
+		void     getCommandList     (std::vector<std::pair<std::string, std::string> >& commands,
 		                             HumdrumFile& infile);
 		void     getUniversalCommandList(std::vector<std::pair<std::string, std::string> >& commands,
 		                             HumdrumFileSet& infiles);
 		void     initialize         (HumdrumFile& infile);
 		void     removeGlobalFilterLines    (HumdrumFile& infile);
 		void     removeUniversalFilterLines (HumdrumFileSet& infiles);
-		void     splitPipeline      (vector<string>& clist, const string& command);
+		void     splitPipeline      (std::vector<std::string>& clist, const std::string& command);
 
 	private:
-		string   m_variant;        // used with -v option.
+		std::string   m_variant;        // used with -v option.
 		bool     m_debugQ = false; // used with --debug option
 
 };
@@ -7414,17 +8533,17 @@ class Tool_fixps : public HumTool {
 
 		bool     run                (HumdrumFileSet& infiles);
 		bool     run                (HumdrumFile& infile);
-		bool     run                (const string& indata, ostream& out);
-		bool     run                (HumdrumFile& infile, ostream& out);
+		bool     run                (const std::string& indata, std::ostream& out);
+		bool     run                (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void     initialize         (HumdrumFile& infile);
 		void     processFile        (HumdrumFile& infile);
 		void     markEmptyVoices    (HumdrumFile& infile);
-		void     removeEmpties      (vector<vector<HTp>>& newlist, HumdrumFile& infile);
+		void     removeEmpties      (std::vector<std::vector<HTp>>& newlist, HumdrumFile& infile);
 		void     removeDuplicateDynamics(HumdrumFile& infile);
-		void     outputNewSpining   (vector<vector<HTp>>& newlist, HumdrumFile& infile);
-		void     printNewManipulator(HumdrumFile& infile, vector<vector<HTp>>& newlist, int line);
+		void     outputNewSpining   (std::vector<std::vector<HTp>>& newlist, HumdrumFile& infile);
+		void     printNewManipulator(HumdrumFile& infile, std::vector<std::vector<HTp>>& newlist, int line);
 
 	private:
 
@@ -7438,8 +8557,8 @@ class Tool_flipper : public HumTool {
 
 		bool     run               (HumdrumFileSet& infiles);
 		bool     run               (HumdrumFile& infile);
-		bool     run               (const string& indata, ostream& out);
-		bool     run               (HumdrumFile& infile, ostream& out);
+		bool     run               (const std::string& indata, std::ostream& out);
+		bool     run               (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void     processFile       (HumdrumFile& infile);
@@ -7447,9 +8566,9 @@ class Tool_flipper : public HumTool {
 
 		void     processLine        (HumdrumFile& infile, int index);
 		void     checkForFlipChanges(HumdrumFile& infile, int index);
-		bool     flipSubspines      (vector<vector<HTp>>& flipees);
-		void     flipSpineTokens    (vector<HTp>& subtokens);
-		void     extractFlipees     (vector<vector<HTp>>& flipees,
+		bool     flipSubspines      (std::vector<std::vector<HTp>>& flipees);
+		void     flipSpineTokens    (std::vector<HTp>& subtokens);
+		void     extractFlipees     (std::vector<std::vector<HTp>>& flipees,
 		                             HumdrumFile& infile, int index);
 
 	private:
@@ -7472,8 +8591,8 @@ class Tool_gasparize : public HumTool {
 
 		bool     run                (HumdrumFileSet& infiles);
 		bool     run                (HumdrumFile& infile);
-		bool     run                (const string& indata, ostream& out);
-		bool     run                (HumdrumFile& infile, ostream& out);
+		bool     run                (const std::string& indata, std::ostream& out);
+		bool     run                (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void     initialize         (HumdrumFile& infile);
@@ -7484,7 +8603,7 @@ class Tool_gasparize : public HumTool {
 		void     fixInstrumentAbbreviations(HumdrumFile& infile);
 		void     addTerminalLongs   (HumdrumFile& infile);
 		void     deleteDummyTranspositions(HumdrumFile& infile);
-		string   getDate            (void);
+		std::string   getDate            (void);
 		void     adjustSystemDecoration(HumdrumFile& infile);
 		void     deleteBreaks       (HumdrumFile& infile);
 		void     updateKeySignatures(HumdrumFile& infile, int lineindex);
@@ -7499,8 +8618,8 @@ class Tool_gasparize : public HumTool {
 		void     addMensuration     (int top, HumdrumFile& infile, int i);
 		void     createEditText     (HumdrumFile& infile);
 		bool     addEditStylingForText(HumdrumFile& infile, HTp sstart, HTp send);
-		string   getEditLine        (const string& text, int fieldindex, HLp line);
-		bool     insertEditText     (const string& text, HumdrumFile& infile, int line, int field);
+		std::string   getEditLine        (const std::string& text, int fieldindex, HLp line);
+		bool     insertEditText     (const std::string& text, HumdrumFile& infile, int line, int field);
 		void     adjustIntrumentNames(HumdrumFile& infile);
 		void     removeKeyDesignations(HumdrumFile& infile);
 		void     fixBarlines        (HumdrumFile& infile);
@@ -7513,10 +8632,34 @@ class Tool_gasparize : public HumTool {
 		void     fixTiesStartEnd(HTp starts, HTp ends);
 
 	private:
-		vector<vector<int>> m_pstates;
-		vector<vector<int>> m_kstates;
-		vector<vector<bool>> m_estates;
+		std::vector<std::vector<int>> m_pstates;
+		std::vector<std::vector<int>> m_kstates;
+		std::vector<std::vector<bool>> m_estates;
 
+};
+
+
+class Tool_got2hum : public HumTool {
+	public:
+		         Tool_got2hum      (void);
+		        ~Tool_got2hum      () {};
+
+		bool     run               (HumdrumFileSet& infiles);
+		bool     run               (HumdrumFile& infile);
+		bool     run               (const std::string& indata, std::ostream& out);
+		bool     run               (HumdrumFile& infile, std::ostream& out);
+
+	protected:
+		void    processFile        (const std::string& instring);
+		void    initialize         (void);
+
+	private:
+		GotScore m_gotscore;
+
+		bool m_editorialQ;
+		bool m_cautionaryQ;
+		bool m_gotQ;
+		bool m_modern_accQ;
 };
 
 
@@ -7527,8 +8670,8 @@ class Tool_grep : public HumTool {
 
 		bool     run               (HumdrumFileSet& infiles);
 		bool     run               (HumdrumFile& infile);
-		bool     run               (const string& indata, ostream& out);
-		bool     run               (HumdrumFile& infile, ostream& out);
+		bool     run               (const std::string& indata, std::ostream& out);
+		bool     run               (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void      processFile         (HumdrumFile& infile);
@@ -7548,8 +8691,8 @@ class Tool_half : public HumTool {
 
 		bool     run           (HumdrumFileSet& infiles);
 		bool     run           (HumdrumFile& infile);
-		bool     run           (const string& indata, ostream& out);
-		bool     run           (HumdrumFile& infile, ostream& out);
+		bool     run           (const std::string& indata, std::ostream& out);
+		bool     run           (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void     initialize    (HumdrumFile& infile);
@@ -7560,6 +8703,43 @@ class Tool_half : public HumTool {
 
 	private:
 		bool     m_lyricBreakQ = false;  // used with -l option
+
+};
+
+
+class Tool_hands : public HumTool {
+	public:
+		            Tool_hands        (void);
+		           ~Tool_hands        () {};
+
+		bool        run               (HumdrumFileSet& infiles);
+		bool        run               (HumdrumFile& infile);
+		bool        run               (const std::string& indata, std::ostream& out);
+		bool        run               (HumdrumFile& infile, std::ostream& out);
+
+	protected:
+		void        processFile       (HumdrumFile& infile);
+		void        initialize        (void);
+		void        colorHands        (HumdrumFile& infile);
+		void        doHandAnalysis    (HumdrumFile& infile);
+		void        doHandAnalysis    (HTp startSpine);
+		void        markNotes         (HumdrumFile& infile);
+		void        markNotes         (HTp sstart, HTp send);
+		void        removeNotes       (HumdrumFile& infile, const std::string& htype);
+		void        removeNotes       (HTp sstart, HTp send, const std::string& htype);
+
+	private:
+		bool        m_colorQ      = false;        // used with -c option
+		std::string m_leftColor   = "dodgerblue"; // used with --left-color option
+		std::string m_rightColor  = "crimson";    // used with --right-color option
+		bool        m_markQ       = false;        // used with -m option
+		std::string m_leftMarker  = "🟦";         //
+		std::string m_rightMarker = "🟥";         //
+		bool        m_leftOnlyQ   = false;        // used with -l option
+		bool        m_rightOnlyQ  = false;        // used with -r option
+		bool        m_attacksOnlyQ = false;       // used with -a option
+
+		std::vector<int> m_trackHasHandMarkup;    // given track number uses hand labels
 
 };
 
@@ -7584,8 +8764,8 @@ class Tool_homorhythm : public HumTool {
 
 		bool        run                (HumdrumFileSet& infiles);
 		bool        run                (HumdrumFile& infile);
-		bool        run                (const string& indata, ostream& out);
-		bool        run                (HumdrumFile& infile, ostream& out);
+		bool        run                (const std::string& indata, std::ostream& out);
+		bool        run                (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void        processFile        (HumdrumFile& infile);
@@ -7594,9 +8774,9 @@ class Tool_homorhythm : public HumTool {
 		void        markHomophonicNotes(void);
 		int         getExtantVoiceCount(HumdrumFile& infile);
 		int         getOriginalVoiceCount(HumdrumFile& infile);
-		void        addRawAnalysis     (HumdrumFile& infile, vector<double>& raw);
-		void        addAccumulatedScores(HumdrumFile& infile, vector<double>& score);
-		void        addAttacks         (HumdrumFile& infile, vector<int>& attacks);
+		void        addRawAnalysis     (HumdrumFile& infile, std::vector<double>& raw);
+		void        addAccumulatedScores(HumdrumFile& infile, std::vector<double>& score);
+		void        addAttacks         (HumdrumFile& infile, std::vector<int>& attacks);
 		void        addFractionAnalysis(HumdrumFile& infile, std::vector<double>& score);
 
 	private:
@@ -7619,8 +8799,8 @@ class Tool_homorhythm2 : public HumTool {
 
 		bool        run                (HumdrumFileSet& infiles);
 		bool        run                (HumdrumFile& infile);
-		bool        run                (const string& indata, ostream& out);
-		bool        run                (HumdrumFile& infile, ostream& out);
+		bool        run                (const std::string& indata, std::ostream& out);
+		bool        run                (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void        processFile        (HumdrumFile& infile);
@@ -7629,7 +8809,7 @@ class Tool_homorhythm2 : public HumTool {
 	private:
 		double      m_threshold = 0.6;
 		double      m_threshold2 = 0.4;
-		vector<double> m_score;
+		std::vector<double> m_score;
 };
 
 
@@ -7640,21 +8820,53 @@ class Tool_hproof : public HumTool {
 
 		bool  run              (HumdrumFileSet& infiles);
 		bool  run              (HumdrumFile& infile);
-		bool  run              (const string& indata, ostream& out);
-		bool  run              (HumdrumFile& infile, ostream& out);
+		bool  run              (const std::string& indata, std::ostream& out);
+		bool  run              (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void  markNonChordTones(HumdrumFile& infile);
 		void  processHarmSpine (HumdrumFile& infile, HTp hstart);
-		void  markNotesInRange (HumdrumFile& infile, HTp ctoken, HTp ntoken, const string& key);
-		void  markHarmonicTones(HTp tok, vector<int>& cts);
-		void  getNewKey        (HTp token, HTp ntoken, string& key);
+		void  markNotesInRange (HumdrumFile& infile, HTp ctoken, HTp ntoken, const std::string& key);
+		void  markHarmonicTones(HTp tok, std::vector<int>& cts);
+		void  getNewKey        (HTp token, HTp ntoken, std::string& key);
 
 	private:
-		vector<HTp> m_kernspines;
+		std::vector<HTp> m_kernspines;
 
 };
 
+
+
+class Tool_humbreak : public HumTool {
+	public:
+		         Tool_humbreak     (void);
+		        ~Tool_humbreak     () {};
+
+		bool     run               (HumdrumFileSet& infiles);
+		bool     run               (HumdrumFile& infile);
+		bool     run               (const std::string& indata, std::ostream& out);
+		bool     run               (HumdrumFile& infile, std::ostream& out);
+
+	protected:
+		void    processFile        (HumdrumFile& infile);
+		void    initialize         (void);
+		void    addBreaks          (HumdrumFile& infile);
+		void    removeBreaks       (HumdrumFile& infile);
+		void    convertPageToLine  (HumdrumFile& infile);
+		void    markLineBreakMeasures(HumdrumFile& infile);
+
+	private:
+		std::map<int, int> m_lineMeasures;  // list of measures to add line breaks to
+		std::map<int, int> m_pageMeasures;  // list of measures to add page breaks to
+
+		std::map<int, int> m_lineOffset;  // measure offsets for measure breaks
+		std::map<int, int> m_pageOffset;  // measure offsets for page breaks
+
+		std::string m_group = "original";
+		bool m_removeQ = false;
+		bool m_page2lineQ = false;
+
+};
 
 
 // A TimePoint records the event times in a file.  These are positions of note attacks
@@ -7664,11 +8876,11 @@ class Tool_hproof : public HumTool {
 class TimePoint {
 	public:
 		// file: pointers to the file in which the index refers to
-		vector<HumdrumFile*> file;
+		std::vector<HumdrumFile*> file;
 
 		// index :: A list of indexes for the lines at which the given timestamp
 		// occurs in each file.  The first index is for the reference work.
-		vector<int> index;
+		std::vector<int> index;
 
 		// timestamp :: The duration from the start of the score to given time in score.
 		HumNum timestamp = -1;
@@ -7690,7 +8902,7 @@ class TimePoint {
 class NotePoint {
 	public:
 		HTp         token          = NULL;   // Humdrum token that contains note
-		string      subtoken;                // string that represents not (token may be chord)
+		std::string subtoken;                // string that represents not (token may be chord)
 		int         subindex       = -1;     // subtoken index of note (in chord)
 		int         measure        = -1;     // measure number that note is found
 		HumNum      measurequarter = -1;     // distance from start of measure to note
@@ -7701,7 +8913,7 @@ class NotePoint {
 		int         processed      = 0;      // has note been processed/matched
 		int         sourceindex    = -1;     // source file index for note
 		int         tpindex        = -1;     // timepoint index of note in source
-		vector<int> matched;       // indexes to the location of the note in TimePoint list.
+		std::vector<int> matched;       // indexes to the location of the note in TimePoint list.
 		                           // the index indicate which score the match is related to,
 		                           // and a value of -1 means there is no equivalent timepoint.
 		void clear(void) {
@@ -7733,13 +8945,13 @@ class Tool_humdiff : public HumTool {
 	protected:
 		void     compareFiles       (HumdrumFile& reference, HumdrumFile& alternate);
 
-		void     compareTimePoints  (vector<vector<TimePoint>>& timepoints, HumdrumFile& reference, HumdrumFile& alternate);
-		void     extractTimePoints  (vector<TimePoint>& points, HumdrumFile& infile);
-		void     printTimePoints    (vector<TimePoint>& timepoints);
-		void     compareLines       (HumNum minval, vector<int>& indexes, vector<vector<TimePoint>>& timepoints, vector<HumdrumFile*> infiles);
-		void     getNoteList        (vector<NotePoint>& notelist, HumdrumFile& infile, int line, int measure, int sourceindex, int tpindex);
-		int      findNoteInList     (NotePoint& np, vector<NotePoint>& nps);
-		void     printNotePoints    (vector<NotePoint>& notelist);
+		void     compareTimePoints  (std::vector<std::vector<TimePoint>>& timepoints, HumdrumFile& reference, HumdrumFile& alternate);
+		void     extractTimePoints  (std::vector<TimePoint>& points, HumdrumFile& infile);
+		void     printTimePoints    (std::vector<TimePoint>& timepoints);
+		void     compareLines       (HumNum minval, std::vector<int>& indexes, std::vector<std::vector<TimePoint>>& timepoints, std::vector<HumdrumFile*> infiles);
+		void     getNoteList        (std::vector<NotePoint>& notelist, HumdrumFile& infile, int line, int measure, int sourceindex, int tpindex);
+		int      findNoteInList     (NotePoint& np, std::vector<NotePoint>& nps);
+		void     printNotePoints    (std::vector<NotePoint>& notelist);
 		void     markNote           (NotePoint& np);
 
 	private:
@@ -7748,8 +8960,8 @@ class Tool_humdiff : public HumTool {
 
 };
 
-ostream& operator<<(ostream& out, TimePoint& tp);
-ostream& operator<<(ostream& out, NotePoint& np);
+std::ostream& operator<<(std::ostream& out, TimePoint& tp);
+std::ostream& operator<<(std::ostream& out, NotePoint& np);
 
 
 
@@ -7760,8 +8972,8 @@ class Tool_humsheet : public HumTool {
 
 		bool     run               (HumdrumFileSet& infiles);
 		bool     run               (HumdrumFile& infile);
-		bool     run               (const string& indata, ostream& out);
-		bool     run               (HumdrumFile& infile, ostream& out);
+		bool     run               (const std::string& indata, std::ostream& out);
+		bool     run               (HumdrumFile& infile, std::ostream& out);
 
 		void     printRowClasses   (HumdrumFile& infile, int row);
 		void     printRowContents  (HumdrumFile& infile, int row);
@@ -7807,8 +9019,8 @@ class Tool_humsort : public HumTool {
 
 		bool     run               (HumdrumFileSet& infiles);
 		bool     run               (HumdrumFile& infile);
-		bool     run               (const string& indata, ostream& out);
-		bool     run               (HumdrumFile& infile, ostream& out);
+		bool     run               (const std::string& indata, std::ostream& out);
+		bool     run               (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void    processFile        (HumdrumFile& infile);
@@ -7823,8 +9035,8 @@ class Tool_humtr : public HumTool {
 
 		bool        run               (HumdrumFileSet& infiles);
 		bool        run               (HumdrumFile& infile);
-		bool        run               (const std::string& indata, ostream& out);
-		bool        run               (HumdrumFile& infile, ostream& out);
+		bool        run               (const std::string& indata, std::ostream& out);
+		bool        run               (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void        processFile       (HumdrumFile& infile);
@@ -7931,6 +9143,40 @@ class Tool_imitation : public HumTool {
 };
 
 
+class Tool_instinfo : public HumTool {
+	public:
+		         Tool_instinfo      (void);
+		        ~Tool_instinfo      () {};
+
+		bool     run                (HumdrumFileSet& infiles);
+		bool     run                (HumdrumFile& infile);
+		bool     run                (const std::string& indata, std::ostream& out);
+		bool     run                (HumdrumFile& infile, std::ostream& out);
+
+	protected:
+		void    processFile         (HumdrumFile& infile);
+		void    initialize          (HumdrumFile& infile);
+		void    updateInstrumentLine(HumdrumFile& infile, int inumIndex,
+		                             std::map<int, std::string>& value,
+		                             std::map<int, int>& track2kindex,
+		                             const std::string& prefix);
+		void    insertInstrumentInfo(HumdrumFile& infile, int index,
+		                             std::map<int, std::string>& info, const std::string& prefix,
+		                             const std::string& key, std::map<int, int>& track2kindex);
+		void    printLine           (HumdrumFile& infile, int index);
+		void    printLine           (HumdrumFile& infile, int index,
+		                             const std::string& key);
+
+	private:
+		std::map<int, std::string> m_icode;  // instrument code, e.g., *Iflt
+		std::map<int, std::string> m_iclass; // instrument class, e.g., *Iww
+		std::map<int, std::string> m_iname;  // instrument name, e.g., *I"flute
+		std::map<int, std::string> m_iabbr;  // instrument name, e.g., *I'flt.
+		std::map<int, std::string> m_inum;   // instrument number, e.g., *I#2
+
+};
+
+
 class Tool_kern2mens : public HumTool {
 	public:
 		         Tool_kern2mens           (void);
@@ -7979,8 +9225,8 @@ class Tool_kernify : public HumTool {
 
 		bool     run          (HumdrumFileSet& infiles);
 		bool     run          (HumdrumFile& infile);
-		bool     run          (const string& indata, ostream& out);
-		bool     run          (HumdrumFile& infile, ostream& out);
+		bool     run          (const std::string& indata, std::ostream& out);
+		bool     run          (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void        initialize             (void);
@@ -7988,9 +9234,12 @@ class Tool_kernify : public HumTool {
 		void        generateDummyKernSpine (HumdrumFile& infile);
 		std::string makeNullLine           (HumdrumLine& line);
 		std::string makeReverseLine        (HumdrumLine& line);
+		bool        prepareDataSpines      (HumdrumFile& infile);
+		bool        prepareDataSpine       (HTp spinestart);
 
 	private:
 		bool m_forceQ = false;  // used with -f option
+		bool m_hasDataInterpretations = false;
 
 };
 
@@ -8002,8 +9251,8 @@ class Tool_kernview : public HumTool {
 
 		bool     run               (HumdrumFileSet& infiles);
 		bool     run               (HumdrumFile& infile);
-		bool     run               (const string& indata, ostream& out);
-		bool     run               (HumdrumFile& infile, ostream& out);
+		bool     run               (const std::string& indata, std::ostream& out);
+		bool     run               (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void     processFile       (HumdrumFile& infile);
@@ -8294,19 +9543,19 @@ class Tool_mei2hum : public HumTool {
 
 class WordInfo {
 	public:
-		string word;                 // text of word
+		std::string word;                 // text of word
 		int notes = 0;               // number of notes in word
 		HumNum starttime;            // start time of word
 		HumNum endtime;              // end time of word
 		int bar = 0;                 // starting barline number for word
-	  	vector<int> bars;            // starting barline number for each syllable
-		vector<string> syllables;    // list of syllables in word with melisma
-		vector<int> notecounts;      // list of note counts for each syllable in word
-		vector<HumNum> starttimes;   // list of start times for each syllable
-		vector<HumNum> endtimes;     // list of end times for each syllable
+	  	std::vector<int> bars;            // starting barline number for each syllable
+		std::vector<std::string> syllables;    // list of syllables in word with melisma
+		std::vector<int> notecounts;      // list of note counts for each syllable in word
+		std::vector<HumNum> starttimes;   // list of start times for each syllable
+		std::vector<HumNum> endtimes;     // list of end times for each syllable
 		HumNum duration(void) { return endtime - starttime; }
-		string name;
-		string abbreviation;
+		std::string name;
+		std::string abbreviation;
 		int partnum = 0;
 		void clear(void) {
 			starttime = 0;
@@ -8333,36 +9582,36 @@ class Tool_melisma : public HumTool {
 
 		bool  run                      (HumdrumFileSet& infiles);
 		bool  run                      (HumdrumFile& infile);
-		bool  run                      (const string& indata, ostream& out);
-		bool  run                      (HumdrumFile& infile, ostream& out);
+		bool  run                      (const std::string& indata, std::ostream& out);
+		bool  run                      (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void   initialize              (HumdrumFile& infile);
 		void   processFile             (HumdrumFile& infile);
-		void   getNoteCounts           (HumdrumFile& infile, vector<vector<int>>& counts);
-		void   getNoteCountsForLyric   (vector<vector<int>>& counts, HTp lyricStart);
+		void   getNoteCounts           (HumdrumFile& infile, std::vector<std::vector<int>>& counts);
+		void   getNoteCountsForLyric   (std::vector<std::vector<int>>& counts, HTp lyricStart);
 		int    getCountForSyllable     (HTp token);
-		void   replaceLyrics           (HumdrumFile& infile, vector<vector<int>>& counts);
-		void   markMelismas            (HumdrumFile& infile, vector<vector<int>>& counts);
+		void   replaceLyrics           (HumdrumFile& infile, std::vector<std::vector<int>>& counts);
+		void   markMelismas            (HumdrumFile& infile, std::vector<std::vector<int>>& counts);
 		void   markMelismaNotes        (HTp text, int count);
-		void   extractWordlist         (vector<WordInfo>& wordinfo, map<string, int>& wordlist,
-		                                HumdrumFile& infile, vector<vector<int>>& notecount);
-		string extractWord             (WordInfo& winfo, HTp token, vector<vector<int>>& counts);
+		void   extractWordlist         (std::vector<WordInfo>& wordinfo, std::map<std::string, int>& wordlist,
+		                                HumdrumFile& infile, std::vector<std::vector<int>>& notecount);
+		std::string extractWord             (WordInfo& winfo, HTp token, std::vector<std::vector<int>>& counts);
 		HumNum getEndtime              (HTp text);
-		void   printWordlist           (HumdrumFile& infile, vector<WordInfo>& wordinfo,
-		                                map<string, int>);
+		void   printWordlist           (HumdrumFile& infile, std::vector<WordInfo>& wordinfo,
+		                                std::map<std::string, int>);
 		void   initializePartInfo      (HumdrumFile& infile);
-		void   getMelismaNoteCounts    (vector<int>& ncounts, vector<int>& mcounts,
+		void   getMelismaNoteCounts    (std::vector<int>& ncounts, std::vector<int>& mcounts,
 		                                HumdrumFile& infile);
 		double getScoreDuration        (HumdrumFile& infile);
 		void   initBarlines            (HumdrumFile& infile);
 
 	private:
-		vector<vector<HumNum>> m_endtimes;      // end time of syllables indexed by line/field
-		vector<string>         m_names;         // name of parts indexed by track
-		vector<string>         m_abbreviations; // abbreviation of parts indexed by track
-		vector<int>            m_partnums;      // part number index by track
-		vector<int>            m_measures;      // current measure number
+		std::vector<std::vector<HumNum>> m_endtimes;      // end time of syllables indexed by line/field
+		std::vector<std::string>         m_names;         // name of parts indexed by track
+		std::vector<std::string>         m_abbreviations; // abbreviation of parts indexed by track
+		std::vector<int>            m_partnums;      // part number index by track
+		std::vector<int>            m_measures;      // current measure number
 
 };
 
@@ -8375,13 +9624,13 @@ class Tool_mens2kern : public HumTool {
 
 		bool     run                 (HumdrumFileSet& infiles);
 		bool     run                 (HumdrumFile& infile);
-		bool     run                 (const string& indata, ostream& out);
-		bool     run                 (HumdrumFile& infile, ostream& out);
+		bool     run                 (const std::string& indata, std::ostream& out);
+		bool     run                 (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void     processFile         (HumdrumFile& infile);
 		void     initialize          (void);
-		void     processMelody       (vector<HTp>& melody);
+		void     processMelody       (std::vector<HTp>& melody);
 		std::string mens2kernRhythm  (const std::string& rhythm,
 		                              bool altera,  bool perfecta,
 		                              bool imperfecta, int maxima_def, int longa_def,
@@ -8405,7 +9654,7 @@ class Tool_meter : public HumTool {
 
 		bool     run               (HumdrumFileSet& infiles);
 		bool     run               (HumdrumFile& infile);
-		bool     run               (const string& indata, std::ostream& out);
+		bool     run               (const std::string& indata, std::ostream& out);
 		bool     run               (HumdrumFile& infile, std::ostream& out);
 
 
@@ -8460,16 +9709,16 @@ class Tool_metlev : public HumTool {
 
 		bool  run              (HumdrumFileSet& infiles);
 		bool  run              (HumdrumFile& infile);
-		bool  run              (const string& indata, ostream& out);
-		bool  run              (HumdrumFile& infile, ostream& out);
+		bool  run              (const std::string& indata, std::ostream& out);
+		bool  run              (HumdrumFile& infile, std::ostream& out);
 
 	protected:
-		void  fillVoiceResults (vector<vector<double> >& results,
+		void  fillVoiceResults (std::vector<std::vector<double> >& results,
 		                        HumdrumFile& infile,
-		                        vector<double>& beatlev);
+		                        std::vector<double>& beatlev);
 
 	private:
-		vector<HTp> m_kernspines;
+		std::vector<HTp> m_kernspines;
 
 };
 
@@ -8501,13 +9750,13 @@ class Tool_mint : public HumTool {
 		bool m_compoundQ = false; // -c option: reduce compound intervals to simple intervals
 		bool m_diatonicQ = false; // -d option: only display the diatonic interval number
 		bool m_lowestQ   = false; // -l option: use lowest note of a chord instead of the highest
+		bool m_cdataQ    = false; // -x option: label the spine **cdata-mint instead of **mint
 
 		std::string       m_kernTracks  = ""; // used with -k option
 		std::string       m_spineTracks = ""; // used with -s option
 		std::vector<bool> m_selectedKernSpines; // used with -k and -s option
 
 };
-
 
 
 class Tool_modori : public HumTool {
@@ -8517,8 +9766,8 @@ class Tool_modori : public HumTool {
 
 		bool     run                          (HumdrumFileSet& infiles);
 		bool     run                          (HumdrumFile& infile);
-		bool     run                          (const string& indata, ostream& out);
-		bool     run                          (HumdrumFile& infile, ostream& out);
+		bool     run                          (const std::string& indata, std::ostream& out);
+		bool     run                          (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void     processFile                  (HumdrumFile& infile);
@@ -8551,11 +9800,11 @@ class Tool_modori : public HumTool {
 		void     convertInstrumentAbbreviationToOriginal (HTp token);
 		void     convertInstrumentAbbreviationToRegular  (HTp token);
 
-		int      getPairedReference           (int index, vector<string>& keys);
+		int      getPairedReference           (int index, std::vector<std::string>& keys);
 		void     storeModOriReferenceRecords  (HumdrumFile& infile);
 		void     processExclusiveInterpretationLine(HumdrumFile& infile, int line);
 		bool     processStaffCompanionSpines  (std::vector<HTp> tokens);
-		bool     processStaffSpines           (vector<HTp>& tokens);
+		bool     processStaffSpines           (std::vector<HTp>& tokens);
 		void     updateLoMo                   (HumdrumFile& infile);
 		void     processLoMo                  (HTp lomo);
 		void     printModoriOutput            (HumdrumFile& infile);
@@ -8673,7 +9922,7 @@ class SonorityNoteData {
 				break;
 			}
 		}
-	
+
 		bool hasAccidental(void) {
 			// Set only with setText() input.
 			return m_accidentalQ;
@@ -8985,6 +10234,10 @@ class Tool_musedata2hum : public HumTool {
 		std::string cleanString      (const std::string& input);
 		void    addTextDirection     (GridMeasure* gm, int part, int staff,
 		                              MuseRecord& mr, HumNum timestamp);
+		void    addAboveBelowKernRdf (void);
+		bool    needsAboveBelowKernRdf(void);
+		void    addDirectionDynamics(GridSlice* slice, int part, MuseRecord& mr);
+		void    printLine           (std::ostream& out, HumdrumLine& line);
 
 	private:
 		// options:
@@ -8993,6 +10246,7 @@ class Tool_musedata2hum : public HumTool {
 		bool m_recipQ = false;         // used with -r option
       std::string m_group = "score"; // used with -g option
 		std::string m_omd = "";        // initial tempo designation (store for later output)
+		bool m_noOmvQ = false;         // used with --omd option
 
 		// state variables:
 		int m_part     = 0;            // staff index currently being processed
@@ -9002,6 +10256,17 @@ class Tool_musedata2hum : public HumTool {
 		int m_lastbarnum = -1;         // barnumber carried over from previous bar
 		HTp m_lastnote = NULL;         // for dealing with chords.
 		double m_tempo = 0.0;          // for initial tempo from MIDI settings
+		bool m_aboveBelowKernRdf = false; // output RDF**kern above/below markers
+
+		// m_measureLineIndex -- keep track of index for processed
+		// measure for debugging.
+		int m_measureLineIndex = -1;
+
+		// m_figuredOffset -- increment for the next figure bass offset.
+		int m_figureOffset = 0;
+
+		// m_quarterDivisions -- currently processed $Q value.
+		int m_quarterDivisions = 0;
 
 		std::map<std::string, bool> m_usedReferences;
 		std::vector<std::string> m_postReferences;
@@ -9070,6 +10335,7 @@ class Tool_musicxml2hum : public HumTool {
 		                             std::vector<SimultaneousEvents*>& nowevents,
 		                             HumNum nowtime,
 		                             std::vector<MxmlPart>& partdata);
+		void   handleFiguredBassWithoutNonZeroEvent (std::vector<SimultaneousEvents*>& nowevents, HumNum nowtime);
 		void   appendNonZeroEvents   (GridMeasure* outdata,
 		                              std::vector<SimultaneousEvents*>& nowevents,
 		                              HumNum nowtime,
@@ -9195,6 +10461,7 @@ class Tool_musicxml2hum : public HumTool {
 		void printResult       (ostream& out, HumdrumFile& outfile);
 		void addMeasureOneNumber(HumdrumFile& infile);
 		bool isUsedHairpin     (pugi::xml_node hairpin, int partindex);
+		void checkForInformation(std::ostream& out, xml_document& doc);
 
 	public:
 
@@ -9208,12 +10475,14 @@ class Tool_musicxml2hum : public HumTool {
 		bool m_stemsQ        = false;
 		int  m_slurabove     = 0;
 		int  m_slurbelow     = 0;
+		int  m_staffabove    = 0;
+		int  m_staffbelow    = 0;
 		char m_hasEditorial  = '\0';
 		bool m_hasOrnamentsQ = false;
 		int  m_maxstaff      = 0;
 		std::vector<std::vector<std::string>> m_last_ottava_direction;
 		std::vector<MusicXmlHarmonyInfo> offsetHarmony;
-		std::vector<MusicXmlFiguredBassInfo> offsetFiguredBass;
+		std::vector<MusicXmlFiguredBassInfo> m_offsetFiguredBass;
 		std::vector<string> m_stop_char;
 
 		// RDF indications in **kern data:
@@ -9226,7 +10495,7 @@ class Tool_musicxml2hum : public HumTool {
 		std::vector<std::vector<pugi::xml_node>> m_current_brackets;
 		std::map<int, string> m_bracket_type_buffer;
 		std::vector<std::vector<pugi::xml_node>> m_used_hairpins;
-		std::vector<pugi::xml_node> m_current_figured_bass;
+		std::vector<std::vector<pugi::xml_node>> m_current_figured_bass;
 		std::vector<std::pair<int, pugi::xml_node>> m_current_text;
 		std::vector<std::pair<int, pugi::xml_node>> m_current_tempo;
 
@@ -9302,8 +10571,8 @@ class MeasureInfo {
 			tracks = tcount;
 		}
 		int num;          // measure number
-		string stopStyle;  // styling for end of last measure
-		string startStyle; // styling for start of first measure
+		std::string stopStyle;  // styling for end of last measure
+		std::string startStyle; // styling for start of first measure
 		int seg;          // measure segment
 		int start;        // starting line of segment
 		int stop;         // ending line of segment
@@ -9311,20 +10580,20 @@ class MeasureInfo {
 		HumdrumFile* file;
 
 		// musical settings at start of measure
-		vector<MyCoord> sclef;     // starting clef of segment
-		vector<MyCoord> skeysig;   // starting keysig of segment
-		vector<MyCoord> skey;      // starting key of segment
-		vector<MyCoord> stimesig;  // starting timesig of segment
-		vector<MyCoord> smet;      // starting met of segment
-		vector<MyCoord> stempo;    // starting tempo of segment
+		std::vector<MyCoord> sclef;     // starting clef of segment
+		std::vector<MyCoord> skeysig;   // starting keysig of segment
+		std::vector<MyCoord> skey;      // starting key of segment
+		std::vector<MyCoord> stimesig;  // starting timesig of segment
+		std::vector<MyCoord> smet;      // starting met of segment
+		std::vector<MyCoord> stempo;    // starting tempo of segment
 
 		// musical settings at start of measure
-		vector<MyCoord> eclef;     // ending clef    of segment
-		vector<MyCoord> ekeysig;   // ending keysig  of segment
-		vector<MyCoord> ekey;      // ending key     of segment
-		vector<MyCoord> etimesig;  // ending timesig of segment
-		vector<MyCoord> emet;      // ending met     of segment
-		vector<MyCoord> etempo;    // ending tempo   of segment
+		std::vector<MyCoord> eclef;     // ending clef    of segment
+		std::vector<MyCoord> ekeysig;   // ending keysig  of segment
+		std::vector<MyCoord> ekey;      // ending key     of segment
+		std::vector<MyCoord> etimesig;  // ending timesig of segment
+		std::vector<MyCoord> emet;      // ending met     of segment
+		std::vector<MyCoord> etempo;    // ending tempo   of segment
 };
 
 
@@ -9336,62 +10605,62 @@ class Tool_myank : public HumTool {
 
 		bool     run                   (HumdrumFileSet& infiles);
 		bool     run                   (HumdrumFile& infile);
-		bool     run                   (const string& indata, ostream& out);
-		bool     run                   (HumdrumFile& infile, ostream& out);
+		bool     run                   (const std::string& indata, std::ostream& out);
+		bool     run                   (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void      initialize            (HumdrumFile& infile);
 		void      example              (void);
-		void      usage                (const string& command);
+		void      usage                (const std::string& command);
 		void      myank                (HumdrumFile& infile,
-		                                vector<MeasureInfo>& outmeasure);
-		void      removeDollarsFromString(string& buffer, int maxx);
-		void      processFieldEntry    (vector<MeasureInfo>& field,
-		                                const string& str,
+		                                std::vector<MeasureInfo>& outmeasure);
+		void      removeDollarsFromString(std::string& buffer, int maxx);
+		void      processFieldEntry    (std::vector<MeasureInfo>& field,
+		                                const std::string& str,
 		                                HumdrumFile& infile, int maxmeasure,
-		                                vector<MeasureInfo>& inmeasures,
-		                                vector<int>& inmap);
-		void      expandMeasureOutList (vector<MeasureInfo>& measureout,
-		                                vector<MeasureInfo>& measurein,
-		                                HumdrumFile& infile, const string& optionstring);
-		void      getMeasureStartStop  (vector<MeasureInfo>& measurelist,
+		                                std::vector<MeasureInfo>& inmeasures,
+		                                std::vector<int>& inmap);
+		void      expandMeasureOutList (std::vector<MeasureInfo>& measureout,
+		                                std::vector<MeasureInfo>& measurein,
+		                                HumdrumFile& infile, const std::string& optionstring);
+		void      getMeasureStartStop  (std::vector<MeasureInfo>& measurelist,
 		                                HumdrumFile& infile);
 		void      printEnding          (HumdrumFile& infile, int lastline, int adjlin);
 		void      printStarting        (HumdrumFile& infile);
 		void      reconcileSpineBoundary(HumdrumFile& infile, int index1, int index2);
 		void      reconcileStartingPosition(HumdrumFile& infile, int index2);
-		void      printJoinLine        (vector<int>& splits, int index, int count);
+		void      printJoinLine        (std::vector<int>& splits, int index, int count);
 		void      printInvisibleMeasure(HumdrumFile& infile, int line);
 		void      fillGlobalDefaults   (HumdrumFile& infile,
-		                                vector<MeasureInfo>& measurein,
-		                                vector<int>& inmap);
+		                                std::vector<MeasureInfo>& measurein,
+		                                std::vector<int>& inmap);
 		void      adjustGlobalInterpretations(HumdrumFile& infile, int ii,
-		                                vector<MeasureInfo>& outmeasures,
+		                                std::vector<MeasureInfo>& outmeasures,
 		                                int index);
 		void      adjustGlobalInterpretationsStart(HumdrumFile& infile, int ii,
-		                                vector<MeasureInfo>& outmeasures,
+		                                std::vector<MeasureInfo>& outmeasures,
 		                                int index);
-		void      getMarkString        (ostream& out, HumdrumFile& infile);
+		void      getMarkString        (std::ostream& out, HumdrumFile& infile);
 		void      printDoubleBarline   (HumdrumFile& infile, int line);
-		void      insertZerothMeasure  (vector<MeasureInfo>& measurelist,
+		void      insertZerothMeasure  (std::vector<MeasureInfo>& measurelist,
 		                                HumdrumFile& infile);
-		void      getMetStates         (vector<vector<MyCoord> >& metstates,
+		void      getMetStates         (std::vector<std::vector<MyCoord> >& metstates,
 		                                HumdrumFile& infile);
 		MyCoord   getLocalMetInfo      (HumdrumFile& infile, int row, int track);
 		int       atEndOfFile          (HumdrumFile& infile, int line);
 		void      processFile          (HumdrumFile& infile);
 		int       getSectionCount      (HumdrumFile& infile);
-		void      getSectionString     (string& sstring, HumdrumFile& infile,
+		void      getSectionString     (std::string& sstring, HumdrumFile& infile,
 		                                int sec);
 		void      collapseSpines       (HumdrumFile& infile, int line);
-		void      printMeasureStart    (HumdrumFile& infile, int line, const string& style);
-		std::string expandMultipliers  (const string& inputstring);
+		void      printMeasureStart    (HumdrumFile& infile, int line, const std::string& style);
+		std::string expandMultipliers  (const std::string& inputstring);
 
-		vector<int> analyzeBarNumbers  (HumdrumFile& infile);
+		std::vector<int> analyzeBarNumbers  (HumdrumFile& infile);
 		int         getBarNumberForLineNumber(int lineNumber);
 		int         getStartLineNumber (void);
 		int         getEndLineNumber   (void);
-		void        printDataLine      (HLp line, bool& startLineHandled, const vector<int>& lastLineResolvedTokenLineIndex, const vector<HumNum>& lastLineDurationsFromNoteStart);
+		void        printDataLine      (HLp line, bool& startLineHandled, const std::vector<int>& lastLineResolvedTokenLineIndex, const std::vector<HumNum>& lastLineDurationsFromNoteStart);
 
 	private:
 		int    m_debugQ      = 0;             // used with --debug option
@@ -9409,12 +10678,12 @@ class Tool_myank : public HumTool {
 		int    m_barnumtextQ = 0;             // used with -T option
 		int    m_section     = 0;             // used with --section option
 		int    m_sectionCountQ = 0;           // used with --section-count option
-		vector<MeasureInfo> m_measureOutList; // used with -m option
-		vector<MeasureInfo> m_measureInList;  // used with -m option
-		vector<vector<MyCoord> > m_metstates;
+		std::vector<MeasureInfo> m_measureOutList; // used with -m option
+		std::vector<MeasureInfo> m_measureInList;  // used with -m option
+		std::vector<std::vector<MyCoord> > m_metstates;
 
-		string      m_lineRange;              // used with -l option
-		vector<int> m_barNumbersPerLine;      // used with -l option
+		std::string m_lineRange;              // used with -l option
+		std::vector<int> m_barNumbersPerLine;      // used with -l option
 		bool m_hideStarting;                  // used with --hide-starting option
 		bool m_hideEnding;                    // used with --hide-ending option
 
@@ -9429,14 +10698,14 @@ class Tool_nproof : public HumTool {
 
 		bool     run               (HumdrumFileSet& infiles);
 		bool     run               (HumdrumFile& infile);
-		bool     run               (const string& indata, std::ostream& out);
+		bool     run               (const std::string& indata, std::ostream& out);
 		bool     run               (HumdrumFile& infile, std::ostream& out);
 
 		void     checkForBlankLines(HumdrumFile& infile);
 		void     checkInstrumentInformation(HumdrumFile& infile);
 		void     checkKeyInformation(HumdrumFile& infile);
 		void     checkSpineTerminations(HumdrumFile& infile);
-		void     checkForValidInstrumentCode(HTp token, vector<pair<string, string>>& instrumentList);
+		void     checkForValidInstrumentCode(HTp token, std::vector<std::pair<std::string, std::string>>& instrumentList);
 		void     checkReferenceRecords(HumdrumFile& infile);
 
 	protected:
@@ -9467,8 +10736,8 @@ class Tool_ordergps : public HumTool {
 
 		bool  run            (HumdrumFileSet& infiles);
 		bool  run            (HumdrumFile& infile);
-		bool  run            (const string& indata, ostream& out);
-		bool  run            (HumdrumFile& infile, ostream& out);
+		bool  run            (const std::string& indata, std::ostream& out);
+		bool  run            (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void  initialize     (void);
@@ -9489,6 +10758,32 @@ class Tool_ordergps : public HumTool {
 };
 
 
+class Tool_pbar : public HumTool {
+	public:
+		            Tool_pbar        (void);
+		           ~Tool_pbar        () {};
+
+		bool        run               (HumdrumFileSet& infiles);
+		bool        run               (HumdrumFile& infile);
+		bool        run               (const std::string& indata, std::ostream& out);
+		bool        run               (HumdrumFile& infile, std::ostream& out);
+
+	protected:
+		void        processFile       (HumdrumFile& infile);
+		void        initialize        (void);
+		void        processSpine      (HTp spineStart);
+		void        printDataLine                   (HumdrumFile& infile, int index);
+		void        printLocalCommentLine           (HumdrumFile& infile, int index);
+		void        addBarLineToFollowingNoteOrRest (HTp token);
+		void        printInvisibleBarlines          (HumdrumFile& infile, int index);
+		void        printBarLine                    (HumdrumFile& infile, int index);
+
+	private:
+		bool        m_invisibleQ = false;   // used with -i option
+
+};
+
+
 
 class Tool_pccount : public HumTool {
 	public:
@@ -9497,8 +10792,8 @@ class Tool_pccount : public HumTool {
 
 		bool  run                       (HumdrumFileSet& infiles);
 		bool  run                       (HumdrumFile& infile);
-		bool  run                       (const string& indata, ostream& out);
-		bool  run                       (HumdrumFile& infile, ostream& out);
+		bool  run                       (const std::string& indata, std::ostream& out);
+		bool  run                       (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void   initialize               (HumdrumFile& infile);
@@ -9514,21 +10809,21 @@ class Tool_pccount : public HumTool {
 		void   printReverseVoiceList    (void);
 		void   printColorList           (void);
 		std::string getPitchClassString (int b40);
-		void   printVegaLiteScript      (const string& jsonvar,
-		                                 const string& target,
-		                                 const string& datavar,
+		void   printVegaLiteScript      (const std::string& jsonvar,
+		                                 const std::string& target,
+		                                 const std::string& datavar,
 		                                 HumdrumFile& infile);
-		void   printVegaLiteHtml        (const string& jsonvar,
-		                                 const string& target,
-		                                 const string& datavar,
+		void   printVegaLiteHtml        (const std::string& jsonvar,
+		                                 const std::string& target,
+		                                 const std::string& datavar,
 		                                 HumdrumFile& infile);
-		void   printVegaLitePage        (const string& jsonvar,
-		                                 const string& target,
-		                                 const string& datavar,
+		void   printVegaLitePage        (const std::string& jsonvar,
+		                                 const std::string& target,
+		                                 const std::string& datavar,
 		                                 HumdrumFile& infile);
 		std::string getFinal            (HumdrumFile& infile);
-		double  getPercent              (const string& pitchclass);
-		int     getCount                (const string& pitchclass);
+		double  getPercent              (const std::string& pitchclass);
+		int     getCount                (const std::string& pitchclass);
 		void    setFactorMaximum        (void);
 		void    setFactorNormalize      (void);
 
@@ -9570,18 +10865,18 @@ class Tool_periodicity : public HumTool {
 
 		bool     run                (HumdrumFileSet& infiles);
 		bool     run                (HumdrumFile& infile);
-		bool     run                (const string& indata, ostream& out);
-		bool     run                (HumdrumFile& infile, ostream& out);
+		bool     run                (const std::string& indata, std::ostream& out);
+		bool     run                (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void     initialize         (HumdrumFile& infile);
 		void     processFile        (HumdrumFile& infile);
-		void     fillAttackGrids    (HumdrumFile& infile, vector<vector<double>>& grids, HumNum minrhy);
-		void     printAttackGrid    (ostream& out, HumdrumFile& infile, vector<vector<double>>& grids, HumNum minrhy);
-		void     doAnalysis         (vector<vector<double>>& analysis, int level, vector<double>& grid);
-		void     doPeriodicityAnalysis(vector<vector<double>> & analysis, vector<double>& grid, HumNum minrhy);
-		void     printPeriodicityAnalysis(ostream& out, vector<vector<double>>& analysis);
-		void     printSvgAnalysis(ostream& out, vector<vector<double>>& analysis, HumNum minrhy);
+		void     fillAttackGrids    (HumdrumFile& infile, std::vector<std::vector<double>>& grids, HumNum minrhy);
+		void     printAttackGrid    (std::ostream& out, HumdrumFile& infile, std::vector<std::vector<double>>& grids, HumNum minrhy);
+		void     doAnalysis         (std::vector<std::vector<double>>& analysis, int level, std::vector<double>& grid);
+		void     doPeriodicityAnalysis(std::vector<std::vector<double>> & analysis, std::vector<double>& grid, HumNum minrhy);
+		void     printPeriodicityAnalysis(std::ostream& out, std::vector<std::vector<double>>& analysis);
+		void     printSvgAnalysis(std::ostream& out, std::vector<std::vector<double>>& analysis, HumNum minrhy);
 		void     getColorMapping(double input, double& hue, double& saturation, double& lightness);
 
 	private:
@@ -9596,8 +10891,8 @@ class Tool_phrase : public HumTool {
 
 		bool  run                 (HumdrumFileSet& infiles);
 		bool  run                 (HumdrumFile& infile);
-		bool  run                 (const string& indata, ostream& out);
-		bool  run                 (HumdrumFile& infile, ostream& out);
+		bool  run                 (const std::string& indata, std::ostream& out);
+		bool  run                 (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void  analyzeSpineByRests (int index);
@@ -9609,16 +10904,16 @@ class Tool_phrase : public HumTool {
 		void  removePhraseMarks   (HTp start);
 
 	private:
-		vector<vector<string>>    m_results;
-		vector<HTp>               m_starts;
+		std::vector<std::vector<std::string>>    m_results;
+		std::vector<HTp>               m_starts;
 		HumdrumFile               m_infile;
-		vector<int>               m_pcount;
-		vector<HumNum>            m_psum;
+		std::vector<int>               m_pcount;
+		std::vector<HumNum>            m_psum;
 		bool                      m_markQ;
 		bool                      m_removeQ;
 		bool                      m_remove2Q;
 		bool                      m_averageQ;
-		string                    m_color;
+		std::string               m_color;
 
 };
 
@@ -9631,15 +10926,15 @@ class Tool_pline : public HumTool {
 
 		bool     run               (HumdrumFileSet& infiles);
 		bool     run               (HumdrumFile& infile);
-		bool     run               (const string& indata, ostream& out);
-		bool     run               (HumdrumFile& infile, ostream& out);
+		bool     run               (const std::string& indata, std::ostream& out);
+		bool     run               (HumdrumFile& infile, std::ostream& out);
 
 
 	protected:
 		void     initialize        (void);
 		void     processFile       (HumdrumFile& infile);
-		void     getPlineInterpretations(HumdrumFile& infile, vector<HTp>& tokens);
-		void     plineToColor      (HumdrumFile& infile, vector<HTp>& tokens);
+		void     getPlineInterpretations(HumdrumFile& infile, std::vector<HTp>& tokens);
+		void     plineToColor      (HumdrumFile& infile, std::vector<HTp>& tokens);
 		void     markRests         (HumdrumFile& infile);
 		void     markSpineRests    (HTp spineStop);
 		void     fillLineInfo      (HumdrumFile& infile, std::vector<std::vector<int>>& lineInfo);
@@ -9656,6 +10951,68 @@ class Tool_pline : public HumTool {
 };
 
 
+class Tool_pliner : public HumTool {
+	public:
+		         Tool_pliner     (void);
+		        ~Tool_pliner     () {};
+
+		bool     run               (HumdrumFileSet& infiles);
+		bool     run               (HumdrumFile& infile);
+		bool     run               (const std::string& indata, std::ostream& out);
+		bool     run               (HumdrumFile& infile, std::ostream& out);
+
+	protected:
+		void     initialize        (void);
+		void     processFile       (HumdrumFile& infile);
+
+		// poem model:
+		struct PoemWord {
+			std::string original;
+			std::string norm;
+			int line   = -1;
+			int pos    = -1;
+		};
+
+		bool     parseVerse        (HumdrumFile& infile, std::vector<std::vector<PoemWord>>& poem);
+
+		// voice model:
+		struct Voice {
+			HTp kernStart = NULL;
+			HTp textStart = NULL;
+		};
+
+		struct SungWord {
+			HTp token       = NULL; // starting token of the reconstructed word
+			std::string norm;
+			bool capitalized = false;
+		};
+
+		struct Span {
+			int line      = -1;
+			int startPos  = -1;
+			int endPos    = -1;
+			bool repeat   = false;
+			HTp startToken = NULL;
+		};
+
+		void     getVoices          (HumdrumFile& infile, std::vector<Voice>& voices);
+		void     buildSungWords     (HTp textStart, std::vector<SungWord>& words);
+		std::string cleanSyllable   (const std::string& text);
+		std::string normalizeWord   (const std::string& text);
+		void     alignVoice         (std::vector<SungWord>& words,
+		                             std::vector<std::vector<PoemWord>>& poem,
+		                             std::vector<Span>& spans);
+		std::string getModifier     (std::vector<std::vector<PoemWord>>& poem, Span& span);
+		void     emitOutput         (HumdrumFile& infile,
+		                             std::map<int, std::map<int, std::string>>& insertions);
+
+	private:
+		std::vector<std::vector<PoemWord>> m_poem;
+		std::vector<Voice> m_voices;
+
+};
+
+
 class Tool_pnum : public HumTool {
 	public:
 		      Tool_pnum               (void);
@@ -9663,8 +11020,8 @@ class Tool_pnum : public HumTool {
 
 		bool  run                     (HumdrumFileSet& infiles);
 		bool  run                     (HumdrumFile& infile);
-		bool  run                     (const string& indata, ostream& out);
-		bool  run                     (HumdrumFile& infile, ostream& out);
+		bool  run                     (const std::string& indata, std::ostream& out);
+		bool  run                     (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void  initialize              (HumdrumFile& infile);
@@ -9686,6 +11043,151 @@ class Tool_pnum : public HumTool {
 
 
 
+
+class _VoiceInfo {
+	public:
+		std::vector<std::vector<double>>   diatonic;
+		std::vector<double>                midibins;
+		std::string                        name;      // name for instrument name of spine
+		std::string                        abbr;      // abbreviation for instrument name of spine
+		int                                track;     // track number for spine
+		bool                               kernQ;     // is spine a **kern spine?
+		double                             hpos;      // horiz. position on system for pitch range data for spine
+		std::vector<int>                   diafinal;  // finalis note diatonic pitch (4=middle-C octave)
+		std::vector<int>                   accfinal;  // finalis note accidental (0 = natural)
+		std::vector<std::string>           namfinal;  // name of voice for finalis note (for "all" display)
+		int                                index = -1;
+
+	public:
+		                _VoiceInfo        (void);
+		void            clear             (void);
+		std::ostream&   print             (std::ostream& out);
+
+};
+
+
+
+class Tool_prange : public HumTool {
+	public:
+		         Tool_prange       (void);
+		        ~Tool_prange       () {};
+
+		bool        run               (HumdrumFileSet& infiles);
+		bool        run               (HumdrumFile& infile);
+		bool        run               (const std::string& indata, std::ostream& out);
+		bool        run               (HumdrumFile& infile, std::ostream& out);
+
+	protected:
+		void        processFile         (HumdrumFile& infile);
+		void        initialize          (void);
+
+		void        mergeAllVoiceInfo           (std::vector<_VoiceInfo>& voiceInfo);
+		void        getVoiceInfo                (std::vector<_VoiceInfo>& voiceInfo, HumdrumFile& infile);
+		std::string getHand                     (HTp sstart);
+		void        fillHistograms              (std::vector<_VoiceInfo>& voiceInfo, HumdrumFile& infile);
+		void        printFilenameBase           (std::ostream& out, const std::string& filename);
+		void        printReferenceRecords       (std::ostream& out, HumdrumFile& infile);
+		void        printScoreEncodedText       (std::ostream& out, const std::string& strang);
+		void        printXmlEncodedText         (std::ostream& out, const std::string& strang);
+		void        printScoreFile              (std::ostream& out, std::vector<_VoiceInfo>& voiceInfo, HumdrumFile& infile);
+		void        printKeySigCompression      (std::ostream& out, int keysig, int extra);
+		void        assignHorizontalPosition    (std::vector<_VoiceInfo>& voiceInfo, int minval, int maxval);
+		int         getKeySignature             (HumdrumFile& infile);
+		void        printScoreVoice             (std::ostream& out, _VoiceInfo& voiceInfo, double maxvalue);
+		void        printDiatonicPitchName      (std::ostream& out, int base7, int acc);
+		std::string getDiatonicPitchName        (int base7, int acc);
+		void        printHtmlStringEncodeSimple (std::ostream& out, const std::string& strang);
+		std::string getNoteTitle                (double value, int diatonic, int acc);
+		int         getDiatonicInterval         (int note1, int note2);
+		int         getTopQuartile              (std::vector<double>& midibins);
+		int         getBottomQuartile           (std::vector<double>& midibins);
+		double      getMaxValue                 (std::vector<std::vector<double>>& bins);
+		double      getVpos                     (double base7);
+		int         getStaffBase7               (int base7);
+		int         getMaxDiatonicIndex         (std::vector<std::vector<double>>& diatonic);
+		int         getMinDiatonicIndex         (std::vector<std::vector<double>>& diatonic);
+		int         getMinDiatonicAcc           (std::vector<std::vector<double>>& diatonic, int index);
+		int         getMaxDiatonicAcc           (std::vector<std::vector<double>>& diatonic, int index);
+		std::string getTitle                    (void);
+		void        clearHistograms             (std::vector<std::vector<double> >& bins, int start);
+		void        printAnalysis               (std::ostream& out, std::vector<double>& midibins);
+		int         getMedian12                 (std::vector<double>& midibins);
+		double      getMean12                   (std::vector<double>& midibins);
+		int         getTessitura                (std::vector<double>& midibins);
+		double      countNotesInRange           (std::vector<double>& midibins, int low, int high);
+		void        printPercentile             (std::ostream& out, std::vector<double>& midibins, double percentile);
+		void        getRange                    (int& rangeL, int& rangeH, const std::string& rangestring);
+		void        mergeFinals                 (std::vector<_VoiceInfo>& voiceInfo,
+		                                         std::vector<std::vector<int>>& diafinal,
+		                                         std::vector<std::vector<int>>& accfinal);
+		void        getInstrumentNames          (std::vector<std::string>& nameByTrack,
+		                                         std::vector<int>& kernSpines, HumdrumFile& infile);
+		void        printEmbeddedScore          (std::ostream& out, std::stringstream& scoredata, HumdrumFile& infile);
+		void        prepareRefmap               (HumdrumFile& infile);
+		int         getMaxStaffPosition         (std::vector<_VoiceInfo>& voiceinfo);
+		int         getPrangeId                 (HumdrumFile& infile);
+		void        processStrandNotes          (HTp sstart, HTp send,
+		                                         std::vector<std::vector<std::pair<HTp, int>>>& trackInfo);
+		void        fillMidiInfo                (HumdrumFile& infile);
+		void        doExtremaMarkup             (HumdrumFile& infile);
+		void        applyMarkup                 (std::vector<std::pair<HTp, int>>& notelist,
+		                                         const std::string& mark);
+
+	private:
+
+		bool m_accQ         = false; // for --acc option
+		bool m_addFractionQ = false; // for --fraction option
+		bool m_allQ         = false; // for --all option
+		bool m_debugQ       = false; // for --debug option
+		bool m_defineQ      = false; // for --score option (use text macro)
+		bool m_diatonicQ    = false; // for --diatonic option
+		bool m_durationQ    = false; // for --duration option
+		bool m_embedQ       = false; // for --embed option
+		bool m_fillOnlyQ    = false; // for --fill option
+		bool m_finalisQ     = false; // for --finalis option
+		bool m_hoverQ       = false; // for --hover option
+		bool m_instrumentQ  = false; // for --instrument option
+		bool m_keyQ         = true;  // for --no-key option
+		bool m_listQ        = false;
+		bool m_localQ       = false; // for --local-maximum option
+		bool m_normQ        = false; // for --norm option
+		bool m_notitleQ     = false; // for --no-title option
+		bool m_percentileQ  = false; // for --percentile option
+		bool m_pitchQ       = false; // for --pitch option
+		bool m_printQ       = false; // for --print option
+		bool m_quartileQ    = false; // for --quartile option
+		bool m_rangeQ       = false; // for --range option
+		bool m_reverseQ     = false; // for --reverse option
+		bool m_scoreQ       = false; // for --score option
+		bool m_titleQ       = false; // for --title option
+		bool m_extremaQ     = false; // for --extrema option
+
+		std::string m_highMark = "🌸";
+		std::string m_lowMark  = "🟢";
+
+		double m_percentile = 50.0;  // for --percentile option
+		std::string m_title;         // for --title option
+
+		int m_rangeL;                // for --range option
+		int m_rangeH;                // for --range option
+
+		std::map<std::string, std::string> m_refmap;
+
+		//   track       >midi       >tokens        <token, subtoken>
+		std::vector<std::vector<std::vector<std::pair<HTp, int>>>> m_trackMidi;
+
+		// m_trackToKernIndex: mapping from track to **kern index
+		std::vector<int> m_trackToKernIndex;
+
+                // m_lineQ: rint analysis line
+                bool m_lineQ = false;
+
+                // m_voiceCount: Number of voices: (0 minimum voices)
+		int m_voiceCount = 0;
+
+};
+
+
 class Tool_recip : public HumTool {
 	public:
 		      Tool_recip               (void);
@@ -9693,8 +11195,8 @@ class Tool_recip : public HumTool {
 
 		bool  run                      (HumdrumFileSet& infiles);
 		bool  run                      (HumdrumFile& infile);
-		bool  run                      (const string& indata, ostream& out);
-		bool  run                      (HumdrumFile& infile, ostream& out);
+		bool  run                      (const std::string& indata, std::ostream& out);
+		bool  run                      (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void  initialize               (HumdrumFile& infile);
@@ -9703,10 +11205,10 @@ class Tool_recip : public HumTool {
 		void  insertAnalysisSpines     (HumdrumFile& infile, HumdrumFile& cfile);
 
 	private:
-		vector<HTp> m_kernspines;
+		std::vector<HTp> m_kernspines;
 		bool        m_graceQ = true;
-		string      m_exinterp = "**recip";
-		string      m_kernpitch = "e";
+		std::string      m_exinterp = "**recip";
+		std::string      m_kernpitch = "e";
 
 };
 
@@ -9719,8 +11221,8 @@ class Tool_restfill : public HumTool {
 
 		bool        run                (HumdrumFileSet& infiles);
 		bool        run                (HumdrumFile& infile);
-		bool        run                (const string& indata, ostream& out);
-		bool        run                (HumdrumFile& infile, ostream& out);
+		bool        run                (const std::string& indata, std::ostream& out);
+		bool        run                (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void        processFile        (HumdrumFile& infile);
@@ -9744,8 +11246,8 @@ class Tool_rid : public HumTool {
 
 		bool     run               (HumdrumFileSet& infiles);
 		bool     run               (HumdrumFile& infile);
-		bool     run               (const string& indata, ostream& out);
-		bool     run               (HumdrumFile& infile, ostream& out);
+		bool     run               (const std::string& indata, std::ostream& out);
+		bool     run               (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void     processFile       (HumdrumFile& infile);
@@ -9774,6 +11276,108 @@ class Tool_rid : public HumTool {
 };
 
 
+class Tool_rmask : public HumTool {
+	public:
+		         Tool_rmask       (void);
+		        ~Tool_rmask       () {};
+
+		bool     run               (HumdrumFileSet& infiles);
+		bool     run               (HumdrumFile& infile);
+		bool     run               (const std::string& indata, std::ostream& out);
+		bool     run               (HumdrumFile& infile, std::ostream& out);
+
+	protected:
+		void        processFile  (HumdrumFile& infile);
+		void        processSpine (HTp token);
+		void        initialize   (HumdrumFile& infile);
+		bool        isDelete     (std::string& value);
+		std::string addRest      (const std::string& input);
+
+	private:
+		bool     m_modifiedQ = false;
+		std::vector<bool> m_spines;
+		std::vector<bool> m_midi;
+
+};
+
+
+class Tool_rphrase : public HumTool {
+	public:
+
+	class VoiceInfo {
+		public:
+			std::string name;
+			std::vector<double> restsBefore;
+			std::vector<double> phraseDurs;
+			std::vector<int>    barStarts;
+			std::vector<HTp>    phraseStartToks;
+	};
+
+		         Tool_rphrase      (void);
+		        ~Tool_rphrase      () {};
+
+		bool     run               (HumdrumFileSet& infiles);
+		bool     run               (HumdrumFile& infile);
+		bool     run               (const std::string& indata, std::ostream& out);
+		bool     run               (HumdrumFile& infile, std::ostream& out);
+		void     finally           (void);
+
+	protected:
+		void     initialize        (void);
+		void     processFile       (HumdrumFile& infile);
+		void     fillVoiceInfo     (std::vector<Tool_rphrase::VoiceInfo>& voiceInfo, std::vector<HTp>& kstarts, HumdrumFile& infile);
+		void     fillVoiceInfo     (Tool_rphrase::VoiceInfo& voiceInfo, HTp& kstart, HumdrumFile& infile);
+		void     fillCompositeInfo  (Tool_rphrase::VoiceInfo& collapseInfo, HumdrumFile& infile);
+		void     printVoiceInfo    (std::vector<Tool_rphrase::VoiceInfo>& voiceInfo);
+		void     printVoiceInfo    (Tool_rphrase::VoiceInfo& voiceInfo);
+
+		void     printEmbeddedVoiceInfo(std::vector<Tool_rphrase::VoiceInfo>& voiceInfo, Tool_rphrase::VoiceInfo& collapseInfo, HumdrumFile& infile);
+		void     printEmbeddedIndividualVoiceInfo(Tool_rphrase::VoiceInfo& voiceInfo, HumdrumFile& infile);
+		void     printEmbeddedCompositeInfo(Tool_rphrase::VoiceInfo& compositeInfo, HumdrumFile& infile);
+
+		void     getCompositeStates(std::vector<int>& noteStates, HumdrumFile& infile);
+		std::string getCompositeLabel(HumdrumFile& infile);
+		void     markPhraseStartsInScore(HumdrumFile& infile, Tool_rphrase::VoiceInfo& voiceInfo);
+		void     markCompositePhraseStartsInScore(HumdrumFile& infile, Tool_rphrase::VoiceInfo& collapseInfo);
+		void     outputMarkedFile  (HumdrumFile& infile, std::vector<Tool_rphrase::VoiceInfo>& voiceInfo,
+		                            Tool_rphrase::VoiceInfo& compositeInfo);
+		void     printDataLine     (HumdrumFile& infile, int index);
+		void     markLongaDurations(HumdrumFile& infile);
+		std::string getVoiceInfo(HumdrumFile& infile);
+		void     printEmbeddedVoiceInfoSummary(std::vector<Tool_rphrase::VoiceInfo>& voiceInfo, HumdrumFile& infile);
+		double   twoDigitRound(double input);
+		void     printHyperlink(const std::string& urlType);
+
+	private:
+		bool        m_averageQ        = false; // for -a option
+		bool        m_allAverageQ     = false; // for -A option
+		bool        m_breathQ         = true;  // for -B option
+		bool        m_barlineQ        = false; // for -m option
+		bool        m_compositeQ      = false; // for -c option
+		bool        m_longaQ          = false; // for -l option
+		bool        m_filenameQ       = false; // for -f option
+		bool        m_fullFilenameQ   = false; // for -F option
+		std::string m_filename;                // for -f or -F option
+		bool        m_sortQ           = false; // for -s option
+		bool        m_reverseSortQ    = false; // for -S option
+		int         m_pcount          = 0;     // for -a option
+		double      m_sum             = 0.0;   // for -a option
+		int         m_pcountComposite = 0;     // for -c option
+		double      m_sumComposite    = 0.0;   // for -c option
+		bool        m_markQ           = false; // for --mark option
+		double      m_durUnit         = 2.0;   // for -d option
+		bool        m_infoQ           = false; // for -i option (when --mark is active)
+		bool        m_squeezeQ        = false; // for -z option
+		bool        m_closeQ          = false; // for --close option
+		std::string m_urlType;                 // for -u option
+
+		int         m_line = 1;
+		std::string m_voiceLengthColor     = "crimson";
+		std::string m_compositeLengthColor = "limegreen";
+
+};
+
+
 class Tool_ruthfix : public HumTool {
 	public:
 		         Tool_ruthfix      (void);
@@ -9792,6 +11396,39 @@ class Tool_ruthfix : public HumTool {
 };
 
 
+class Tool_sab2gs : public HumTool {
+	public:
+		         Tool_sab2gs      (void);
+		        ~Tool_sab2gs      () {};
+
+		bool     run               (HumdrumFileSet& infiles);
+		bool     run               (HumdrumFile& infile);
+		bool     run               (const std::string& indata, std::ostream& out);
+		bool     run               (HumdrumFile& infile, std::ostream& out);
+
+	protected:
+		void    processFile        (HumdrumFile& infile);
+		void    initialize         (void);
+
+		void    adjustMiddleVoice  (HTp spineStart);
+		void    printGrandStaff    (HumdrumFile& infile, std::vector<HTp>& starts);
+		std::string hasBelowMarker(HumdrumFile& infile);
+
+		void    printReducedLine   (HumdrumFile& infile, int index, std::vector<int>& ktracks);
+		void    printSpineMerge    (HumdrumFile& infile, int index, std::vector<int>& ktracks);
+		void    printSpineSplit    (HumdrumFile& infile, int index, std::vector<int>& ktracks);
+		void    printSwappedLine   (HumdrumFile& infile, int index, std::vector<int>& ktracks);
+
+	private:
+		bool    m_hasCrossStaff = false;   // Middle voice has notes/rests on bottom staff
+		bool    m_hasBelowMarker = false;  // Input data has RDF**kern down marker
+		std::string  m_belowMarker = "<";       // RDF**kern marker for staff down
+		bool    m_downQ = false;           // Used only *down/*Xdown for staff changes
+
+
+};
+
+
 class Tool_satb2gs : public HumTool {
 	public:
 		         Tool_satb2gs      (void);
@@ -9799,8 +11436,8 @@ class Tool_satb2gs : public HumTool {
 
 		bool     run               (HumdrumFileSet& infiles);
 		bool     run               (HumdrumFile& infile);
-		bool     run               (const string& indata, ostream& out);
-		bool     run               (HumdrumFile& infile, ostream& out);
+		bool     run               (const std::string& indata, std::ostream& out);
+		bool     run               (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void    processFile        (HumdrumFile& infile);
@@ -9817,7 +11454,7 @@ class Tool_satb2gs : public HumTool {
 		void    printHeaderLine    (HumdrumFile& infile, int line,
 		                            std::vector<std::vector<int>>& tracks);
 		bool    validateHeader     (HumdrumFile& infile);
-		vector<HTp> getClefs       (HumdrumFile& infile, int line);
+		std::vector<HTp> getClefs       (HumdrumFile& infile, int line);
 
 };
 
@@ -9829,21 +11466,21 @@ class Tool_scordatura : public HumTool {
 
 		bool     run               (HumdrumFileSet& infiles);
 		bool     run               (HumdrumFile& infile);
-		bool     run               (const string& indata, ostream& out);
-		bool     run               (HumdrumFile& infile, ostream& out);
+		bool     run               (const std::string& indata, std::ostream& out);
+		bool     run               (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void     processFile       (HumdrumFile& infile);
 		void     initialize        (void);
-		void     getScordaturaRdfs (vector<HTp>& rdfs, HumdrumFile& infile);
+		void     getScordaturaRdfs (std::vector<HTp>& rdfs, HumdrumFile& infile);
 		void     processScordatura (HumdrumFile& infile, HTp reference);
-		void     processScordaturas(HumdrumFile& infile, vector<HTp>& rdfs);
+		void     processScordaturas(HumdrumFile& infile, std::vector<HTp>& rdfs);
 		void     flipScordaturaInfo(HTp reference, int diatonic, int chromatic);
-		void     transposeStrand   (HTp sstart, HTp sstop, const string& marker);
-		void     transposeChord    (HTp token, const string& marker);
-		std::string transposeNote     (const string& note);
-		void     transposeMarker   (HumdrumFile& infile, const string& marker, int diatonic, int chromatic);
-		std::set<int> parsePitches(const string& input);
+		void     transposeStrand   (HTp sstart, HTp sstop, const std::string& marker);
+		void     transposeChord    (HTp token, const std::string& marker);
+		std::string transposeNote     (const std::string& note);
+		void     transposeMarker   (HumdrumFile& infile, const std::string& marker, int diatonic, int chromatic);
+		std::set<int> parsePitches(const std::string& input);
 		void     markPitches       (HumdrumFile& infile);
 		void     markPitches       (HTp sstart, HTp sstop);
 		void     markPitches       (HTp token);
@@ -9894,7 +11531,7 @@ class Tool_semitones : public HumTool {
 		int         filterData(HTp token);
 		std::vector<HTp> getTieGroup(HTp token);
 		HTp         getNextNote(HTp token);
-		bool        hasTieContinue(const string& value);
+		bool        hasTieContinue(const std::string& value);
 
 	private:
 
@@ -9934,11 +11571,12 @@ class Tool_shed : public HumTool {
 
 		bool     run               (HumdrumFileSet& infiles);
 		bool     run               (HumdrumFile& infile);
-		bool     run               (const string& indata, ostream& out);
-		bool     run               (HumdrumFile& infile, ostream& out);
+		bool     run               (const std::string& indata, std::ostream& out);
+		bool     run               (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void    processFile                      (HumdrumFile& infile);
+		void    processExpression                (HumdrumFile& infile);
 		void    searchAndReplaceInterpretation   (HumdrumFile& infile);
 		void    searchAndReplaceExinterp         (HumdrumFile& infile);
 		void    searchAndReplaceData             (HumdrumFile& infile);
@@ -9955,9 +11593,9 @@ class Tool_shed : public HumTool {
 		bool    isValidDataType    (HTp token);
 		bool    isValidSpine       (HTp token);
 		std::vector<std::string> addToExInterpList(void);
-		void    parseExpression    (const string& value);
+		void    parseExpression    (const std::string& value);
 		void    prepareSearch      (int index);
-		std::string getExInterp    (const string& value);
+		std::string getExInterp    (const std::string& value);
 
 	private:
 		std::vector<std::string> m_searches;  // search strings
@@ -10000,8 +11638,8 @@ class Tool_sic : public HumTool {
 
 		bool     run               (HumdrumFileSet& infiles);
 		bool     run               (HumdrumFile& infile);
-		bool     run               (const string& indata, ostream& out);
-		bool     run               (HumdrumFile& infile, ostream& out);
+		bool     run               (const std::string& indata, std::ostream& out);
+		bool     run               (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void     processFile       (HumdrumFile& infile);
@@ -10122,9 +11760,9 @@ class MeasureComparisonGrid {
 		std::string  getQoff2                  (int index);
 		double       getScoreDuration2         (void);
 
-		ostream&     printCorrelationGrid      (ostream& out = std::cout);
-		ostream&     printCorrelationDiagonal  (ostream& out = std::cout);
-		ostream&     printSvgGrid              (ostream& out = std::cout);
+		std::ostream&     printCorrelationGrid      (std::ostream& out = std::cout);
+		std::ostream&     printCorrelationDiagonal  (std::ostream& out = std::cout);
+		std::ostream&     printSvgGrid              (std::ostream& out = std::cout);
 		void         getColorMapping           (double input, double& hue, double& saturation,
 				 double& lightness);
 
@@ -10143,8 +11781,8 @@ class Tool_simat : public HumTool {
 
 		bool     run                (HumdrumFileSet& infiles);
 		bool     run                (HumdrumFile& infile1, HumdrumFile& infile2);
-		bool     run                (const string& indata1, const string& indata2, ostream& out);
-		bool     run                (HumdrumFile& infile1, HumdrumFile& infile2, ostream& out);
+		bool     run                (const std::string& indata1, const std::string& indata2, std::ostream& out);
+		bool     run                (HumdrumFile& infile1, HumdrumFile& infile2, std::ostream& out);
 
 	protected:
 		void     initialize         (HumdrumFile& infile1, HumdrumFile& infile2);
@@ -10165,8 +11803,8 @@ class Tool_slurcheck : public HumTool {
 
 		bool     run               (HumdrumFileSet& infiles);
 		bool     run               (HumdrumFile& infile);
-		bool     run               (const string& indata, ostream& out);
-		bool     run               (HumdrumFile& infile, ostream& out);
+		bool     run               (const std::string& indata, std::ostream& out);
+		bool     run               (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void     processFile       (HumdrumFile& infile);
@@ -10184,8 +11822,8 @@ class Tool_spinetrace : public HumTool {
 
 		bool  run                      (HumdrumFileSet& infiles);
 		bool  run                      (HumdrumFile& infile);
-		bool  run                      (const string& indata, ostream& out);
-		bool  run                      (HumdrumFile& infile, ostream& out);
+		bool  run                      (const std::string& indata, std::ostream& out);
+		bool  run                      (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void  initialize               (HumdrumFile& infile);
@@ -10204,8 +11842,8 @@ class Tool_strophe : public HumTool {
 
 		bool     run               (HumdrumFileSet& infiles);
 		bool     run               (HumdrumFile& infile);
-		bool     run               (const string& indata, ostream& out);
-		bool     run               (HumdrumFile& infile, ostream& out);
+		bool     run               (const std::string& indata, std::ostream& out);
+		bool     run               (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void     processFile       (HumdrumFile& infile);
@@ -10231,8 +11869,8 @@ class Tool_synco : public HumTool {
 
 		bool     run               (HumdrumFileSet& infiles);
 		bool     run               (HumdrumFile& infile);
-		bool     run               (const string& indata, ostream& out);
-		bool     run               (HumdrumFile& infile, ostream& out);
+		bool     run               (const std::string& indata, std::ostream& out);
+		bool     run               (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void      processFile      (HumdrumFile& infile);
@@ -10266,8 +11904,8 @@ class Tool_tabber : public HumTool {
 
 		bool  run                      (HumdrumFileSet& infiles);
 		bool  run                      (HumdrumFile& infile);
-		bool  run                      (const string& indata, ostream& out);
-		bool  run                      (HumdrumFile& infile, ostream& out);
+		bool  run                      (const std::string& indata, std::ostream& out);
+		bool  run                      (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void  initialize               (HumdrumFile& infile);
@@ -10279,6 +11917,94 @@ class Tool_tabber : public HumTool {
 
 
 
+class Tool_tandeminfo : public HumTool {
+	public:
+	class Entry {
+		public:
+			HTp token = NULL;
+			std::string description;
+			int count = 0;
+	};
+
+		         Tool_tandeminfo   (void);
+		        ~Tool_tandeminfo   () {};
+
+		bool     run               (HumdrumFileSet& infiles);
+		bool     run               (HumdrumFile& infile);
+		bool     run               (const std::string& indata, std::ostream& out);
+		bool     run               (HumdrumFile& infile, std::ostream& out);
+
+
+	protected:
+		void     initialize        (void);
+		void     processFile       (HumdrumFile& infile);
+		void     printEntries      (HumdrumFile& infile);
+		void     printEntriesHtml  (HumdrumFile& infile);
+		void     printEntriesText  (HumdrumFile& infile);
+		void     doCountAnalysis   (void);
+
+		std::string getDescription         (HTp token);
+		std::string checkForKeySignature   (const std::string& tok);
+		std::string checkForKeyDesignation (const std::string& tok);
+		std::string checkForInstrumentInfo (const std::string& tok);
+		std::string checkForLabelInfo      (const std::string& tok);
+		std::string checkForTimeSignature  (const std::string& tok);
+		std::string checkForMeter          (const std::string& tok);
+		std::string checkForTempoMarking   (const std::string& tok);
+		std::string checkForClef           (const std::string& tok);
+		std::string checkForStaffPartGroup (const std::string& tok);
+		std::string checkForTuplet         (const std::string& tok);
+		std::string checkForHands          (const std::string& tok);
+		std::string checkForPosition       (const std::string& tok);
+		std::string checkForCue            (const std::string& tok);
+		std::string checkForFlip           (const std::string& tok);
+		std::string checkForTremolo        (const std::string& tok);
+		std::string checkForOttava         (const std::string& tok);
+		std::string checkForPedal          (const std::string& tok);
+		std::string checkForBracket        (const std::string& tok);
+		std::string checkForRscale         (const std::string& tok);
+		std::string checkForTimebase       (const std::string& tok);
+		std::string checkForTransposition  (const std::string& tok);
+		std::string checkForGrp            (const std::string& tok);
+		std::string checkForStria          (const std::string& tok);
+		std::string checkForFont           (const std::string& tok);
+		std::string checkForVerseLabels    (const std::string& tok);
+		std::string checkForLanguage       (const std::string& tok);
+		std::string checkForStemInfo       (const std::string& tok);
+		std::string checkForXywh           (const std::string& tok);
+		std::string checkForCustos         (const std::string& tok);
+		std::string checkForTextInterps    (const std::string& tok);
+		std::string checkForRep            (const std::string& tok);
+		std::string checkForPline          (const std::string& tok);
+		std::string checkForTacet          (const std::string& tok);
+		std::string checkForFb             (const std::string& tok);
+		std::string checkForColor          (const std::string& tok);
+		std::string checkForThru           (const std::string& tok);
+
+	private:
+		bool m_exclusiveQ   = true;   // used with -X option (don't print exclusive interpretation)
+		bool m_unknownQ     = false;  // used with -u option (print only unknown tandem interpretations)
+		bool m_filenameQ    = false;  // used with -f option (print only unknown tandem interpretations)
+		bool m_descriptionQ = false;  // used with -m option (print description of interpretation)
+		bool m_locationQ    = false;  // used with -l option (print location of interpretation in file)
+		bool m_zeroQ        = false;  // used with -z option (location address by 0-index)
+		bool m_tableQ       = false;  // used with -t option (display results as HTML table)
+		bool m_closeQ       = false;  // used with --close option (HTML details closed by default)
+		bool m_sortQ        = false;  // used with -s (sort entries alphabetically by tandem interpretation)
+		bool m_headerOnlyQ  = false;  // used with -h option (process only header interpretations)
+		bool m_bodyOnlyQ    = false;  // used with -H option (process only body interpretations)
+		bool m_countQ       = false;  // used with -c option (only show unique list with counts);
+		bool m_sortByCountQ = false;  // used with -c and -n options (sort from low to high count)
+		bool m_sortByReverseCountQ = false;  // used with -c and -N options (sort from high to low count)
+		bool m_humdrumQ     = false;  // used with --humdrum option (output data formatted with Humdrum syntax)
+
+		std::string m_unknown = "unknown";
+
+		std::vector<Tool_tandeminfo::Entry> m_entries;
+		std::map<std::string, int> m_count;
+};
+
+
 class Tool_tassoize : public HumTool {
 	public:
 		         Tool_tassoize   (void);
@@ -10286,8 +12012,8 @@ class Tool_tassoize : public HumTool {
 
 		bool     run                (HumdrumFileSet& infiles);
 		bool     run                (HumdrumFile& infile);
-		bool     run                (const string& indata, ostream& out);
-		bool     run                (HumdrumFile& infile, ostream& out);
+		bool     run                (const std::string& indata, std::ostream& out);
+		bool     run                (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void     initialize         (HumdrumFile& infile);
@@ -10301,14 +12027,70 @@ class Tool_tassoize : public HumTool {
 		void     fixInstrumentAbbreviations(HumdrumFile& infile);
 		void     addTerminalLongs   (HumdrumFile& infile);
 		void     deleteDummyTranspositions(HumdrumFile& infile);
-		string   getDate            (void);
+		std::string   getDate            (void);
 		void     adjustSystemDecoration(HumdrumFile& infile);
 
 	private:
-		vector<vector<int>> m_pstates;
-		vector<vector<int>> m_kstates;
-		vector<vector<bool>> m_estates;
+		std::vector<std::vector<int>> m_pstates;
+		std::vector<std::vector<int>> m_kstates;
+		std::vector<std::vector<bool>> m_estates;
 
+};
+
+
+class Tool_text : public HumTool {
+	public:
+		         Tool_text       (void);
+		        ~Tool_text       () {};
+
+		bool     run               (HumdrumFileSet& infiles);
+		bool     run               (HumdrumFile& infile);
+		bool     run               (const std::string& indata, std::ostream& out);
+		bool     run               (HumdrumFile& infile, std::ostream& out);
+
+	protected:
+		void     processFile       (HumdrumFile& infile);
+		void     initialize        (void);
+		void     processTextSpine  (HTp tspine, int vth, int vsize);
+		void     processPlineSpine (HTp tspine, int vth, int vsize);
+		bool     hasParam          (HTp tspine, const std::string& target);
+		std::string getParamListOne(std::vector<HTp>& tspine, const std::string& target);
+		std::string getParamListTwo(std::vector<std::vector<HTp>>& tspine, const std::string& target);
+		std::string getParmTimestamp(HTp token, const std::string& target);
+		void     removePartText    (HTp startspine, int vth, int vsize);
+		void     removeText        (HumdrumFile& infile);
+		std::string getSyllable    (HTp token);
+		void     fillPlines        (std::vector<std::vector<HTp>>& plines, HTp tspine,
+		                            int vth, int vsize);
+		void     addSyllables      (std::vector<HTp>& syllables);
+		std::string getPlineLabel  (std::vector<HTp>& pieces);
+		void     printPlineSyllables(std::vector<HTp>& pieces);
+		void     printPline(std::vector<std::vector<HTp>>& p, const char* description);
+		std::string getPlineRow    (std::vector<HTp>& pieces);
+		void        zprintPlineRow (std::vector<HTp>& pieces);
+		void        makeTextArray  (std::vector<std::vector<HTp>>& texts, std::vector<HTp> spines);
+		std::string makeStyle      (void);
+		int countSyllables         (std::vector<HTp>& tokens);
+		void markBis               (HTp spine);
+
+	private:
+		bool     m_onlyQ      = false;
+		bool     m_aboveQ     = false;
+		bool     m_belowQ     = false;
+		bool     m_joinQ      = false;
+		bool     m_removeQ    = false;
+		bool     m_removeAllQ = false;
+		bool     m_mergeQ     =  true;
+		bool     m_rawQ       = false;
+		bool     m_repeatsQ   = false;
+		bool     m_showVerseQ = false;
+		bool     m_countQ     =  true;
+		bool     m_refrainOnlyQ = false;
+		bool     m_verseOnlyQ   = false;
+		bool     m_noBisQ       = false;
+
+		std::vector<std::vector<std::string>> m_text;
+		std::stringstream m_output;
 };
 
 
@@ -10319,8 +12101,8 @@ class Tool_textdur : public HumTool {
 
 		bool     run               (HumdrumFileSet& infiles);
 		bool     run               (HumdrumFile& infile);
-		bool     run               (const string& indata, ostream& out);
-		bool     run               (HumdrumFile& infile, ostream& out);
+		bool     run               (const std::string& indata, std::ostream& out);
+		bool     run               (HumdrumFile& infile, std::ostream& out);
 
 
 	protected:
@@ -10328,13 +12110,13 @@ class Tool_textdur : public HumTool {
 		void     processFile       (HumdrumFile& infile);
 		void     printMelismas     (HumdrumFile& infile);
 		void     printDurations     (HumdrumFile& infile);
-		void     getTextSpineStarts(HumdrumFile& infile, vector<HTp>& starts);
-		void     processTextSpine  (vector<HTp>& starts, int index);
+		void     getTextSpineStarts(HumdrumFile& infile, std::vector<HTp>& starts);
+		void     processTextSpine  (std::vector<HTp>& starts, int index);
 		int      getMelisma        (HTp tok1, HTp tok2);
 		HumNum   getDuration       (HTp tok1, HTp tok2);
 		HTp      getTandemKernToken(HTp token);
 		void     printInterleaved  (HumdrumFile& infile);
-		void     printInterleavedLine(HumdrumLine& line, vector<bool>& textTrack);
+		void     printInterleavedLine(HumdrumLine& line, std::vector<bool>& textTrack);
 		void     printTokenAnalysis(HTp token);
 		void     printAnalysis      (void);
 		void     printDurationAverage(void);
@@ -10349,7 +12131,7 @@ class Tool_textdur : public HumTool {
 	private:
 		std::vector<HTp>                 m_textStarts;
 		std::vector<int>                 m_track2column;
-		std::vector<string>              m_columnName;
+		std::vector<std::string>         m_columnName;
 
 		std::vector<std::vector<HTp>>    m_syllables;  // List of syllables in **text/**sylba
 		std::vector<std::vector<HumNum>> m_durations;  // List of durations excluding trailing rests
@@ -10371,8 +12153,8 @@ class Tool_thru : public HumTool {
 
 		bool     run               (HumdrumFileSet& infiles);
 		bool     run               (HumdrumFile& infile);
-		bool     run               (const string& indata, ostream& out);
-		bool     run               (HumdrumFile& infile, ostream& out);
+		bool     run               (const std::string& indata, std::ostream& out);
+		bool     run               (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void      processFile         (HumdrumFile& infile);
@@ -10382,9 +12164,9 @@ class Tool_thru : public HumTool {
 		void      example             (void);
 		void      processData         (HumdrumFile& infile);
 		void      usage               (const char* command);
-		void      getLabelSequence    (vector<string>& labelsequence,
-		                               const string& astring);
-		int       getLabelIndex       (vector<string>& labels, string& key);
+		void      getLabelSequence    (std::vector<std::string>& labelsequence,
+		                               const std::string& astring);
+		int       getLabelIndex       (std::vector<std::string>& labels, std::string& key);
 		void      printLabelList      (HumdrumFile& infile);
 		void      printLabelInfo      (HumdrumFile& infile);
 		int       getBarline          (HumdrumFile& infile, int line);
@@ -10395,8 +12177,8 @@ class Tool_thru : public HumTool {
 		bool      m_infoQ = false;    // used with -i option
 		bool      m_keepQ = false;    // used with -k option
 		bool      m_quietQ = false;   // used with -q option
-		string    m_variation = "";   // used with -v option
-		string    m_realization = ""; // used with -r option
+		std::string    m_variation = "";   // used with -v option
+		std::string    m_realization = ""; // used with -r option
 
 };
 
@@ -10408,7 +12190,7 @@ class Tool_tie : public HumTool {
 
 		bool     run                     (HumdrumFileSet& infiles);
 		bool     run                     (HumdrumFile& infile);
-		bool     run                     (const string& indata, std::ostream& out);
+		bool     run                     (const std::string& indata, std::ostream& out);
 		bool     run                     (HumdrumFile& infile, std::ostream& out);
 
 	protected:
@@ -10445,8 +12227,8 @@ class Tool_timebase : public HumTool {
 
 		bool  run                 (HumdrumFileSet& infiles);
 		bool  run                 (HumdrumFile& infile);
-		bool  run                 (const string& indata, ostream& out);
-		bool  run                 (HumdrumFile& infile, ostream& out);
+		bool  run                 (const std::string& indata, std::ostream& out);
+		bool  run                 (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void   processFile         (HumdrumFile& infile);
@@ -10469,8 +12251,8 @@ class Tool_transpose : public HumTool {
 
 		bool     run             (HumdrumFileSet& infiles);
 		bool     run             (HumdrumFile& infile);
-		bool     run             (const std::string& indata, ostream& out);
-		bool     run             (HumdrumFile& infile, ostream& out);
+		bool     run             (const std::string& indata, std::ostream& out);
+		bool     run             (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 
@@ -10478,14 +12260,14 @@ class Tool_transpose : public HumTool {
 		void     initialize             (HumdrumFile& infile);
 		void     convertScore           (HumdrumFile& infile, int style);
 		void     processFile            (HumdrumFile& infile,
-		                                 vector<bool>& spineprocess);
+		                                 std::vector<bool>& spineprocess);
 		void     convertToConcertPitches(HumdrumFile& infile, int line,
-		                                 vector<int>& tvals);
+		                                 std::vector<int>& tvals);
 		void     convertToWrittenPitches(HumdrumFile& infile, int line,
-		                                 vector<int>& tvals);
+		                                 std::vector<int>& tvals);
 		void     printNewKeySignature   (const std::string& keysig, int trans);
 		void     processInterpretationLine(HumdrumFile& infile, int line,
-		                                 vector<int>& tvals, int style);
+		                                 std::vector<int>& tvals, int style);
 		int      isKeyMarker            (const std::string& str);
 		void     printNewKeyInterpretation(HumdrumLine& aRecord,
 		                                 int index, int transval);
@@ -10499,54 +12281,54 @@ class Tool_transpose : public HumTool {
 		void     example                (void);
 		void     usage                  (const std::string& command);
 		void     printHumdrumDataRecord (HumdrumLine& record,
-		                                 vector<bool>& spineprocess);
+		                                 std::vector<bool>& spineprocess);
 
 		double   pearsonCorrelation     (int size, double* x, double* y);
 		void     doAutoTransposeAnalysis(HumdrumFile& infile);
-		void     addToHistogramDouble   (vector<vector<double> >& histogram,
+		void     addToHistogramDouble   (std::vector<std::vector<double> >& histogram,
 		                                 int pc, double start, double dur,
 		                                 double tdur, int segments);
-		double   storeHistogramForTrack (vector<vector<double> >& histogram,
+		double   storeHistogramForTrack (std::vector<std::vector<double> >& histogram,
 		                                 HumdrumFile& infile, int track,
 		                                 int segments);
-		void     printHistograms        (int segments, vector<int> ktracks,
-		                                vector<vector<vector<double> > >&
+		void     printHistograms        (int segments, std::vector<int> ktracks,
+		                                std::vector<std::vector<std::vector<double> > >&
 		                                 trackhist);
-		void     doAutoKeyAnalysis      (vector<vector<vector<double> > >&
+		void     doAutoKeyAnalysis      (std::vector<std::vector<std::vector<double> > >&
 		                                 analysis, int level, int hop, int count,
-		                                 int segments, vector<int>& ktracks,
-		                                 vector<vector<vector<double> > >&
+		                                 int segments, std::vector<int>& ktracks,
+		                                 std::vector<std::vector<std::vector<double> > >&
 		                                 trackhist);
-		void     doTrackKeyAnalysis     (vector<vector<double> >& analysis,
+		void     doTrackKeyAnalysis     (std::vector<std::vector<double> >& analysis,
 		                                 int level, int hop, int count,
-		                                 vector<vector<double> >& trackhist,
-		                                 vector<double>& majorweights,
-		                                 vector<double>& minorweights);
-		void     identifyKeyDouble      (vector<double>& correls,
-		                                 vector<double>& histogram,
-		                                 vector<double>& majorweights,
-		                                 vector<double>& minorweights);
-		void     fillWeightsWithKostkaPayne(vector<double>& maj,
-		                                 vector<double>& min);
-		void     printRawTrackAnalysis  (vector<vector<vector<double> > >&
-		                                 analysis, vector<int>& ktracks);
-		void     doSingleAnalysis       (vector<double>& analysis,
+		                                 std::vector<std::vector<double> >& trackhist,
+		                                 std::vector<double>& majorweights,
+		                                 std::vector<double>& minorweights);
+		void     identifyKeyDouble      (std::vector<double>& correls,
+		                                 std::vector<double>& histogram,
+		                                 std::vector<double>& majorweights,
+		                                 std::vector<double>& minorweights);
+		void     fillWeightsWithKostkaPayne(std::vector<double>& maj,
+		                                 std::vector<double>& min);
+		void     printRawTrackAnalysis  (std::vector<std::vector<std::vector<double> > >&
+		                                 analysis, std::vector<int>& ktracks);
+		void     doSingleAnalysis       (std::vector<double>& analysis,
 		                                 int startindex, int length,
-		                                 vector<vector<double> >& trackhist,
-		                                 vector<double>& majorweights,
-		                                 vector<double>& minorweights);
-		void     identifyKey            (vector<double>& correls,
-		                                 vector<double>& histogram,
-		                                 vector<double>& majorweights,
-		                                 vector<double>& minorweights);
-		void     doTranspositionAnalysis(vector<vector<vector<double> > >&
+		                                 std::vector<std::vector<double> >& trackhist,
+		                                 std::vector<double>& majorweights,
+		                                 std::vector<double>& minorweights);
+		void     identifyKey            (std::vector<double>& correls,
+		                                 std::vector<double>& histogram,
+		                                 std::vector<double>& majorweights,
+		                                 std::vector<double>& minorweights);
+		void     doTranspositionAnalysis(std::vector<std::vector<std::vector<double> > >&
 		                                 analysis);
 		int      calculateTranspositionFromKey(int targetkey,
 		                                 HumdrumFile& infile);
 		void     printTransposedToken   (HumdrumFile& infile, int row, int col,
 		                                 int transval);
 		void     printTransposeInformation(HumdrumFile& infile,
-		                                 vector<bool>& spineprocess,
+		                                 std::vector<bool>& spineprocess,
 		                                 int line, int transval);
 		int      getTransposeInfo       (HumdrumFile& infile, int row, int col);
 		void     printNewKernString     (const std::string& string, int transval);
@@ -10558,7 +12340,7 @@ class Tool_transpose : public HumTool {
 		int      currentkey   = 0;
 		int      autoQ        = 0;   // used with --auto option
 		int      debugQ       = 0;   // used with --debug option
-		string   spinestring  = "";  // used with -s option
+		std::string   spinestring  = "";  // used with -s option
 		int      octave       = 0;   // used with -o option
 		int      concertQ     = 0;   // used with -C option
 		int      writtenQ     = 0;   // used with -W option
@@ -10575,8 +12357,8 @@ class Tool_tremolo : public HumTool {
 
 		bool     run               (HumdrumFileSet& infiles);
 		bool     run               (HumdrumFile& infile);
-		bool     run               (const string& indata, ostream& out);
-		bool     run               (HumdrumFile& infile, ostream& out);
+		bool     run               (const std::string& indata, std::ostream& out);
+		bool     run               (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void    processFile        (HumdrumFile& infile);
@@ -10599,6 +12381,41 @@ class Tool_tremolo : public HumTool {
 };
 
 
+class Tool_triad : public HumTool {
+	public:
+		         Tool_triad          (void);
+		        ~Tool_triad          () {};
+
+		bool     run                  (HumdrumFileSet& infiles);
+		bool     run                  (HumdrumFile& infile);
+		bool     run                  (const std::string& indata, std::ostream& out);
+		bool     run                  (HumdrumFile& infile, std::ostream& out);
+		void     processFile          (HumdrumFile& infile);
+		std::string fillInMajorMinor  (HumdrumFile& infile, int index);
+
+	protected:
+		void     initialize        (void);
+
+	private:
+		bool m_appendQ  = false;        // -a
+		bool m_classQ   = false;        // -c
+		bool m_lowQ     = false;        // -l
+		bool m_pitchesQ = false;        // -p
+		bool m_qualityQ = false;        // -q
+		bool m_restQ    = false;        // -R
+		bool m_rootQ    = false;        // -r
+		bool m_noInversionQ = true;     // -I
+		bool m_asciiQ   = false;        // --ascii
+		bool m_rootColorQ = true;       // --no-color
+		bool m_summaryQ = false;        // not implemented
+		bool m_unisonQ  = false;        // -U
+		bool m_partialQ  = false;       // -P
+		std::vector<std::string>        m_pcColor; 
+		std::string m_color = "salmon"; // color of analysis text
+
+};
+
+
 class Tool_trillspell : public HumTool {
 	public:
 		      Tool_trillspell     (void);
@@ -10606,15 +12423,15 @@ class Tool_trillspell : public HumTool {
 
 		bool  run                 (HumdrumFileSet& infiles);
 		bool  run                 (HumdrumFile& infile);
-		bool  run                 (const string& indata, ostream& out);
-		bool  run                 (HumdrumFile& infile, ostream& out);
+		bool  run                 (const std::string& indata, std::ostream& out);
+		bool  run                 (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void  processFile         (HumdrumFile& infile);
 		bool  analyzeOrnamentAccidentals(HumdrumFile& infile);
-		void  resetDiatonicStatesWithKeySignature(vector<int>& states,
-		                                          vector<int>& signature);
-		void  fillKeySignature    (vector<int>& states, const string& keysig);
+		void  resetDiatonicStatesWithKeySignature(std::vector<int>& states,
+		                                          std::vector<int>& signature);
+		void  fillKeySignature    (std::vector<int>& states, const std::string& keysig);
 		int   getBase40           (int diatonic, int accidental);
 
 	private:
@@ -10631,8 +12448,8 @@ class Tool_tspos : public HumTool {
 
 		bool     run               (HumdrumFileSet& infiles);
 		bool     run               (HumdrumFile& infile);
-		bool     run               (const string& indata, ostream& out);
-		bool     run               (HumdrumFile& infile, ostream& out);
+		bool     run               (const std::string& indata, std::ostream& out);
+		bool     run               (HumdrumFile& infile, std::ostream& out);
 
 	protected:
 		void             initialize        (HumdrumFile& infile);
@@ -10656,9 +12473,10 @@ class Tool_tspos : public HumTool {
 		bool             hasFullTriadAttack(HumdrumLine& line);
 		void             avoidRdfCollisions(HumdrumFile& infile);
 		void             printUsedMarkers(void);
-		std::string      makeOpacityColor(std::string& color, double value, double total);
+		std::string      makeOpacityColor(std::string& color, double value, double total, bool enhance = false);
 		int              getToolCounter(HumdrumFile& infile);
 		std::string      makePercentString(double value, double total, int digits);
+		int              logisticColorMap(double input, double max);
 
 	private:
 		std::string m_root_marker      = "@";
@@ -10689,7 +12507,7 @@ class Tool_tspos : public HumTool {
 		bool m_triadAttack = false;  // used with -x option
 
 		// Statistical data variables:
-		vector<bool> m_triadState;
+		std::vector<bool> m_triadState;
 
 		// m_partTriadPositions -- count the number of chordal positions by
 		// voice.  The first dimention is the track number of the part, and
@@ -10701,10 +12519,10 @@ class Tool_tspos : public HumTool {
 		// 4 = count of third positions in partial triadic chords
 		// 5 = count of root positions in partial triadic chords ("open fifths")
 		// 6 = count of fifth positions in partial triadic chords
-		std::vector<vector<int>> m_partTriadPositions;
+		std::vector<std::vector<int>> m_partTriadPositions;
 		int m_positionCount = 7; // entries in 2nd dim. of m_partTriadPositions
 
-		string m_toolName = "tspos";
+		std::string m_toolName = "tspos";
 
 		std::vector<int> m_voiceCount;
 		// m_voice: used with -v option to limit analysis to sonorities that
@@ -10719,7 +12537,33 @@ class Tool_tspos : public HumTool {
 		bool m_questionQ = true;
 		int  m_toolCount = 0;
 
-		std::vector<string> m_fullNames;
+		std::vector<std::string> m_fullNames;
+};
+
+
+class Tool_vcross : public HumTool {
+	public:
+		         Tool_vcross     (void);
+		        ~Tool_vcross     () {};
+
+		bool     run               (HumdrumFileSet& infiles);
+		bool     run               (HumdrumFile& infile);
+		bool     run               (const std::string& indata, std::ostream& out);
+		bool     run               (HumdrumFile& infile, std::ostream& out);
+
+	protected:
+		void    processFile        (HumdrumFile& infile);
+		void    initialize         (void);
+		void    getMidiInfo        (std::vector<int>& midis, HTp token);
+		void    compareVoices      (std::vector<HTp>& higher, std::vector<HTp>& lower);
+		void    processLine        (HumdrumFile& infile, int index);
+
+	private:
+		bool m_redQ = false;
+		bool m_greenQ = false;
+		bool m_blueQ = false;
+
+
 };
 
 

--- a/include/tool-pliner.h
+++ b/include/tool-pliner.h
@@ -6,8 +6,8 @@
 // vim:           ts=3 noexpandtab
 //
 // Description:   Insert *pline poetic-line annotations into a **kern score
-//                by aligning the sung **text declamation of each voice
-//                against a poem given in a !!@VERSE: global comment block.
+//                by aligning each voice's **text declamation against the
+//                poem reconstructed by textract from the underlay.
 //
 
 #ifndef _TOOL_PLINER_H
@@ -47,7 +47,7 @@ class Tool_pliner : public HumTool {
 			int pos    = -1;
 		};
 
-		bool     parseVerse        (HumdrumFile& infile, std::vector<std::vector<PoemWord>>& poem);
+		bool     extractPoem       (HumdrumFile& infile, std::vector<std::vector<PoemWord>>& poem);
 
 		// voice model:
 		struct Voice {

--- a/include/tool-pliner.h
+++ b/include/tool-pliner.h
@@ -1,0 +1,93 @@
+//
+// Programmer:    Alexander Morgan
+// Creation Date: Wed Jul 15 2026
+// Filename:      tool-pliner.h
+// Syntax:        C++11; humlib
+// vim:           ts=3 noexpandtab
+//
+// Description:   Insert *pline poetic-line annotations into a **kern score
+//                by aligning the sung **text declamation of each voice
+//                against a poem given in a !!@VERSE: global comment block.
+//
+
+#ifndef _TOOL_PLINER_H
+#define _TOOL_PLINER_H
+
+#include "HumTool.h"
+#include "HumdrumFile.h"
+
+#include <map>
+#include <ostream>
+#include <string>
+#include <vector>
+
+namespace hum {
+
+// START_MERGE
+
+class Tool_pliner : public HumTool {
+	public:
+		         Tool_pliner     (void);
+		        ~Tool_pliner     () {};
+
+		bool     run               (HumdrumFileSet& infiles);
+		bool     run               (HumdrumFile& infile);
+		bool     run               (const std::string& indata, std::ostream& out);
+		bool     run               (HumdrumFile& infile, std::ostream& out);
+
+	protected:
+		void     initialize        (void);
+		void     processFile       (HumdrumFile& infile);
+
+		// poem model:
+		struct PoemWord {
+			std::string original;
+			std::string norm;
+			int line   = -1;
+			int pos    = -1;
+		};
+
+		bool     parseVerse        (HumdrumFile& infile, std::vector<std::vector<PoemWord>>& poem);
+
+		// voice model:
+		struct Voice {
+			HTp kernStart = NULL;
+			HTp textStart = NULL;
+		};
+
+		struct SungWord {
+			HTp token       = NULL; // starting token of the reconstructed word
+			std::string norm;
+			bool capitalized = false;
+		};
+
+		struct Span {
+			int line      = -1;
+			int startPos  = -1;
+			int endPos    = -1;
+			bool repeat   = false;
+			HTp startToken = NULL;
+		};
+
+		void     getVoices          (HumdrumFile& infile, std::vector<Voice>& voices);
+		void     buildSungWords     (HTp textStart, std::vector<SungWord>& words);
+		std::string cleanSyllable   (const std::string& text);
+		std::string normalizeWord   (const std::string& text);
+		void     alignVoice         (std::vector<SungWord>& words,
+		                             std::vector<std::vector<PoemWord>>& poem,
+		                             std::vector<Span>& spans);
+		std::string getModifier     (std::vector<std::vector<PoemWord>>& poem, Span& span);
+		void     emitOutput         (HumdrumFile& infile,
+		                             std::map<int, std::map<int, std::string>>& insertions);
+
+	private:
+		std::vector<std::vector<PoemWord>> m_poem;
+		std::vector<Voice> m_voices;
+
+};
+
+// END_MERGE
+
+} // end namespace hum
+
+#endif /* _TOOL_PLINER_H */

--- a/include/tool-textract.h
+++ b/include/tool-textract.h
@@ -1,0 +1,92 @@
+//
+// Programmer:    Alexander Morgan
+// Creation Date: Fri Jul 24 2026
+// Filename:      tool-textract.h
+// Syntax:        C++11; humlib
+// vim:           ts=3 noexpandtab
+//
+// Description:   Reconstruct the poetic text being set in a score by
+//                examining each voice's **text underlay (not !!@VERSE).
+//
+
+#ifndef _TOOL_TEXTRACT_H
+#define _TOOL_TEXTRACT_H
+
+#include "HumTool.h"
+#include "HumdrumFile.h"
+
+#include <ostream>
+#include <string>
+#include <vector>
+
+namespace hum {
+
+// START_MERGE
+
+class Tool_textract : public HumTool {
+	public:
+		         Tool_textract    (void);
+		        ~Tool_textract    () {};
+
+		bool     run              (HumdrumFileSet& infiles);
+		bool     run              (HumdrumFile& infile);
+		bool     run              (const std::string& indata, std::ostream& out);
+		bool     run              (HumdrumFile& infile, std::ostream& out);
+
+	protected:
+		struct SungWord {
+			std::string original;
+			std::string norm;
+			int  syllables   = 0;
+			bool capitalized = false;
+			bool bis         = false;
+		};
+
+		struct Voice {
+			HTp textStart = NULL;
+			std::vector<SungWord> words;
+			std::vector<std::vector<SungWord>> lines;
+		};
+
+		struct LineCluster {
+			std::vector<std::vector<SungWord>> members; // one entry per contributing voice line
+			std::vector<int> voiceIds;
+			double avgPos = 0.0;
+		};
+
+		void     initialize       (void);
+		void     processFile      (HumdrumFile& infile);
+
+		void     getVoices        (HumdrumFile& infile, std::vector<Voice>& voices);
+		void     buildSungWords   (HTp textStart, std::vector<SungWord>& words);
+		std::string normalizeWord (const std::string& text);
+		std::string cleanOrigPiece(const std::string& text);
+		void     collapseRepeats  (std::vector<SungWord>& words);
+		void     segmentLines     (Voice& voice);
+		int      lineSyllables    (const std::vector<SungWord>& line);
+		int      expectedSyllables(int lineIndex);
+		int      distanceToAllowed(int syllables);
+		bool     isAllowedLength  (int syllables, int tol = 0);
+		bool     endsWithVowel    (const std::string& norm);
+		bool     startsWithVowel  (const std::string& norm);
+		bool     elidesWith       (const SungWord& left, const SungWord& right);
+		bool     likelyLineStart  (const std::string& norm);
+		bool     linesSimilar     (const std::vector<SungWord>& a,
+		                           const std::vector<SungWord>& b);
+		bool     isSubSequence    (const std::vector<SungWord>& shorter,
+		                           const std::vector<SungWord>& longer);
+		void     dedupeVoiceLines (Voice& voice);
+		void     reconstructText  (std::vector<Voice>& voices);
+		void     refineLines      (std::vector<std::vector<SungWord>>& lines);
+		std::vector<SungWord> consensusLine(LineCluster& cluster);
+		std::string lineToString  (const std::vector<SungWord>& line);
+
+	private:
+		std::vector<int> m_sylCounts; // empty = unused
+};
+
+// END_MERGE
+
+} // end namespace hum
+
+#endif /* _TOOL_TEXTRACT_H */

--- a/include/tool-textract.h
+++ b/include/tool-textract.h
@@ -64,9 +64,10 @@ class Tool_textract : public HumTool {
 		void     collapseRepeats  (std::vector<SungWord>& words);
 		void     segmentLines     (Voice& voice);
 		int      lineSyllables    (const std::vector<SungWord>& line);
-		int      expectedSyllables(int lineIndex);
 		int      distanceToAllowed(int syllables);
 		bool     isAllowedLength  (int syllables, int tol = 0);
+		int      minAllowedLength (void);
+		int      maxAllowedLength (void);
 		bool     endsWithVowel    (const std::string& norm);
 		bool     startsWithVowel  (const std::string& norm);
 		bool     elidesWith       (const SungWord& left, const SungWord& right);

--- a/include/tool-textract.h
+++ b/include/tool-textract.h
@@ -79,11 +79,14 @@ class Tool_textract : public HumTool {
 		void     dedupeVoiceLines (Voice& voice);
 		void     reconstructText  (std::vector<Voice>& voices);
 		void     refineLines      (std::vector<std::vector<SungWord>>& lines);
+		int      detectGenreLineCount(HumdrumFile& infile);
+		void     enforceLineCount (std::vector<std::vector<SungWord>>& lines);
 		std::vector<SungWord> consensusLine(LineCluster& cluster);
 		std::string lineToString  (const std::vector<SungWord>& line);
 
 	private:
 		std::vector<int> m_sylCounts; // empty = unused
+		int m_expectedLines = 0;      // 0 = unset / auto
 };
 
 // END_MERGE

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mon Jul 27 00:10:44 CEST 2026
+// Last Modified: Mon Jul 27 00:21:27 CEST 2026
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -144978,25 +144978,39 @@ void Tool_textract::refineLines(vector<vector<SungWord>>& lines) {
 		// Too short: try merging following incomplete fragments until the
 		// combination hits an allowed length (or stops improving).
 		if ((syl < minAllow) && (i + 1 < (int)lines.size())) {
-			// Never glue two capital-started openings together (e.g. a
-			// partial "Aviene" onto "Sì duro...").
+			vector<SungWord> combined = lines[i];
+			combined.insert(combined.end(), lines[i+1].begin(), lines[i+1].end());
+			int firstCombSyl = lineSyllables(combined);
+
+			// Two capital openings are usually different lines (e.g.
+			// partial "Aviene" before "Sì duro..."), but allow the merge
+			// when the combination itself hits an allowed length (e.g.
+			// "Tra" + "Giove in Cielo..." → 11).
 			if (!lines[i].empty() && lines[i][0].capitalized &&
-					!lines[i+1].empty() && lines[i+1][0].capitalized) {
+					!lines[i+1].empty() && lines[i+1][0].capitalized &&
+					!isAllowedLength(firstCombSyl, 1)) {
 				out.push_back(lines[i]);
 				i++;
 				continue;
 			}
-			vector<SungWord> combined = lines[i];
+
+			combined = lines[i];
 			int j = i + 1;
 			while (j < (int)lines.size()) {
 				int nextSyl = lineSyllables(lines[j]);
-				// Do not absorb a following line that is already complete.
-				if (isAllowedLength(nextSyl, 1)) {
+				// Do not absorb a following line that is already complete,
+				// unless attaching the short prefix makes an allowed length
+				// (handled by the first-iteration check above via hits).
+				if (isAllowedLength(nextSyl, 1) && j > i + 1) {
 					break;
 				}
-				if (!lines[j].empty() && lines[j][0].capitalized &&
+				if (j > i + 1 && !lines[j].empty() && lines[j][0].capitalized &&
 						!combined.empty() && combined[0].capitalized) {
-					break;
+					vector<SungWord> trialCap = combined;
+					trialCap.insert(trialCap.end(), lines[j].begin(), lines[j].end());
+					if (!isAllowedLength(lineSyllables(trialCap), 1)) {
+						break;
+					}
 				}
 				vector<SungWord> trial = combined;
 				trial.insert(trial.end(), lines[j].begin(), lines[j].end());

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Sun Jul 26 23:03:28 CEST 2026
+// Last Modified: Sun Jul 26 23:12:37 CEST 2026
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -143868,18 +143868,11 @@ void Tool_textract::processFile(HumdrumFile& infile) {
 	vector<Voice> voices;
 	getVoices(infile, voices);
 
-	for (int vi=0; vi<(int)voices.size(); vi++) {
-		Voice& voice = voices[vi];
+	for (Voice& voice : voices) {
 		buildSungWords(voice.textStart, voice.words);
 		collapseRepeats(voice.words);
 		segmentLines(voice);
 		dedupeVoiceLines(voice);
-		cerr << "VOICE " << vi << " lines:" << endl;
-		for (int li=0; li<(int)voice.lines.size(); li++) {
-			int syl = lineSyllables(voice.lines[li]);
-			cerr << "  [" << li << "] syl=" << syl << " "
-			     << lineToString(voice.lines[li]) << endl;
-		}
 	}
 
 	reconstructText(voices);
@@ -144439,7 +144432,12 @@ void Tool_textract::segmentLines(Voice& voice) {
 			bool doBreak = true;
 			if (!likelyLineStart(w.norm)) {
 				// Mid-line exception, e.g. "Amore" in "Sciogli pietoso Amore".
-				if ((int)cur.size() <= 2) {
+				// Do not apply it to a lone capitalized word: that is usually
+				// an incomplete line-start (partial *pline:a* attempt) and
+				// must stay separate from the next capital ("Aviene" | "Sì").
+				if ((int)cur.size() == 1 && cur[0].capitalized) {
+					doBreak = true;
+				} else if ((int)cur.size() <= 2) {
 					doBreak = false;
 				} else if (!m_sylCounts.empty()) {
 					// With -s, suppress the break only while the current
@@ -144475,10 +144473,11 @@ void Tool_textract::segmentLines(Voice& voice) {
 bool Tool_textract::likelyLineStart(const string& norm) {
 	static const set<string> starters = {
 		"e", "ed", "a", "ad", "di", "de", "del", "che", "chi",
-		"la", "le", "il", "lo", "gli", "ne", "ma", "per", "se",
+		"la", "le", "il", "lo", "gli", "ne", "ma", "per", "se", "si",
 		"non", "un", "una", "uno", "i", "o", "oh", "ah", "deh", "quando",
 		"come", "cosi", "poi", "anzi", "hor", "or", "ora", "ore",
-		"sol", "solo", "su", "sul", "tra", "fra", "con", "da", "dal"
+		"sol", "solo", "su", "sul", "tra", "fra", "con", "da", "dal",
+		"lasso", "mentre"
 	};
 	if (starters.count(norm)) {
 		return true;
@@ -144920,12 +144919,24 @@ void Tool_textract::refineLines(vector<vector<SungWord>>& lines) {
 		// Too short: try merging following incomplete fragments until the
 		// combination hits an allowed length (or stops improving).
 		if ((syl < minAllow) && (i + 1 < (int)lines.size())) {
+			// Never glue two capital-started openings together (e.g. a
+			// partial "Aviene" onto "Sì duro...").
+			if (!lines[i].empty() && lines[i][0].capitalized &&
+					!lines[i+1].empty() && lines[i+1][0].capitalized) {
+				out.push_back(lines[i]);
+				i++;
+				continue;
+			}
 			vector<SungWord> combined = lines[i];
 			int j = i + 1;
 			while (j < (int)lines.size()) {
 				int nextSyl = lineSyllables(lines[j]);
 				// Do not absorb a following line that is already complete.
 				if (isAllowedLength(nextSyl, 1)) {
+					break;
+				}
+				if (!lines[j].empty() && lines[j][0].capitalized &&
+						!combined.empty() && combined[0].capitalized) {
 					break;
 				}
 				vector<SungWord> trial = combined;

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Sat Jul 25 08:37:05 CEST 2026
+// Last Modified: Sun Jul 26 23:03:28 CEST 2026
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -127829,7 +127829,7 @@ void Tool_pline::getPlineInterpretations(HumdrumFile& infile, vector<HTp>& token
 //
 
 Tool_pliner::Tool_pliner(void) {
-	// no options currently defined.
+	define("s|syllables|syl=s:", "allowed line lengths passed to textract (comma-separated set; e.g. 7,11)");
 }
 
 
@@ -127899,9 +127899,8 @@ void Tool_pliner::processFile(HumdrumFile& infile) {
 	m_poem.clear();
 	m_voices.clear();
 
-	bool haveVerse = parseVerse(infile, m_poem);
-	if (!haveVerse) {
-		// Nothing to do: no !!@VERSE: block found, so echo input unchanged.
+	bool havePoem = extractPoem(infile, m_poem);
+	if (!havePoem) {
 		m_humdrum_text << infile;
 		return;
 	}
@@ -127960,59 +127959,38 @@ void Tool_pliner::processFile(HumdrumFile& infile) {
 
 //////////////////////////////
 //
-// Tool_pliner::parseVerse -- Extract the poem lines/words from the
-//    !!@VERSE: global comment block.  The block starts on a line matching
-//    "!!@VERSE:" and continues on subsequent "!!<text>" global comment
-//    lines (not starting with another "!!@" tag) until the first line that
-//    does not match that pattern (typically a blank "!!" separator line or
-//    the next "!!@" tag).
+// Tool_pliner::extractPoem -- Reconstruct the poem via textract and
+//    split it into normalized PoemWord lines for alignment.
 //
 
-bool Tool_pliner::parseVerse(HumdrumFile& infile, vector<vector<PoemWord>>& poem) {
+bool Tool_pliner::extractPoem(HumdrumFile& infile, vector<vector<PoemWord>>& poem) {
 	poem.clear();
-	HumRegex hre;
 
-	int verseLine = -1;
-	for (int i=0; i<infile.getLineCount(); i++) {
-		if (!infile[i].isCommentGlobal()) {
-			continue;
-		}
-		HTp token = infile.token(i, 0);
-		if (hre.search(token, "^!!@VERSE:\\s*$")) {
-			verseLine = i;
-			break;
-		}
+	Tool_textract textract;
+	vector<string> argv;
+	argv.push_back("textract");
+	if (getBoolean("syllables")) {
+		argv.push_back("-s");
+		argv.push_back(getString("syllables"));
 	}
-	if (verseLine < 0) {
+	textract.process(argv);
+	textract.run(infile);
+
+	string text = textract.getFreeText();
+	if (text.empty()) {
 		return false;
 	}
 
+	HumRegex hre;
+	istringstream stream(text);
+	string line;
 	int lineNum = 0;
-	for (int i=verseLine+1; i<infile.getLineCount(); i++) {
-		if (!infile[i].isCommentGlobal()) {
-			break;
-		}
-		HTp token = infile.token(i, 0);
-		string text = *token;
-		if (hre.search(text, "^!!@VERSE:\\s*$")) {
-			// A poem may be split across multiple stanzas, each
-			// re-introduced by its own repeated "!!@VERSE:" tag; treat
-			// this as a stanza separator and keep collecting lines
-			// rather than stopping the poem here.
+	while (getline(stream, line)) {
+		if (line.empty()) {
 			continue;
 		}
-		if (hre.search(text, "^!!@")) {
-			// start of a different tagged section (e.g. "!!@TVERSE:").
-			break;
-		}
-		if (!hre.search(text, "^!!\\s*(\\S.*)$")) {
-			// blank "!!" separator line (or malformed line): end of poem.
-			break;
-		}
-		string content = hre.getMatch(1);
-
 		vector<string> rawwords;
-		hre.split(rawwords, content, "\\s+");
+		hre.split(rawwords, line, "\\s+");
 
 		vector<PoemWord> lineWords;
 		for (string& w : rawwords) {
@@ -128024,12 +128002,6 @@ bool Tool_pliner::parseVerse(HumdrumFile& infile, vector<vector<PoemWord>>& poem
 				continue;
 			}
 			if ((norm[0] == '\'') && !lineWords.empty()) {
-				// A word-initial apostrophe with nothing before it (e.g.
-				// the "'n" in "E 'n mia ragion...") is a typographical
-				// elision split off from the previous word by whitespace
-				// in the verse text; rejoin it so that "E" + "'n" reads
-				// as the single elided word "e'n", matching how the
-				// same elision is sung as one word in the **text spines.
 				lineWords.back().norm += norm;
 				lineWords.back().original += " " + w;
 				continue;
@@ -128238,6 +128210,33 @@ void Tool_pliner::buildSungWords(HTp textStart, vector<SungWord>& words) {
 				accum += normalizeWord(part);
 				if (!trailingDash) {
 					finalize();
+				}
+			} else if (wordOpen && !leadingDash) {
+				// Trailing '-' on the previous syllable already marked the
+				// word open; some files omit the leading '-' on the next
+				// syllable (e.g. "Quan-" / "d'ec-").  Continue unless this
+				// part clearly starts a new word (capital letter).
+				bool newCap = false;
+				for (char c : core) {
+					if (isalpha((unsigned char)c)) {
+						newCap = isupper((unsigned char)c) != 0;
+						break;
+					}
+				}
+				if (!newCap) {
+					accum += normalizeWord(part);
+					if (!trailingDash) {
+						finalize();
+					}
+				} else {
+					finalize();
+					startToken = cur;
+					accum = normalizeWord(part);
+					capitalized = true;
+					wordOpen = true;
+					if (!trailingDash) {
+						finalize();
+					}
 				}
 			} else {
 				// starts a new word (closing any dangling previous word).
@@ -128564,16 +128563,20 @@ void Tool_pliner::alignVoice(vector<SungWord>& words, vector<vector<PoemWord>>& 
 			// enter only partway into the line, e.g. singing just its
 			// tail).  Check every position of a short lookahead of
 			// upcoming lines for the best-confirmed placement.
-			if (sw.capitalized) {
-				int maxLineLookahead = 6;
-				for (int line = ptrLine + 1;
-						(line <= ptrLine + maxLineLookahead) && (line < (int)poem.size());
-						line++) {
-					for (int p = 0; p < lineWordCount(line); p++) {
-						int s = scoreRun(wi, line, p);
-						if (s > 0) {
-							cands.push_back({line, p, s, 3});
-						}
+			//
+			// Non-capitalized words can also land mid-line ahead of the
+			// pointer (e.g. singing "stille di gielo" of line 5 before
+			// that line's opening "Quand'ecco").  Search them too, but
+			// with lower priority so linear progress still wins ties.
+			int maxLineLookahead = sw.capitalized ? 6 : 2;
+			int lookaheadPriority = sw.capitalized ? 3 : 4;
+			for (int line = ptrLine + 1;
+					(line <= ptrLine + maxLineLookahead) && (line < (int)poem.size());
+					line++) {
+				for (int p = 0; p < lineWordCount(line); p++) {
+					int s = scoreRun(wi, line, p);
+					if (s > 0) {
+						cands.push_back({line, p, s, lookaheadPriority});
 					}
 				}
 			}
@@ -143776,7 +143779,7 @@ HumNum Tool_textdur::getDuration(HTp tok1, HTp tok2) {
 //
 
 Tool_textract::Tool_textract(void) {
-	define("s|syllables|syl=s:", "expected line lengths in syllables (comma-separated, cycles; e.g. 11,7)");
+	define("s|syllables|syl=s:", "allowed line lengths in syllables (comma-separated set; e.g. 7,11)");
 }
 
 
@@ -143865,11 +143868,18 @@ void Tool_textract::processFile(HumdrumFile& infile) {
 	vector<Voice> voices;
 	getVoices(infile, voices);
 
-	for (Voice& voice : voices) {
+	for (int vi=0; vi<(int)voices.size(); vi++) {
+		Voice& voice = voices[vi];
 		buildSungWords(voice.textStart, voice.words);
 		collapseRepeats(voice.words);
 		segmentLines(voice);
 		dedupeVoiceLines(voice);
+		cerr << "VOICE " << vi << " lines:" << endl;
+		for (int li=0; li<(int)voice.lines.size(); li++) {
+			int syl = lineSyllables(voice.lines[li]);
+			cerr << "  [" << li << "] syl=" << syl << " "
+			     << lineToString(voice.lines[li]) << endl;
+		}
 	}
 
 	reconstructText(voices);
@@ -144013,7 +144023,7 @@ void Tool_textract::buildSungWords(HTp textStart, vector<SungWord>& words) {
 	int sylCount = 0;
 	bool capitalized = false;
 	bool bis = false;
-	bool inBis = false;
+	int bisDepth = 0;
 
 	auto finalize = [&]() {
 		if (wordOpen && !accumNorm.empty()) {
@@ -144041,9 +144051,6 @@ void Tool_textract::buildSungWords(HTp textStart, vector<SungWord>& words) {
 		}
 
 		string raw = *cur;
-		if (raw.find('<') != string::npos) {
-			inBis = true;
-		}
 
 		vector<string> parts;
 		size_t pos = 0;
@@ -144062,6 +144069,12 @@ void Tool_textract::buildSungWords(HTp textStart, vector<SungWord>& words) {
 			if (part.empty()) {
 				continue;
 			}
+			for (char c : part) {
+				if (c == '<') {
+					bisDepth++;
+				}
+			}
+			bool inBis = (bisDepth > 0);
 			string core = part;
 			if (!core.empty() && (core[0] == '<')) {
 				core = core.substr(1);
@@ -144070,6 +144083,13 @@ void Tool_textract::buildSungWords(HTp textStart, vector<SungWord>& words) {
 			bool trailingDash = endsWithContinuationDash(core);
 			string n = normalizeWord(part);
 			string o = cleanOrigPiece(part);
+			for (char c : part) {
+				if (c == '>') {
+					if (bisDepth > 0) {
+						bisDepth--;
+					}
+				}
+			}
 			if (n.empty() && o.empty()) {
 				continue;
 			}
@@ -144080,6 +144100,34 @@ void Tool_textract::buildSungWords(HTp textStart, vector<SungWord>& words) {
 				sylCount++;
 				if (!trailingDash) {
 					finalize();
+				}
+			} else if (wordOpen && !leadingDash) {
+				// Previous syllable had trailing '-'; next may omit leading '-'.
+				bool newCap = false;
+				for (char c : core) {
+					if (isalpha((unsigned char)c)) {
+						newCap = isupper((unsigned char)c) != 0;
+						break;
+					}
+				}
+				if (!newCap) {
+					accumNorm += n;
+					accumOrig += o;
+					sylCount++;
+					if (!trailingDash) {
+						finalize();
+					}
+				} else {
+					finalize();
+					capitalized = true;
+					bis = inBis;
+					accumNorm = n;
+					accumOrig = o;
+					sylCount = 1;
+					wordOpen = true;
+					if (!trailingDash) {
+						finalize();
+					}
 				}
 			} else {
 				if (wordOpen) {
@@ -144103,9 +144151,6 @@ void Tool_textract::buildSungWords(HTp textStart, vector<SungWord>& words) {
 			}
 		}
 
-		if (raw.find('>') != string::npos) {
-			inBis = false;
-		}
 		cur = cur->getNextToken();
 	}
 	finalize();
@@ -144297,20 +144342,6 @@ int Tool_textract::lineSyllables(const vector<SungWord>& line) {
 
 //////////////////////////////
 //
-// Tool_textract::expectedSyllables -- Positional target; list cycles.
-//
-
-int Tool_textract::expectedSyllables(int lineIndex) {
-	if (m_sylCounts.empty()) {
-		return 0;
-	}
-	return m_sylCounts[lineIndex % (int)m_sylCounts.size()];
-}
-
-
-
-//////////////////////////////
-//
 // Tool_textract::distanceToAllowed -- Min distance to any -s length.
 //
 
@@ -144348,6 +144379,42 @@ bool Tool_textract::isAllowedLength(int syllables, int tol) {
 
 //////////////////////////////
 //
+// Tool_textract::minAllowedLength -- Smallest length in the -s set.
+//
+
+int Tool_textract::minAllowedLength(void) {
+	if (m_sylCounts.empty()) {
+		return 0;
+	}
+	int m = m_sylCounts[0];
+	for (int t : m_sylCounts) {
+		m = min(m, t);
+	}
+	return m;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::maxAllowedLength -- Largest length in the -s set.
+//
+
+int Tool_textract::maxAllowedLength(void) {
+	if (m_sylCounts.empty()) {
+		return 0;
+	}
+	int m = m_sylCounts[0];
+	for (int t : m_sylCounts) {
+		m = max(m, t);
+	}
+	return m;
+}
+
+
+
+//////////////////////////////
+//
 // Tool_textract::segmentLines -- Split a voice on capitalized words.
 //    Mid-line capitals (not common line-starters) may stay in the current
 //    line.  Syllable targets (-s) are applied later in refineLines.
@@ -144375,8 +144442,15 @@ void Tool_textract::segmentLines(Voice& voice) {
 				if ((int)cur.size() <= 2) {
 					doBreak = false;
 				} else if (!m_sylCounts.empty()) {
+					// With -s, suppress the break only while the current
+					// line is still short of every allowed length (still
+					// being built).  Once it is at/near an allowed length,
+					// or has overshot the longest allowed length, break so
+					// a missed boundary cannot glue the rest of the poem
+					// into one mega-line.
 					int have = lineSyllables(cur);
-					if (!isAllowedLength(have, 1)) {
+					if (!isAllowedLength(have, 1) &&
+							(have <= maxAllowedLength() + 1)) {
 						doBreak = false;
 					}
 				}
@@ -144402,16 +144476,17 @@ bool Tool_textract::likelyLineStart(const string& norm) {
 	static const set<string> starters = {
 		"e", "ed", "a", "ad", "di", "de", "del", "che", "chi",
 		"la", "le", "il", "lo", "gli", "ne", "ma", "per", "se",
-		"non", "un", "una", "uno", "i", "o", "oh", "ah", "quando",
+		"non", "un", "una", "uno", "i", "o", "oh", "ah", "deh", "quando",
 		"come", "cosi", "poi", "anzi", "hor", "or", "ora", "ore",
 		"sol", "solo", "su", "sul", "tra", "fra", "con", "da", "dal"
 	};
 	if (starters.count(norm)) {
 		return true;
 	}
-	// "E'n", "Né", "Sol' io" folded forms.
+	// "E'n", "Né", "Sol' io", "Quand'ecco" folded forms.
 	if ((norm == "ne") || (norm.rfind("sol", 0) == 0) ||
-			(norm.rfind("e'", 0) == 0) || (norm.rfind("ne'", 0) == 0)) {
+			(norm.rfind("e'", 0) == 0) || (norm.rfind("ne'", 0) == 0) ||
+			(norm.rfind("quand", 0) == 0)) {
 		return true;
 	}
 	return false;
@@ -144458,7 +144533,7 @@ bool Tool_textract::linesSimilar(const vector<SungWord>& a,
 		}
 	}
 	double ratio = (double)dp[a.size()][b.size()] / (double)maxLen;
-	return ratio >= 0.75;
+	return ratio >= 0.65;
 }
 
 
@@ -144635,8 +144710,8 @@ vector<Tool_textract::SungWord> Tool_textract::consensusLine(LineCluster& cluste
 
 //////////////////////////////
 //
-// Tool_textract::reconstructText -- Cluster lines across voices, keep
-//    majority-supported lines, order by typical singing order, emit text.
+// Tool_textract::reconstructText -- Cluster lines across voices, resolve
+//    wording conflicts by majority, order by typical singing order, emit text.
 //
 
 void Tool_textract::reconstructText(vector<Voice>& voices) {
@@ -144658,7 +144733,6 @@ void Tool_textract::reconstructText(vector<Voice>& voices) {
 				if (!similar && !lineInRep && !repInLine) {
 					continue;
 				}
-				// Short fragments only merge if they cover most of the other line.
 				if (!similar && lineInRep &&
 						((int)line.size() * 2 < (int)rep.size())) {
 					continue;
@@ -144667,7 +144741,6 @@ void Tool_textract::reconstructText(vector<Voice>& voices) {
 						((int)rep.size() * 2 < (int)line.size())) {
 					continue;
 				}
-				// Require shared first word when both are capitalized starts.
 				if (!line.empty() && !rep.empty() &&
 						line[0].capitalized && rep[0].capitalized &&
 						(line[0].norm != rep[0].norm)) {
@@ -144679,7 +144752,6 @@ void Tool_textract::reconstructText(vector<Voice>& voices) {
 			if (best >= 0) {
 				clusters[best].members.push_back(line);
 				clusters[best].voiceIds.push_back(vi);
-				// Prefer storing fuller versions first for later consensus.
 				if (line.size() > clusters[best].members[0].size()) {
 					swap(clusters[best].members[0],
 							clusters[best].members.back());
@@ -144693,10 +144765,6 @@ void Tool_textract::reconstructText(vector<Voice>& voices) {
 		}
 	}
 
-	int nVoices = (int)voices.size();
-	int majority = (nVoices + 1) / 2;
-
-	// Compute average position among contributing voices.
 	for (LineCluster& c : clusters) {
 		double sum = 0;
 		int count = 0;
@@ -144707,7 +144775,6 @@ void Tool_textract::reconstructText(vector<Voice>& voices) {
 				continue;
 			}
 			seen.insert(vi);
-			// position = index of this line among that voice's lines
 			auto rep = consensusLine(c);
 			for (int li=0; li<(int)voices[vi].lines.size(); li++) {
 				if (linesSimilar(voices[vi].lines[li], rep) ||
@@ -144722,17 +144789,62 @@ void Tool_textract::reconstructText(vector<Voice>& voices) {
 		c.avgPos = (count > 0) ? (sum / count) : 0;
 	}
 
+	// Merge clusters that are conflicting readings of the same line.
+	bool merged = true;
+	while (merged) {
+		merged = false;
+		for (int i=0; i<(int)clusters.size() && !merged; i++) {
+			auto ri = consensusLine(clusters[i]);
+			for (int j=i+1; j<(int)clusters.size(); j++) {
+				auto rj = consensusLine(clusters[j]);
+				bool similar = linesSimilar(ri, rj);
+				bool iInJ = isSubSequence(ri, rj);
+				bool jInI = isSubSequence(rj, ri);
+				if (!similar && !iInJ && !jInI) {
+					continue;
+				}
+				if (!similar && iInJ && ((int)ri.size() * 2 < (int)rj.size())) {
+					continue;
+				}
+				if (!similar && jInI && ((int)rj.size() * 2 < (int)ri.size())) {
+					continue;
+				}
+				if (!ri.empty() && !rj.empty() &&
+						ri[0].capitalized && rj[0].capitalized &&
+						(ri[0].norm != rj[0].norm)) {
+					continue;
+				}
+				clusters[i].members.insert(clusters[i].members.end(),
+						clusters[j].members.begin(), clusters[j].members.end());
+				clusters[i].voiceIds.insert(clusters[i].voiceIds.end(),
+						clusters[j].voiceIds.begin(), clusters[j].voiceIds.end());
+				int ni = (int)set<int>(clusters[i].voiceIds.begin(),
+						clusters[i].voiceIds.end()).size();
+				int nj = (int)set<int>(clusters[j].voiceIds.begin(),
+						clusters[j].voiceIds.end()).size();
+				clusters[i].avgPos = (clusters[i].avgPos * ni + clusters[j].avgPos * nj)
+						/ max(ni + nj, 1);
+				clusters.erase(clusters.begin() + j);
+				merged = true;
+				break;
+			}
+		}
+	}
+
 	vector<int> keep;
 	for (int ci=0; ci<(int)clusters.size(); ci++) {
-		set<int> uniqVoices(clusters[ci].voiceIds.begin(), clusters[ci].voiceIds.end());
-		if ((int)uniqVoices.size() >= majority) {
-			keep.push_back(ci);
-		}
+		keep.push_back(ci);
 	}
 
 	stable_sort(keep.begin(), keep.end(), [&](int a, int b) {
 		if (fabs(clusters[a].avgPos - clusters[b].avgPos) > 1e-6) {
 			return clusters[a].avgPos < clusters[b].avgPos;
+		}
+		// More widely attested readings first on a position tie.
+		int na = (int)set<int>(clusters[a].voiceIds.begin(), clusters[a].voiceIds.end()).size();
+		int nb = (int)set<int>(clusters[b].voiceIds.begin(), clusters[b].voiceIds.end()).size();
+		if (na != nb) {
+			return na > nb;
 		}
 		return a < b;
 	});
@@ -144741,7 +144853,27 @@ void Tool_textract::reconstructText(vector<Voice>& voices) {
 	for (int ci : keep) {
 		auto line = consensusLine(clusters[ci]);
 		collapseRepeats(line);
-		if (!line.empty()) {
+		if (line.empty()) {
+			continue;
+		}
+		bool skip = false;
+		for (size_t pi=0; pi<poem.size(); pi++) {
+			auto& prev = poem[pi];
+			if (linesSimilar(line, prev)) {
+				skip = true;
+				break;
+			}
+			if (isSubSequence(line, prev)) {
+				skip = true;
+				break;
+			}
+			if (isSubSequence(prev, line)) {
+				poem[pi] = line;
+				skip = true;
+				break;
+			}
+		}
+		if (!skip) {
 			poem.push_back(line);
 		}
 	}
@@ -144759,9 +144891,11 @@ void Tool_textract::reconstructText(vector<Voice>& voices) {
 
 //////////////////////////////
 //
-// Tool_textract::refineLines -- Apply -s lengths (list cycles; any listed
-//    length is allowed).  Metrical counts subtract synaloepha/apostrophe
-//    elision between adjacent words, including across a merge boundary.
+// Tool_textract::refineLines -- Apply -s lengths as a set of allowed
+//    metrical counts (not an alternating cycle).  Too-short lines may be
+//    merged; too-long lines may be split on capitals.  Metrical counts
+//    subtract synaloepha/apostrophe elision between adjacent words,
+//    including across a merge boundary.
 //
 
 void Tool_textract::refineLines(vector<vector<SungWord>>& lines) {
@@ -144769,62 +144903,57 @@ void Tool_textract::refineLines(vector<vector<SungWord>>& lines) {
 		return;
 	}
 
+	const int minAllow = minAllowedLength();
+	const int maxAllow = maxAllowedLength();
+
 	vector<vector<SungWord>> out;
 	int i = 0;
 	while (i < (int)lines.size()) {
-		int target = expectedSyllables((int)out.size());
 		int syl = lineSyllables(lines[i]);
 
-		if (isAllowedLength(syl) || (syl == target)) {
+		if (isAllowedLength(syl, 1)) {
 			out.push_back(lines[i]);
 			i++;
 			continue;
 		}
 
-		if (i + 1 < (int)lines.size()) {
-			int nextSyl = lineSyllables(lines[i+1]);
-			bool nextComplete = isAllowedLength(nextSyl);
+		// Too short: try merging following incomplete fragments until the
+		// combination hits an allowed length (or stops improving).
+		if ((syl < minAllow) && (i + 1 < (int)lines.size())) {
 			vector<SungWord> combined = lines[i];
-			combined.insert(combined.end(), lines[i+1].begin(), lines[i+1].end());
-			int combSyl = lineSyllables(combined); // includes cross-line elision
-			bool hits = isAllowedLength(combSyl) || (combSyl == target);
-			bool improves = distanceToAllowed(combSyl) < distanceToAllowed(syl);
-
-			// Never absorb a complete following line unless the merge exactly hits.
-			bool allowMerge = hits || (improves && !nextComplete);
-			if (allowMerge && !hits && !lines[i+1].empty() &&
-					likelyLineStart(lines[i+1][0].norm) && nextComplete) {
-				allowMerge = false;
-			}
-
-			if (allowMerge) {
-				int j = i + 2;
-				while (j < (int)lines.size() && !isAllowedLength(lineSyllables(combined))) {
-					if (isAllowedLength(lineSyllables(lines[j]))) {
-						break;
-					}
-					vector<SungWord> trial = combined;
-					trial.insert(trial.end(), lines[j].begin(), lines[j].end());
-					int t2 = lineSyllables(combined);
-					int t3 = lineSyllables(trial);
-					if (distanceToAllowed(t3) <= distanceToAllowed(t2)) {
-						combined.swap(trial);
-						j++;
-					} else {
-						break;
-					}
+			int j = i + 1;
+			while (j < (int)lines.size()) {
+				int nextSyl = lineSyllables(lines[j]);
+				// Do not absorb a following line that is already complete.
+				if (isAllowedLength(nextSyl, 1)) {
+					break;
 				}
+				vector<SungWord> trial = combined;
+				trial.insert(trial.end(), lines[j].begin(), lines[j].end());
+				int combSyl = lineSyllables(trial);
+				if (isAllowedLength(combSyl, 1)) {
+					combined.swap(trial);
+					j++;
+					break;
+				}
+				if (distanceToAllowed(combSyl) < distanceToAllowed(lineSyllables(combined))
+						&& (combSyl <= maxAllow + 1)) {
+					combined.swap(trial);
+					j++;
+					continue;
+				}
+				break;
+			}
+			if (j > i + 1 || isAllowedLength(lineSyllables(combined), 1)) {
 				out.push_back(combined);
 				i = j;
 				continue;
 			}
 		}
 
-		int maxAllowed = m_sylCounts[0];
-		for (int t : m_sylCounts) {
-			maxAllowed = max(maxAllowed, t);
-		}
-		if (syl > maxAllowed + 1) {
+		// Too long: split on a capital so the left side matches an allowed
+		// length (prefer the earliest such break).
+		if (syl > maxAllow + 1) {
 			int bestBreak = -1;
 			int bestDist = 9999;
 			for (int k=1; k<(int)lines[i].size(); k++) {
@@ -144837,6 +144966,10 @@ void Tool_textract::refineLines(vector<vector<SungWord>>& lines) {
 				if (isAllowedLength(leftSyl, 1) && (dist < bestDist)) {
 					bestDist = dist;
 					bestBreak = k;
+					// Earliest exact-ish hit is enough.
+					if (dist == 0) {
+						break;
+					}
 				}
 			}
 			if (bestBreak > 0) {

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mon Jul 27 00:21:27 CEST 2026
+// Last Modified: Mon Jul 27 13:54:29 CEST 2026
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -127830,6 +127830,7 @@ void Tool_pline::getPlineInterpretations(HumdrumFile& infile, vector<HTp>& token
 
 Tool_pliner::Tool_pliner(void) {
 	define("s|syllables|syl=s:", "allowed line lengths passed to textract (comma-separated set; e.g. 7,11)");
+	define("l|lines=i:0", "expected poem line count passed to textract (0=auto; sonetto→14)");
 }
 
 
@@ -127972,6 +127973,11 @@ bool Tool_pliner::extractPoem(HumdrumFile& infile, vector<vector<PoemWord>>& poe
 	if (getBoolean("syllables")) {
 		argv.push_back("-s");
 		argv.push_back(getString("syllables"));
+	}
+	int linesOpt = getInteger("lines");
+	if (linesOpt > 0) {
+		argv.push_back("-l");
+		argv.push_back(to_string(linesOpt));
 	}
 	textract.process(argv);
 	textract.run(infile);
@@ -143789,6 +143795,7 @@ HumNum Tool_textdur::getDuration(HTp tok1, HTp tok2) {
 
 Tool_textract::Tool_textract(void) {
 	define("s|syllables|syl=s:", "allowed line lengths in syllables (comma-separated set; e.g. 7,11)");
+	define("l|lines=i:0", "expected number of poem lines (0=auto; !!@GENRE sonetto→14)");
 }
 
 
@@ -143845,6 +143852,7 @@ bool Tool_textract::run(HumdrumFile& infile) {
 
 void Tool_textract::initialize(void) {
 	m_sylCounts.clear();
+	m_expectedLines = 0;
 
 	if (getBoolean("syllables")) {
 		HumRegex hre;
@@ -143864,6 +143872,11 @@ void Tool_textract::initialize(void) {
 			}
 		}
 	}
+
+	int linesOpt = getInteger("lines");
+	if (linesOpt > 0) {
+		m_expectedLines = linesOpt;
+	}
 }
 
 
@@ -143882,6 +143895,10 @@ void Tool_textract::processFile(HumdrumFile& infile) {
 		collapseRepeats(voice.words);
 		segmentLines(voice);
 		dedupeVoiceLines(voice);
+	}
+
+	if (m_expectedLines <= 0) {
+		m_expectedLines = detectGenreLineCount(infile);
 	}
 
 	reconstructText(voices);
@@ -144919,6 +144936,7 @@ void Tool_textract::reconstructText(vector<Voice>& voices) {
 	}
 
 	refineLines(poem);
+	enforceLineCount(poem);
 
 	for (auto& line : poem) {
 		if (!line.empty()) {
@@ -145069,6 +145087,177 @@ void Tool_textract::refineLines(vector<vector<SungWord>>& lines) {
 		i++;
 	}
 	lines.swap(out);
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::detectGenreLineCount -- If the score has
+//    !!@GENRE: sonetto (spaces or tabs after the colon), return 14;
+//    otherwise 0.
+//
+
+int Tool_textract::detectGenreLineCount(HumdrumFile& infile) {
+	HumRegex hre;
+	for (int i=0; i<infile.getLineCount(); i++) {
+		const string& line = infile[i].getText();
+		if (hre.search(line, "^!!@GENRE:\\s*sonetto\\b", "i")) {
+			return 14;
+		}
+	}
+	return 0;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::enforceLineCount -- Nudge the poem toward
+//    m_expectedLines by merging extras or splitting shorts.
+//
+
+void Tool_textract::enforceLineCount(vector<vector<SungWord>>& lines) {
+	if (lines.empty() || (m_expectedLines <= 0)) {
+		return;
+	}
+
+	auto mergeScore = [&](int i) -> double {
+		// Lower is better.  Prefer merges that hit -s lengths; avoid
+		// gluing two strong line-starters when possible.
+		if ((i < 0) || (i + 1 >= (int)lines.size())) {
+			return 1e9;
+		}
+		vector<SungWord> combined = lines[i];
+		combined.insert(combined.end(), lines[i+1].begin(), lines[i+1].end());
+		int combSyl = lineSyllables(combined);
+		double score = 0;
+		if (!m_sylCounts.empty()) {
+			score += distanceToAllowed(combSyl);
+			if (isAllowedLength(combSyl, 1)) {
+				score -= 3.0;
+			}
+		} else {
+			score += (double)combined.size() * 0.01;
+		}
+		bool leftStart = !lines[i].empty() && likelyLineStart(lines[i][0].norm);
+		bool rightStart = !lines[i+1].empty() && likelyLineStart(lines[i+1][0].norm);
+		if (leftStart && rightStart) {
+			score += 5.0;
+		} else if (!lines[i+1].empty() && lines[i+1][0].capitalized &&
+				!likelyLineStart(lines[i+1][0].norm)) {
+			// Mid-line capital continuation — good merge candidate.
+			score -= 1.0;
+		}
+		// Prefer merging a very short fragment.
+		int leftSyl = lineSyllables(lines[i]);
+		int rightSyl = lineSyllables(lines[i+1]);
+		if (!m_sylCounts.empty()) {
+			if (!isAllowedLength(leftSyl, 1)) {
+				score -= 1.5;
+			}
+			if (!isAllowedLength(rightSyl, 1)) {
+				score -= 1.5;
+			}
+		} else {
+			if (lines[i].size() <= 2) {
+				score -= 1.0;
+			}
+			if (lines[i+1].size() <= 2) {
+				score -= 1.0;
+			}
+		}
+		return score;
+	};
+
+	// Too many lines: repeatedly merge the best adjacent pair.
+	int guard = 0;
+	while (((int)lines.size() > m_expectedLines) && (guard++ < 100)) {
+		int best = -1;
+		double bestScore = 1e9;
+		for (int i=0; i+1 < (int)lines.size(); i++) {
+			double s = mergeScore(i);
+			if (s < bestScore) {
+				bestScore = s;
+				best = i;
+			}
+		}
+		if (best < 0) {
+			break;
+		}
+		// If every remaining pair is two strong starters and we still
+		// must reduce count, take the least-bad (already chosen).
+		lines[best].insert(lines[best].end(),
+				lines[best+1].begin(), lines[best+1].end());
+		lines.erase(lines.begin() + best + 1);
+	}
+
+	auto splitCandidate = [&](int li, int& breakAt) -> double {
+		// Lower is better.  Returns 1e9 if no capital split exists.
+		breakAt = -1;
+		if ((li < 0) || (li >= (int)lines.size()) || (lines[li].size() < 2)) {
+			return 1e9;
+		}
+		double best = 1e9;
+		for (int k=1; k<(int)lines[li].size(); k++) {
+			if (!lines[li][k].capitalized) {
+				continue;
+			}
+			vector<SungWord> left(lines[li].begin(), lines[li].begin() + k);
+			vector<SungWord> right(lines[li].begin() + k, lines[li].end());
+			if (left.empty() || right.empty()) {
+				continue;
+			}
+			int leftSyl = lineSyllables(left);
+			int rightSyl = lineSyllables(right);
+			double score = 0;
+			if (!m_sylCounts.empty()) {
+				score += distanceToAllowed(leftSyl) + distanceToAllowed(rightSyl);
+				if (isAllowedLength(leftSyl, 1)) {
+					score -= 2.0;
+				}
+				if (isAllowedLength(rightSyl, 1)) {
+					score -= 2.0;
+				}
+			} else {
+				score += fabs((double)left.size() - (double)right.size()) * 0.1;
+			}
+			if (likelyLineStart(lines[li][k].norm)) {
+				score -= 1.5;
+			}
+			if (score < best) {
+				best = score;
+				breakAt = k;
+			}
+		}
+		return best;
+	};
+
+	// Too few lines: split the best oversized / capital-bearing line.
+	guard = 0;
+	while (((int)lines.size() < m_expectedLines) && (guard++ < 100)) {
+		int bestLine = -1;
+		int bestBreak = -1;
+		double bestScore = 1e9;
+		for (int li=0; li<(int)lines.size(); li++) {
+			int br = -1;
+			double s = splitCandidate(li, br);
+			if ((br > 0) && (s < bestScore)) {
+				bestScore = s;
+				bestLine = li;
+				bestBreak = br;
+			}
+		}
+		if ((bestLine < 0) || (bestBreak <= 0)) {
+			break;
+		}
+		vector<SungWord> left(lines[bestLine].begin(),
+				lines[bestLine].begin() + bestBreak);
+		vector<SungWord> right(lines[bestLine].begin() + bestBreak,
+				lines[bestLine].end());
+		lines[bestLine] = left;
+		lines.insert(lines.begin() + bestLine + 1, right);
+	}
 }
 
 

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mon Jul 27 13:54:29 CEST 2026
+// Last Modified: Fri Jul 31 14:13:03 CEST 2026
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -127831,6 +127831,7 @@ void Tool_pline::getPlineInterpretations(HumdrumFile& infile, vector<HTp>& token
 Tool_pliner::Tool_pliner(void) {
 	define("s|syllables|syl=s:", "allowed line lengths passed to textract (comma-separated set; e.g. 7,11)");
 	define("l|lines=i:0", "expected poem line count passed to textract (0=auto; sonetto→14)");
+	define("t|text=s:", "poem text file (skip textract; empty lines discarded, lines trimmed)");
 }
 
 
@@ -127960,29 +127961,46 @@ void Tool_pliner::processFile(HumdrumFile& infile) {
 
 //////////////////////////////
 //
-// Tool_pliner::extractPoem -- Reconstruct the poem via textract and
-//    split it into normalized PoemWord lines for alignment.
+// Tool_pliner::extractPoem -- Load the poem either from a user-specified
+//    text file (-t/--text) or via textract from the underlay, then split
+//    it into normalized PoemWord lines for alignment.
 //
 
 bool Tool_pliner::extractPoem(HumdrumFile& infile, vector<vector<PoemWord>>& poem) {
 	poem.clear();
 
-	Tool_textract textract;
-	vector<string> argv;
-	argv.push_back("textract");
-	if (getBoolean("syllables")) {
-		argv.push_back("-s");
-		argv.push_back(getString("syllables"));
+	string text;
+	if (getBoolean("text")) {
+		string path = getString("text");
+		if (path.empty()) {
+			return false;
+		}
+		ifstream in(path.c_str());
+		if (!in) {
+			cerr << "Error: cannot open text file: " << path << endl;
+			return false;
+		}
+		ostringstream oss;
+		oss << in.rdbuf();
+		text = oss.str();
+	} else {
+		Tool_textract textract;
+		vector<string> argv;
+		argv.push_back("textract");
+		if (getBoolean("syllables")) {
+			argv.push_back("-s");
+			argv.push_back(getString("syllables"));
+		}
+		int linesOpt = getInteger("lines");
+		if (linesOpt > 0) {
+			argv.push_back("-l");
+			argv.push_back(to_string(linesOpt));
+		}
+		textract.process(argv);
+		textract.run(infile);
+		text = textract.getFreeText();
 	}
-	int linesOpt = getInteger("lines");
-	if (linesOpt > 0) {
-		argv.push_back("-l");
-		argv.push_back(to_string(linesOpt));
-	}
-	textract.process(argv);
-	textract.run(infile);
 
-	string text = textract.getFreeText();
 	if (text.empty()) {
 		return false;
 	}
@@ -127992,9 +128010,14 @@ bool Tool_pliner::extractPoem(HumdrumFile& infile, vector<vector<PoemWord>>& poe
 	string line;
 	int lineNum = 0;
 	while (getline(stream, line)) {
-		if (line.empty()) {
+		// Trim leading/trailing whitespace; skip empty lines.
+		size_t start = line.find_first_not_of(" \t\r\n");
+		if (start == string::npos) {
 			continue;
 		}
+		size_t end = line.find_last_not_of(" \t\r\n");
+		line = line.substr(start, end - start + 1);
+
 		vector<string> rawwords;
 		hre.split(rawwords, line, "\\s+");
 

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Sun Jul 26 23:12:37 CEST 2026
+// Last Modified: Mon Jul 27 00:10:44 CEST 2026
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -128272,12 +128272,12 @@ void Tool_pliner::buildSungWords(HTp textStart, vector<SungWord>& words) {
 //////////////////////////////
 //
 // Tool_pliner::alignVoice -- Align a voice's sequence of sung words
-//    against the poem, tracking a mostly-forward-moving pointer (repeats
-//    are assumed to stay close by: within the current line or the
-//    immediately preceding line), rather than depending on any
-//    pre-existing editorial markup.  Runs of consecutive words assigned
-//    to the same (line, repeat-state) are collapsed into "spans"; each
-//    span marks one *pline transition.
+//    against the poem, tracking a mostly-forward-moving pointer.  Local
+//    repeats are sought within the current line and a short lookback of
+//    preceding lines (a closing-stanza repeat may jump back more than
+//    one line, e.g. from line 14 back to line 12).  Runs of consecutive
+//    words assigned to the same (line, repeat-state) are collapsed into
+//    "spans"; each span marks one *pline transition.
 //
 //    A span only counts as a repeat ("r") if it does not, by the time it
 //    ends, reach any further into the line than this voice had already
@@ -128291,7 +128291,6 @@ void Tool_pliner::buildSungWords(HTp textStart, vector<SungWord>& words) {
 //    starts by re-treading already-sung words, because it ends up
 //    covering new ground.
 //
-
 void Tool_pliner::alignVoice(vector<SungWord>& words, vector<vector<PoemWord>>& poem,
 		vector<Span>& spans) {
 	spans.clear();
@@ -128541,8 +128540,13 @@ void Tool_pliner::alignVoice(vector<SungWord>& words, vector<vector<PoemWord>>& 
 			}
 
 			// bounded backward candidates: current line up to the
-			// pointer, then the immediately preceding line.
-			int lowLine = ptrLine - 1;
+			// pointer, then a short lookback of preceding lines.
+			// Capitalized re-entries (typical line openings of a
+			// repeated tercet/quatrain) may jump back several lines;
+			// non-capitals stay closer so common words do not snap to
+			// distant earlier matches.
+			int maxLineLookback = sw.capitalized ? 6 : 2;
+			int lowLine = ptrLine - maxLineLookback;
 			if (lowLine < 0) {
 				lowLine = 0;
 			}
@@ -128551,7 +128555,12 @@ void Tool_pliner::alignVoice(vector<SungWord>& words, vector<vector<PoemWord>>& 
 				for (int p = hi; p >= 0; p--) {
 					int s = scoreRun(wi, line, p);
 					if (s > 0) {
-						cands.push_back({line, p, s, 2});
+						int backDist = ptrLine - line;
+						// Near repeats (same/previous line) keep priority
+						// 2; farther lookbacks are weaker than forward
+						// progress so only a clearly better scoreRun wins.
+						int pri = (backDist <= 1) ? 2 : 5;
+						cands.push_back({line, p, s, pri});
 					}
 				}
 			}
@@ -144445,7 +144454,10 @@ void Tool_textract::segmentLines(Voice& voice) {
 					// being built).  Once it is at/near an allowed length,
 					// or has overshot the longest allowed length, break so
 					// a missed boundary cannot glue the rest of the poem
-					// into one mega-line.
+					// into one mega-line.  Mid-line capitals after a shorter
+					// allowed hit (e.g. "Amor" after a 7 when -s is 7,11)
+					// are repaired later in refineLines by folding a short
+					// trailing fragment back into the previous line.
 					int have = lineSyllables(cur);
 					if (!isAllowedLength(have, 1) &&
 							(have <= maxAllowedLength() + 1)) {
@@ -144656,6 +144668,18 @@ vector<Tool_textract::SungWord> Tool_textract::consensusLine(LineCluster& cluste
 		}
 		score -= 0.75 * fabs((double)m.size() - (double)medianLen);
 
+		// Prefer a reading whose metrical count hits an allowed -s length
+		// (e.g. full "Riso tra perle..." at 11 over a mid-entry
+		// "Tra perle..." at 9 when -s 7,11).
+		if (!m_sylCounts.empty()) {
+			int syl = lineSyllables(m);
+			if (isAllowedLength(syl, 1)) {
+				score += 3.0;
+			} else {
+				score -= distanceToAllowed(syl);
+			}
+		}
+
 		// Penalize an immediate repeated half of the line.
 		int n = (int)m.size();
 		if ((n >= 4) && (n % 2 == 0)) {
@@ -144742,7 +144766,12 @@ void Tool_textract::reconstructText(vector<Voice>& voices) {
 				}
 				if (!line.empty() && !rep.empty() &&
 						line[0].capitalized && rep[0].capitalized &&
-						(line[0].norm != rep[0].norm)) {
+						(line[0].norm != rep[0].norm) &&
+						!lineInRep && !repInLine) {
+					// Different line openings usually mean different
+					// poem lines, but not when one reading is a mid-line
+					// entry into the other ("Tra perle..." vs
+					// "Riso tra perle...").
 					continue;
 				}
 				best = ci;
@@ -144810,7 +144839,8 @@ void Tool_textract::reconstructText(vector<Voice>& voices) {
 				}
 				if (!ri.empty() && !rj.empty() &&
 						ri[0].capitalized && rj[0].capitalized &&
-						(ri[0].norm != rj[0].norm)) {
+						(ri[0].norm != rj[0].norm) &&
+						!iInJ && !jInI) {
 					continue;
 				}
 				clusters[i].members.insert(clusters[i].members.end(),
@@ -144858,16 +144888,27 @@ void Tool_textract::reconstructText(vector<Voice>& voices) {
 		bool skip = false;
 		for (size_t pi=0; pi<poem.size(); pi++) {
 			auto& prev = poem[pi];
-			if (linesSimilar(line, prev)) {
-				skip = true;
-				break;
-			}
-			if (isSubSequence(line, prev)) {
-				skip = true;
-				break;
-			}
-			if (isSubSequence(prev, line)) {
-				poem[pi] = line;
+			if (linesSimilar(line, prev) || isSubSequence(line, prev) ||
+					isSubSequence(prev, line)) {
+				// Same poem line attested in fuller/partial forms: keep
+				// the metrically better (or longer) reading.
+				bool lineBetter = false;
+				if (!m_sylCounts.empty()) {
+					int sylNew = lineSyllables(line);
+					int sylOld = lineSyllables(prev);
+					int dNew = distanceToAllowed(sylNew);
+					int dOld = distanceToAllowed(sylOld);
+					if (dNew < dOld) {
+						lineBetter = true;
+					} else if ((dNew == dOld) && (line.size() > prev.size())) {
+						lineBetter = true;
+					}
+				} else if (line.size() > prev.size()) {
+					lineBetter = true;
+				}
+				if (lineBetter) {
+					poem[pi] = line;
+				}
 				skip = true;
 				break;
 			}
@@ -144909,6 +144950,24 @@ void Tool_textract::refineLines(vector<vector<SungWord>>& lines) {
 	int i = 0;
 	while (i < (int)lines.size()) {
 		int syl = lineSyllables(lines[i]);
+
+		// Short trailing fragment after a line that already hit a shorter
+		// allowed length (e.g. "Ma che…schivargli" at 7 + "Amor ci toglie"):
+		// fold back if the combination hits an allowed length and the
+		// fragment does not open with a typical line-starter.
+		if (!isAllowedLength(syl, 1) && !out.empty()) {
+			if (lines[i].empty() || !likelyLineStart(lines[i][0].norm)) {
+				vector<SungWord> combined = out.back();
+				combined.insert(combined.end(), lines[i].begin(), lines[i].end());
+				int combSyl = lineSyllables(combined);
+				if (isAllowedLength(combSyl, 1) &&
+						(distanceToAllowed(combSyl) <= distanceToAllowed(lineSyllables(out.back())))) {
+					out.back().swap(combined);
+					i++;
+					continue;
+				}
+			}
+		}
 
 		if (isAllowedLength(syl, 1)) {
 			out.push_back(lines[i]);

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mon Jul 20 10:35:12 CEST 2026
+// Last Modified: Sat Jul 25 08:37:05 CEST 2026
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -128420,7 +128420,7 @@ void Tool_pliner::alignVoice(vector<SungWord>& words, vector<vector<PoemWord>>& 
 	// poem line 0, search a short lookahead window of this voice's
 	// opening words for the (line, pos) placement that gives the best
 	// run of consecutive matches (elision-tolerant, via matchLen/
-	// scoreRun), and anchor there instead. If nothing matches at all
+	// scoreRun), and anchor there instead.  If nothing matches at all
 	// within the lookahead, fall back to (0, 0) as a last resort.
 	auto findInitialAnchor = [&](size_t startIdx, int& outLine, int& outPos) -> bool {
 		const int maxLookahead = 6;
@@ -128486,12 +128486,17 @@ void Tool_pliner::alignVoice(vector<SungWord>& words, vector<vector<PoemWord>>& 
 		// candSpanStart records where the coverage actually began).
 		int candSpanStart = -1;
 
-		// Score plausible candidate placements for this word by how many
-		// consecutive words are confirmed in the poem. A multi-word
+		// Gather every plausible candidate placement for this word and
+		// score each by how many consecutive words it (and the words
+		// that follow) actually confirm in the poem.  A multi-word
 		// confirmed match is always preferred over a match based on a
 		// single corresponding syllable/word, no matter which kind of
-		// candidate produced it. Ties in score are broken by the priority
-		// listed below (lower is preferred).
+		// candidate (forward continuation, skipped-word, backward
+		// repeat, or a jump to a later line) produced it; a single-word
+		// match is only used as a fallback when nothing stronger can be
+		// found anywhere.  Ties in score are broken by the priority
+		// listed below (lower is preferred), reflecting that the text
+		// declamation is almost always linear.
 		struct Cand { int line=-1; int pos=-1; int score=0; int priority=99; };
 		vector<Cand> cands;
 
@@ -128557,7 +128562,7 @@ void Tool_pliner::alignVoice(vector<SungWord>& words, vector<vector<PoemWord>>& 
 			// omitting, one or more intervening lines), and it need not
 			// land on that line's very first word either (the voice may
 			// enter only partway into the line, e.g. singing just its
-			// tail). Check every position of a short lookahead of
+			// tail).  Check every position of a short lookahead of
 			// upcoming lines for the best-confirmed placement.
 			if (sw.capitalized) {
 				int maxLineLookahead = 6;
@@ -128635,6 +128640,26 @@ void Tool_pliner::alignVoice(vector<SungWord>& words, vector<vector<PoemWord>>& 
 		ptrLine = candLine;
 		ptrPos  = candPos;
 
+		// Landing back at or before the position where the current span
+		// itself began (within the same line) marks the start of a
+		// fresh declamation block (e.g. two separate partial attempts
+		// at a line before it has ever been completed in full, or two
+		// separate full repeats of a line separated by a rest).  A
+		// backward step that stays strictly after the span's own start
+		// (e.g. immediately re-singing the tail end of a line, or a
+		// word repeated for emphasis) is treated as a decorative
+		// extension of the same ongoing statement instead -- unless the
+		// current span has already covered the line in full, in which
+		// case a backward step all the way back to the line's own
+		// start still begins a new (fresh, complete) statement.  A
+		// lesser backward step (a tail-only fragment sung again right
+		// after a full statement) is split out into its own *pline
+		// transition only if that preceding full statement was itself
+		// the line's original (non-repeat) statement -- i.e. this tail
+		// fragment is the line's first true repeat and deserves its
+		// own tag.  If the preceding full statement was already itself
+		// a repeat, a further tail-only echo right after it is instead
+		// treated as a decorative extension folded into that span.
 		bool curIsFull = haveSpan && (cur.startPos == 0) &&
 				(cur.endPos == lineWordCount(cur.line) - 1);
 		bool curWouldBeRepeat = haveSpan && (cur.endPos <= spanFarAtStart);
@@ -143741,6 +143766,1093 @@ HumNum Tool_textdur::getDuration(HTp tok1, HTp tok2) {
 	return duration;
 }
 
+
+
+
+
+//////////////////////////////
+//
+// Tool_textract::Tool_textract --
+//
+
+Tool_textract::Tool_textract(void) {
+	define("s|syllables|syl=s:", "expected line lengths in syllables (comma-separated, cycles; e.g. 11,7)");
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::run --
+//
+
+bool Tool_textract::run(HumdrumFileSet& infiles) {
+	bool status = true;
+	for (int i=0; i<infiles.getCount(); i++) {
+		status &= run(infiles[i]);
+	}
+	return status;
+}
+
+
+bool Tool_textract::run(const string& indata, ostream& out) {
+	HumdrumFile infile(indata);
+	bool status = run(infile);
+	if (hasAnyText()) {
+		getAllText(out);
+	} else {
+		out << infile;
+	}
+	return status;
+}
+
+
+bool Tool_textract::run(HumdrumFile& infile, ostream& out) {
+	bool status = run(infile);
+	if (hasAnyText()) {
+		getAllText(out);
+	} else {
+		out << infile;
+	}
+	return status;
+}
+
+
+bool Tool_textract::run(HumdrumFile& infile) {
+	initialize();
+	processFile(infile);
+	return true;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::initialize --
+//
+
+void Tool_textract::initialize(void) {
+	m_sylCounts.clear();
+
+	if (getBoolean("syllables")) {
+		HumRegex hre;
+		vector<string> pieces;
+		hre.split(pieces, getString("syllables"), "\\s*,\\s*");
+		for (string& p : pieces) {
+			if (p.empty()) {
+				continue;
+			}
+			try {
+				int n = stoi(p);
+				if (n > 0) {
+					m_sylCounts.push_back(n);
+				}
+			} catch (...) {
+				// ignore malformed entries
+			}
+		}
+	}
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::processFile --
+//
+
+void Tool_textract::processFile(HumdrumFile& infile) {
+	vector<Voice> voices;
+	getVoices(infile, voices);
+
+	for (Voice& voice : voices) {
+		buildSungWords(voice.textStart, voice.words);
+		collapseRepeats(voice.words);
+		segmentLines(voice);
+		dedupeVoiceLines(voice);
+	}
+
+	reconstructText(voices);
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::getVoices -- Pair each **kern with its following **text.
+//
+
+void Tool_textract::getVoices(HumdrumFile& infile, vector<Voice>& voices) {
+	voices.clear();
+	vector<HTp> starts;
+	infile.getSpineStartList(starts);
+
+	for (int i=0; i<(int)starts.size(); i++) {
+		if (!starts[i]->isKern()) {
+			continue;
+		}
+		if ((i + 1 < (int)starts.size()) && starts[i+1]->isDataType("**text")) {
+			Voice voice;
+			voice.textStart = starts[i+1];
+			voices.push_back(voice);
+		}
+	}
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::normalizeWord -- Lower-case ASCII, strip punctuation,
+//    fold common accented vowels, keep apostrophes.
+//
+
+string Tool_textract::normalizeWord(const string& text) {
+	string out;
+	for (size_t i=0; i<text.size(); i++) {
+		unsigned char c = (unsigned char)text[i];
+		if ((c == '<') || (c == '>')) {
+			continue;
+		}
+		if ((c == ',') || (c == '.') || (c == ':') || (c == ';') ||
+				(c == '!') || (c == '?') || (c == '"')) {
+			continue;
+		}
+		if ((c == 0xC3) && (i + 1 < text.size())) {
+			unsigned char c2 = (unsigned char)text[i+1];
+			char folded = 0;
+			switch (c2) {
+				case 0x80: case 0x81: case 0xA0: case 0xA1: folded = 'a'; break;
+				case 0x88: case 0x89: case 0xA8: case 0xA9: folded = 'e'; break;
+				case 0x8C: case 0x8D: case 0xAC: case 0xAD: folded = 'i'; break;
+				case 0x92: case 0x93: case 0xB2: case 0xB3: folded = 'o'; break;
+				case 0x99: case 0x9A: case 0xB9: case 0xBA: folded = 'u'; break;
+			}
+			if (folded) {
+				out += folded;
+				i++;
+				continue;
+			}
+		}
+		// "e1"/"a1"/... grave encoding used in some underlays
+		if (((c >= 'a') && (c <= 'z')) || ((c >= 'A') && (c <= 'Z'))) {
+			char base = (char)tolower(c);
+			if ((i + 1 < text.size()) && (text[i+1] == '1') &&
+					((base == 'a') || (base == 'e') || (base == 'i') ||
+					 (base == 'o') || (base == 'u'))) {
+				out += base;
+				i++;
+				continue;
+			}
+			out += base;
+			continue;
+		}
+		if (c == '-') {
+			continue;
+		}
+		out += (char)c;
+	}
+	return out;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::cleanOrigPiece -- Strip hyphens/markers from one syllable
+//    for display joining.
+//
+
+string Tool_textract::cleanOrigPiece(const string& text) {
+	string out;
+	for (size_t i=0; i<text.size(); i++) {
+		unsigned char c = (unsigned char)text[i];
+		if ((c == '<') || (c == '>') || (c == '-')) {
+			continue;
+		}
+		if ((c == ',') || (c == '.') || (c == ':') || (c == ';') ||
+				(c == '!') || (c == '?') || (c == '"')) {
+			continue;
+		}
+		out += (char)c;
+	}
+	return out;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::buildSungWords -- Reconstruct words from hyphenated
+//    syllables; track capitalization, syllable counts, and <bis> spans.
+//
+
+void Tool_textract::buildSungWords(HTp textStart, vector<SungWord>& words) {
+	words.clear();
+	if (!textStart) {
+		return;
+	}
+
+	auto endsWithContinuationDash = [](const string& s) {
+		string tmp = s;
+		while (!tmp.empty()) {
+			char c = tmp.back();
+			if ((c == ',') || (c == '.') || (c == ':') || (c == ';') ||
+					(c == '!') || (c == '?') || (c == '"') || (c == '>')) {
+				tmp.pop_back();
+				continue;
+			}
+			break;
+		}
+		return !tmp.empty() && (tmp.back() == '-');
+	};
+
+	bool wordOpen = false;
+	string accumNorm;
+	string accumOrig;
+	int sylCount = 0;
+	bool capitalized = false;
+	bool bis = false;
+	bool inBis = false;
+
+	auto finalize = [&]() {
+		if (wordOpen && !accumNorm.empty()) {
+			SungWord sw;
+			sw.original = accumOrig;
+			sw.norm = accumNorm;
+			sw.syllables = max(sylCount, 1);
+			sw.capitalized = capitalized;
+			sw.bis = bis;
+			words.push_back(sw);
+		}
+		wordOpen = false;
+		accumNorm.clear();
+		accumOrig.clear();
+		sylCount = 0;
+		capitalized = false;
+		bis = false;
+	};
+
+	HTp cur = textStart;
+	while (cur) {
+		if (!cur->isData() || cur->isNull()) {
+			cur = cur->getNextToken();
+			continue;
+		}
+
+		string raw = *cur;
+		if (raw.find('<') != string::npos) {
+			inBis = true;
+		}
+
+		vector<string> parts;
+		size_t pos = 0;
+		while (pos <= raw.size()) {
+			size_t sp = raw.find(' ', pos);
+			if (sp == string::npos) {
+				parts.push_back(raw.substr(pos));
+				break;
+			}
+			parts.push_back(raw.substr(pos, sp - pos));
+			pos = sp + 1;
+		}
+
+		for (int idx=0; idx<(int)parts.size(); idx++) {
+			string part = parts[idx];
+			if (part.empty()) {
+				continue;
+			}
+			string core = part;
+			if (!core.empty() && (core[0] == '<')) {
+				core = core.substr(1);
+			}
+			bool leadingDash = !core.empty() && (core[0] == '-');
+			bool trailingDash = endsWithContinuationDash(core);
+			string n = normalizeWord(part);
+			string o = cleanOrigPiece(part);
+			if (n.empty() && o.empty()) {
+				continue;
+			}
+
+			if ((idx == 0) && wordOpen && leadingDash) {
+				accumNorm += n;
+				accumOrig += o;
+				sylCount++;
+				if (!trailingDash) {
+					finalize();
+				}
+			} else {
+				if (wordOpen) {
+					finalize();
+				}
+				capitalized = false;
+				for (char c : core) {
+					if (isalpha((unsigned char)c)) {
+						capitalized = isupper((unsigned char)c) != 0;
+						break;
+					}
+				}
+				bis = inBis;
+				accumNorm = n;
+				accumOrig = o;
+				sylCount = 1;
+				wordOpen = true;
+				if (!trailingDash) {
+					finalize();
+				}
+			}
+		}
+
+		if (raw.find('>') != string::npos) {
+			inBis = false;
+		}
+		cur = cur->getNextToken();
+	}
+	finalize();
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::collapseRepeats -- Remove immediate repeated blocks
+//    (musical re-iterations of the same words).
+//
+
+void Tool_textract::collapseRepeats(vector<SungWord>& words) {
+	// Drop editorial <bis> content entirely: it restates already-sung text.
+	{
+		vector<SungWord> filtered;
+		for (SungWord& w : words) {
+			if (!w.bis) {
+				filtered.push_back(w);
+			}
+		}
+		words.swap(filtered);
+	}
+
+	bool changed = true;
+	while (changed) {
+		changed = false;
+		int n = (int)words.size();
+		for (int L = n / 2; L >= 1; L--) {
+			for (int i = 0; i + 2 * L <= (int)words.size(); i++) {
+				bool match = true;
+				for (int k = 0; k < L; k++) {
+					if (words[i + k].norm != words[i + L + k].norm) {
+						match = false;
+						break;
+					}
+				}
+				if (match) {
+					words.erase(words.begin() + i + L, words.begin() + i + 2 * L);
+					changed = true;
+					break;
+				}
+			}
+			if (changed) {
+				break;
+			}
+		}
+	}
+
+	// Drop a word that restates the previous two concatenated ("che"+"volgi"→"chevolgi").
+	for (int i = 2; i < (int)words.size(); ) {
+		if (words[i].norm == words[i-2].norm + words[i-1].norm) {
+			words.erase(words.begin() + i);
+			continue;
+		}
+		i++;
+	}
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::endsWithVowel -- Last alphabetic char is a vowel sound.
+//
+
+bool Tool_textract::endsWithVowel(const string& norm) {
+	for (int i=(int)norm.size()-1; i>=0; i--) {
+		unsigned char c = (unsigned char)norm[i];
+		if (c == '\'') {
+			continue;
+		}
+		if (!isalpha(c)) {
+			continue;
+		}
+		char l = (char)tolower(c);
+		return (l == 'a') || (l == 'e') || (l == 'i') || (l == 'o') || (l == 'u');
+	}
+	return false;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::startsWithVowel -- First alphabetic char is a vowel sound.
+//
+
+bool Tool_textract::startsWithVowel(const string& norm) {
+	for (size_t i=0; i<norm.size(); i++) {
+		unsigned char c = (unsigned char)norm[i];
+		if (c == '\'') {
+			// Leading apostrophe ("'n") is an elision remnant, not a vowel start.
+			return false;
+		}
+		if (!isalpha(c)) {
+			continue;
+		}
+		char l = (char)tolower(c);
+		return (l == 'a') || (l == 'e') || (l == 'i') || (l == 'o') || (l == 'u');
+	}
+	return false;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::elidesWith -- Synaloepha / apostrophe elision between words.
+//    Mirrors pliner's apostrophe-aware matching: split on ' and check
+//    prefix/suffix relationships, plus vowel-vowel synaloepha.
+//
+
+bool Tool_textract::elidesWith(const SungWord& left, const SungWord& right) {
+	const string& a = left.norm;
+	const string& b = right.norm;
+	if (a.empty() || b.empty()) {
+		return false;
+	}
+
+	// Elision remnant attached to the next word ("E" + "'n").
+	if (b[0] == '\'') {
+		return true;
+	}
+
+	// Apostrophe contraction across a split underlay ("gli" + "occhi" with
+	// one side written "gl'occhi"-style).  Split on ' and compare pieces
+	// with startswith/endswith, as in pliner.
+	auto apostropheElision = [](const string& x, const string& y) -> bool {
+		size_t apos = x.find('\'');
+		if (apos == string::npos) {
+			return false;
+		}
+		string pre = x.substr(0, apos);
+		string suf = x.substr(apos + 1);
+		if (!pre.empty() && !suf.empty() && !y.empty()) {
+			// x = pre'suf; y matches suf (startswith) or pre (endswith of y
+			// when y is the left word — handled by swapping args).
+			if (y.compare(0, suf.size(), suf) == 0) {
+				return true;
+			}
+			if (y.size() >= pre.size() &&
+					(y.compare(y.size() - pre.size(), pre.size(), pre) == 0)) {
+				return true;
+			}
+			// Truncated prefix: "gl" vs "gli".
+			if ((pre.size() >= 2) && (y.size() >= 2) &&
+					(y.rfind(pre, 0) == 0 || pre.rfind(y, 0) == 0)) {
+				return true;
+			}
+		}
+		return false;
+	};
+	if (apostropheElision(a, b) || apostropheElision(b, a)) {
+		return true;
+	}
+
+	// Synaloepha: vowel-final + vowel-initial (also across line boundaries).
+	return endsWithVowel(a) && startsWithVowel(b);
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::lineSyllables -- Written syllable sum minus elisions
+//    (synaloepha / apostrophe) between adjacent words, including across
+//    what may later become a line boundary when lines are merged.
+//
+
+int Tool_textract::lineSyllables(const vector<SungWord>& line) {
+	if (line.empty()) {
+		return 0;
+	}
+	int n = 0;
+	for (const SungWord& w : line) {
+		n += w.syllables;
+	}
+	for (size_t i=0; i+1 < line.size(); i++) {
+		if (elidesWith(line[i], line[i+1])) {
+			n--;
+		}
+	}
+	return (n > 0) ? n : 0;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::expectedSyllables -- Positional target; list cycles.
+//
+
+int Tool_textract::expectedSyllables(int lineIndex) {
+	if (m_sylCounts.empty()) {
+		return 0;
+	}
+	return m_sylCounts[lineIndex % (int)m_sylCounts.size()];
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::distanceToAllowed -- Min distance to any -s length.
+//
+
+int Tool_textract::distanceToAllowed(int syllables) {
+	if (m_sylCounts.empty()) {
+		return abs(syllables);
+	}
+	int best = abs(syllables - m_sylCounts[0]);
+	for (int t : m_sylCounts) {
+		best = min(best, abs(syllables - t));
+	}
+	return best;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::isAllowedLength -- True if syllables matches a -s value.
+//
+
+bool Tool_textract::isAllowedLength(int syllables, int tol) {
+	if (m_sylCounts.empty()) {
+		return false;
+	}
+	for (int t : m_sylCounts) {
+		if (abs(syllables - t) <= tol) {
+			return true;
+		}
+	}
+	return false;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::segmentLines -- Split a voice on capitalized words.
+//    Mid-line capitals (not common line-starters) may stay in the current
+//    line.  Syllable targets (-s) are applied later in refineLines.
+//
+
+void Tool_textract::segmentLines(Voice& voice) {
+	voice.lines.clear();
+	if (voice.words.empty()) {
+		return;
+	}
+
+	vector<SungWord> cur;
+	auto flush = [&]() {
+		if (!cur.empty()) {
+			voice.lines.push_back(cur);
+			cur.clear();
+		}
+	};
+
+	for (SungWord& w : voice.words) {
+		if (!cur.empty() && w.capitalized) {
+			bool doBreak = true;
+			if (!likelyLineStart(w.norm)) {
+				// Mid-line exception, e.g. "Amore" in "Sciogli pietoso Amore".
+				if ((int)cur.size() <= 2) {
+					doBreak = false;
+				} else if (!m_sylCounts.empty()) {
+					int have = lineSyllables(cur);
+					if (!isAllowedLength(have, 1)) {
+						doBreak = false;
+					}
+				}
+			}
+			if (doBreak) {
+				flush();
+			}
+		}
+		cur.push_back(w);
+	}
+	flush();
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::likelyLineStart -- Common poetic line-initial words;
+//    capitals outside this set are more often mid-line exceptions.
+//
+
+bool Tool_textract::likelyLineStart(const string& norm) {
+	static const set<string> starters = {
+		"e", "ed", "a", "ad", "di", "de", "del", "che", "chi",
+		"la", "le", "il", "lo", "gli", "ne", "ma", "per", "se",
+		"non", "un", "una", "uno", "i", "o", "oh", "ah", "quando",
+		"come", "cosi", "poi", "anzi", "hor", "or", "ora", "ore",
+		"sol", "solo", "su", "sul", "tra", "fra", "con", "da", "dal"
+	};
+	if (starters.count(norm)) {
+		return true;
+	}
+	// "E'n", "Né", "Sol' io" folded forms.
+	if ((norm == "ne") || (norm.rfind("sol", 0) == 0) ||
+			(norm.rfind("e'", 0) == 0) || (norm.rfind("ne'", 0) == 0)) {
+		return true;
+	}
+	return false;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::linesSimilar -- Soft equality via token LCS ratio.
+//
+
+bool Tool_textract::linesSimilar(const vector<SungWord>& a,
+		const vector<SungWord>& b) {
+	if (a.empty() || b.empty()) {
+		return false;
+	}
+	if (a.size() == b.size()) {
+		bool exact = true;
+		for (size_t i=0; i<a.size(); i++) {
+			if (a[i].norm != b[i].norm) {
+				exact = false;
+				break;
+			}
+		}
+		if (exact) {
+			return true;
+		}
+	}
+	int maxLen = (int)max(a.size(), b.size());
+	int minLen = (int)min(a.size(), b.size());
+	if (maxLen - minLen > max(2, minLen / 2)) {
+		return false;
+	}
+	// LCS length
+	vector<vector<int>> dp(a.size() + 1, vector<int>(b.size() + 1, 0));
+	for (size_t i=1; i<=a.size(); i++) {
+		for (size_t j=1; j<=b.size(); j++) {
+			if (a[i-1].norm == b[j-1].norm) {
+				dp[i][j] = dp[i-1][j-1] + 1;
+			} else {
+				dp[i][j] = max(dp[i-1][j], dp[i][j-1]);
+			}
+		}
+	}
+	double ratio = (double)dp[a.size()][b.size()] / (double)maxLen;
+	return ratio >= 0.75;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::isSubSequence -- Contiguous sub-sequence test on norms.
+//
+
+bool Tool_textract::isSubSequence(const vector<SungWord>& shorter,
+		const vector<SungWord>& longer) {
+	if (shorter.size() >= longer.size()) {
+		return false;
+	}
+	if (shorter.empty()) {
+		return false;
+	}
+	for (size_t i=0; i + shorter.size() <= longer.size(); i++) {
+		bool ok = true;
+		for (size_t k=0; k<shorter.size(); k++) {
+			if (shorter[k].norm != longer[i+k].norm) {
+				ok = false;
+				break;
+			}
+		}
+		if (ok) {
+			return true;
+		}
+	}
+	return false;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::dedupeVoiceLines -- Drop musical re-statements of a line;
+//    keep the fuller version when one line contains another.
+//
+
+void Tool_textract::dedupeVoiceLines(Voice& voice) {
+	vector<vector<SungWord>> uniq;
+	for (auto& line : voice.lines) {
+		if (line.empty()) {
+			continue;
+		}
+		bool absorbed = false;
+		for (int i=0; i<(int)uniq.size(); i++) {
+			if (linesSimilar(line, uniq[i]) || isSubSequence(line, uniq[i])) {
+				absorbed = true;
+				break;
+			}
+			if (isSubSequence(uniq[i], line)) {
+				uniq[i] = line;
+				absorbed = true;
+				break;
+			}
+		}
+		if (!absorbed) {
+			uniq.push_back(line);
+		}
+	}
+	voice.lines.swap(uniq);
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::lineToString --
+//
+
+string Tool_textract::lineToString(const vector<SungWord>& line) {
+	string out;
+	for (size_t i=0; i<line.size(); i++) {
+		if (i) {
+			out += " ";
+		}
+		out += line[i].original;
+	}
+	return out;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::consensusLine -- Prefer the most common wording; break
+//    ties toward the longest non-repetitious form.
+//
+
+vector<Tool_textract::SungWord> Tool_textract::consensusLine(LineCluster& cluster) {
+	if (cluster.members.empty()) {
+		return {};
+	}
+	if (cluster.members.size() == 1) {
+		return cluster.members[0];
+	}
+
+	// Median length: trailing junk / local re-iterations often make outliers long.
+	vector<int> lengths;
+	for (auto& m : cluster.members) {
+		lengths.push_back((int)m.size());
+	}
+	sort(lengths.begin(), lengths.end());
+	int medianLen = lengths[lengths.size() / 2];
+
+	int bestIdx = 0;
+	double bestScore = -1e9;
+	for (int i=0; i<(int)cluster.members.size(); i++) {
+		auto& m = cluster.members[i];
+		double score = 0;
+		for (int j=0; j<(int)cluster.members.size(); j++) {
+			if (linesSimilar(m, cluster.members[j])) {
+				score += 1.0;
+				// Bonus when lengths agree (same wording, not a padded variant).
+				if (m.size() == cluster.members[j].size()) {
+					score += 0.5;
+				}
+			}
+		}
+		score -= 0.75 * fabs((double)m.size() - (double)medianLen);
+
+		// Penalize an immediate repeated half of the line.
+		int n = (int)m.size();
+		if ((n >= 4) && (n % 2 == 0)) {
+			bool half = true;
+			for (int k=0; k<n/2; k++) {
+				if (m[k].norm != m[n/2 + k].norm) {
+					half = false;
+					break;
+				}
+			}
+			if (half) {
+				score -= 5.0;
+			}
+		}
+		// Penalize a word that is the concatenation of the previous two
+		// (e.g. "che" + "volgi" restated as "chevolgi").
+		for (int k=2; k<n; k++) {
+			if (m[k].norm == m[k-2].norm + m[k-1].norm) {
+				score -= 2.0;
+			}
+			if ((k >= 3) && (m[k-1].norm + m[k].norm == m[k-3].norm + m[k-2].norm)) {
+				score -= 1.0;
+			}
+		}
+		if (score > bestScore) {
+			bestScore = score;
+			bestIdx = i;
+		}
+	}
+
+	vector<SungWord> result = cluster.members[bestIdx];
+	// Trim trailing words absent from a majority of members (local debris).
+	while (result.size() > 1) {
+		int idx = (int)result.size() - 1;
+		int withWord = 0;
+		for (auto& m : cluster.members) {
+			if (((int)m.size() > idx) && (m[idx].norm == result[idx].norm)) {
+				withWord++;
+			}
+		}
+		if (withWord * 2 < (int)cluster.members.size()) {
+			result.pop_back();
+		} else {
+			break;
+		}
+	}
+	return result;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::reconstructText -- Cluster lines across voices, keep
+//    majority-supported lines, order by typical singing order, emit text.
+//
+
+void Tool_textract::reconstructText(vector<Voice>& voices) {
+	if (voices.empty()) {
+		return;
+	}
+
+	vector<LineCluster> clusters;
+
+	for (int vi=0; vi<(int)voices.size(); vi++) {
+		for (int li=0; li<(int)voices[vi].lines.size(); li++) {
+			auto& line = voices[vi].lines[li];
+			int best = -1;
+			for (int ci=0; ci<(int)clusters.size(); ci++) {
+				auto rep = consensusLine(clusters[ci]);
+				bool similar = linesSimilar(line, rep);
+				bool lineInRep = isSubSequence(line, rep);
+				bool repInLine = isSubSequence(rep, line);
+				if (!similar && !lineInRep && !repInLine) {
+					continue;
+				}
+				// Short fragments only merge if they cover most of the other line.
+				if (!similar && lineInRep &&
+						((int)line.size() * 2 < (int)rep.size())) {
+					continue;
+				}
+				if (!similar && repInLine &&
+						((int)rep.size() * 2 < (int)line.size())) {
+					continue;
+				}
+				// Require shared first word when both are capitalized starts.
+				if (!line.empty() && !rep.empty() &&
+						line[0].capitalized && rep[0].capitalized &&
+						(line[0].norm != rep[0].norm)) {
+					continue;
+				}
+				best = ci;
+				break;
+			}
+			if (best >= 0) {
+				clusters[best].members.push_back(line);
+				clusters[best].voiceIds.push_back(vi);
+				// Prefer storing fuller versions first for later consensus.
+				if (line.size() > clusters[best].members[0].size()) {
+					swap(clusters[best].members[0],
+							clusters[best].members.back());
+				}
+			} else {
+				LineCluster c;
+				c.members.push_back(line);
+				c.voiceIds.push_back(vi);
+				clusters.push_back(c);
+			}
+		}
+	}
+
+	int nVoices = (int)voices.size();
+	int majority = (nVoices + 1) / 2;
+
+	// Compute average position among contributing voices.
+	for (LineCluster& c : clusters) {
+		double sum = 0;
+		int count = 0;
+		set<int> seen;
+		for (int k=0; k<(int)c.voiceIds.size(); k++) {
+			int vi = c.voiceIds[k];
+			if (seen.count(vi)) {
+				continue;
+			}
+			seen.insert(vi);
+			// position = index of this line among that voice's lines
+			auto rep = consensusLine(c);
+			for (int li=0; li<(int)voices[vi].lines.size(); li++) {
+				if (linesSimilar(voices[vi].lines[li], rep) ||
+						isSubSequence(voices[vi].lines[li], rep) ||
+						isSubSequence(rep, voices[vi].lines[li])) {
+					sum += li;
+					count++;
+					break;
+				}
+			}
+		}
+		c.avgPos = (count > 0) ? (sum / count) : 0;
+	}
+
+	vector<int> keep;
+	for (int ci=0; ci<(int)clusters.size(); ci++) {
+		set<int> uniqVoices(clusters[ci].voiceIds.begin(), clusters[ci].voiceIds.end());
+		if ((int)uniqVoices.size() >= majority) {
+			keep.push_back(ci);
+		}
+	}
+
+	stable_sort(keep.begin(), keep.end(), [&](int a, int b) {
+		if (fabs(clusters[a].avgPos - clusters[b].avgPos) > 1e-6) {
+			return clusters[a].avgPos < clusters[b].avgPos;
+		}
+		return a < b;
+	});
+
+	vector<vector<SungWord>> poem;
+	for (int ci : keep) {
+		auto line = consensusLine(clusters[ci]);
+		collapseRepeats(line);
+		if (!line.empty()) {
+			poem.push_back(line);
+		}
+	}
+
+	refineLines(poem);
+
+	for (auto& line : poem) {
+		if (!line.empty()) {
+			m_free_text << lineToString(line) << endl;
+		}
+	}
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::refineLines -- Apply -s lengths (list cycles; any listed
+//    length is allowed).  Metrical counts subtract synaloepha/apostrophe
+//    elision between adjacent words, including across a merge boundary.
+//
+
+void Tool_textract::refineLines(vector<vector<SungWord>>& lines) {
+	if (lines.empty() || m_sylCounts.empty()) {
+		return;
+	}
+
+	vector<vector<SungWord>> out;
+	int i = 0;
+	while (i < (int)lines.size()) {
+		int target = expectedSyllables((int)out.size());
+		int syl = lineSyllables(lines[i]);
+
+		if (isAllowedLength(syl) || (syl == target)) {
+			out.push_back(lines[i]);
+			i++;
+			continue;
+		}
+
+		if (i + 1 < (int)lines.size()) {
+			int nextSyl = lineSyllables(lines[i+1]);
+			bool nextComplete = isAllowedLength(nextSyl);
+			vector<SungWord> combined = lines[i];
+			combined.insert(combined.end(), lines[i+1].begin(), lines[i+1].end());
+			int combSyl = lineSyllables(combined); // includes cross-line elision
+			bool hits = isAllowedLength(combSyl) || (combSyl == target);
+			bool improves = distanceToAllowed(combSyl) < distanceToAllowed(syl);
+
+			// Never absorb a complete following line unless the merge exactly hits.
+			bool allowMerge = hits || (improves && !nextComplete);
+			if (allowMerge && !hits && !lines[i+1].empty() &&
+					likelyLineStart(lines[i+1][0].norm) && nextComplete) {
+				allowMerge = false;
+			}
+
+			if (allowMerge) {
+				int j = i + 2;
+				while (j < (int)lines.size() && !isAllowedLength(lineSyllables(combined))) {
+					if (isAllowedLength(lineSyllables(lines[j]))) {
+						break;
+					}
+					vector<SungWord> trial = combined;
+					trial.insert(trial.end(), lines[j].begin(), lines[j].end());
+					int t2 = lineSyllables(combined);
+					int t3 = lineSyllables(trial);
+					if (distanceToAllowed(t3) <= distanceToAllowed(t2)) {
+						combined.swap(trial);
+						j++;
+					} else {
+						break;
+					}
+				}
+				out.push_back(combined);
+				i = j;
+				continue;
+			}
+		}
+
+		int maxAllowed = m_sylCounts[0];
+		for (int t : m_sylCounts) {
+			maxAllowed = max(maxAllowed, t);
+		}
+		if (syl > maxAllowed + 1) {
+			int bestBreak = -1;
+			int bestDist = 9999;
+			for (int k=1; k<(int)lines[i].size(); k++) {
+				if (!lines[i][k].capitalized) {
+					continue;
+				}
+				vector<SungWord> left(lines[i].begin(), lines[i].begin() + k);
+				int leftSyl = lineSyllables(left);
+				int dist = distanceToAllowed(leftSyl);
+				if (isAllowedLength(leftSyl, 1) && (dist < bestDist)) {
+					bestDist = dist;
+					bestBreak = k;
+				}
+			}
+			if (bestBreak > 0) {
+				vector<SungWord> left(lines[i].begin(), lines[i].begin() + bestBreak);
+				vector<SungWord> right(lines[i].begin() + bestBreak, lines[i].end());
+				out.push_back(left);
+				lines[i] = right;
+				continue;
+			}
+		}
+
+		out.push_back(lines[i]);
+		i++;
+	}
+	lines.swap(out);
+}
 
 
 

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -127825,6 +127825,919 @@ void Tool_pline::getPlineInterpretations(HumdrumFile& infile, vector<HTp>& token
 
 /////////////////////////////////
 //
+// Tool_pliner::Tool_pliner -- Set the recognized options for the tool.
+//
+
+Tool_pliner::Tool_pliner(void) {
+	// no options currently defined.
+}
+
+
+
+/////////////////////////////////
+//
+// Tool_pliner::run -- Do the main work of the tool.
+//
+
+bool Tool_pliner::run(HumdrumFileSet& infiles) {
+	bool status = true;
+	for (int i=0; i<infiles.getCount(); i++) {
+		status &= run(infiles[i]);
+	}
+	return status;
+}
+
+
+bool Tool_pliner::run(const string& indata, ostream& out) {
+	HumdrumFile infile(indata);
+	bool status = run(infile);
+	if (hasAnyText()) {
+		getAllText(out);
+	} else {
+		out << infile;
+	}
+	return status;
+}
+
+
+bool Tool_pliner::run(HumdrumFile& infile, ostream& out) {
+	bool status = run(infile);
+	if (hasAnyText()) {
+		getAllText(out);
+	} else {
+		out << infile;
+	}
+	return status;
+}
+
+
+bool Tool_pliner::run(HumdrumFile& infile) {
+	initialize();
+	processFile(infile);
+	return true;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_pliner::initialize --
+//
+
+void Tool_pliner::initialize(void) {
+	// nothing to do yet.
+}
+
+
+
+//////////////////////////////
+//
+// Tool_pliner::processFile --
+//
+
+void Tool_pliner::processFile(HumdrumFile& infile) {
+	m_poem.clear();
+	m_voices.clear();
+
+	bool haveVerse = parseVerse(infile, m_poem);
+	if (!haveVerse) {
+		// Nothing to do: no !!@VERSE: block found, so echo input unchanged.
+		m_humdrum_text << infile;
+		return;
+	}
+
+	getVoices(infile, m_voices);
+
+	if (getenv("PLINER_DEBUG")) {
+		for (size_t li=0; li<m_poem.size(); li++) {
+			cerr << "POEM line=" << li << ":";
+			for (auto& pw : m_poem[li]) {
+				cerr << " [" << pw.norm << "]";
+			}
+			cerr << endl;
+		}
+	}
+
+	map<int, map<int, string>> insertions;
+
+	for (Voice& voice : m_voices) {
+		vector<SungWord> words;
+		buildSungWords(voice.textStart, words);
+
+		if (getenv("PLINER_DEBUG")) {
+			cerr << "VOICE track=" << voice.kernStart->getTrack() << endl;
+			for (auto& w : words) {
+				cerr << "  word=[" << w.norm << "] cap=" << w.capitalized
+				     << " line=" << w.token->getLineIndex() << endl;
+			}
+		}
+
+		vector<Span> spans;
+		alignVoice(words, m_poem, spans);
+
+		int kernTrack = voice.kernStart->getTrack();
+		int textTrack = voice.textStart->getTrack();
+
+		for (Span& span : spans) {
+			if (!span.startToken) {
+				continue;
+			}
+			if ((span.line < 0) || (span.line >= (int)m_poem.size())) {
+				continue;
+			}
+			string modifier = getModifier(m_poem, span);
+			string text = "*pline:" + to_string(span.line + 1) + modifier;
+			int li = span.startToken->getLineIndex();
+			insertions[li][kernTrack] = text;
+			insertions[li][textTrack] = text;
+		}
+	}
+
+	emitOutput(infile, insertions);
+}
+
+
+
+//////////////////////////////
+//
+// Tool_pliner::parseVerse -- Extract the poem lines/words from the
+//    !!@VERSE: global comment block.  The block starts on a line matching
+//    "!!@VERSE:" and continues on subsequent "!!<text>" global comment
+//    lines (not starting with another "!!@" tag) until the first line that
+//    does not match that pattern (typically a blank "!!" separator line or
+//    the next "!!@" tag).
+//
+
+bool Tool_pliner::parseVerse(HumdrumFile& infile, vector<vector<PoemWord>>& poem) {
+	poem.clear();
+	HumRegex hre;
+
+	int verseLine = -1;
+	for (int i=0; i<infile.getLineCount(); i++) {
+		if (!infile[i].isCommentGlobal()) {
+			continue;
+		}
+		HTp token = infile.token(i, 0);
+		if (hre.search(token, "^!!@VERSE:\\s*$")) {
+			verseLine = i;
+			break;
+		}
+	}
+	if (verseLine < 0) {
+		return false;
+	}
+
+	int lineNum = 0;
+	for (int i=verseLine+1; i<infile.getLineCount(); i++) {
+		if (!infile[i].isCommentGlobal()) {
+			break;
+		}
+		HTp token = infile.token(i, 0);
+		string text = *token;
+		if (hre.search(text, "^!!@VERSE:\\s*$")) {
+			// A poem may be split across multiple stanzas, each
+			// re-introduced by its own repeated "!!@VERSE:" tag; treat
+			// this as a stanza separator and keep collecting lines
+			// rather than stopping the poem here.
+			continue;
+		}
+		if (hre.search(text, "^!!@")) {
+			// start of a different tagged section (e.g. "!!@TVERSE:").
+			break;
+		}
+		if (!hre.search(text, "^!!\\s*(\\S.*)$")) {
+			// blank "!!" separator line (or malformed line): end of poem.
+			break;
+		}
+		string content = hre.getMatch(1);
+
+		vector<string> rawwords;
+		hre.split(rawwords, content, "\\s+");
+
+		vector<PoemWord> lineWords;
+		for (string& w : rawwords) {
+			if (w.empty()) {
+				continue;
+			}
+			string norm = normalizeWord(w);
+			if (norm.empty()) {
+				continue;
+			}
+			if ((norm[0] == '\'') && !lineWords.empty()) {
+				// A word-initial apostrophe with nothing before it (e.g.
+				// the "'n" in "E 'n mia ragion...") is a typographical
+				// elision split off from the previous word by whitespace
+				// in the verse text; rejoin it so that "E" + "'n" reads
+				// as the single elided word "e'n", matching how the
+				// same elision is sung as one word in the **text spines.
+				lineWords.back().norm += norm;
+				lineWords.back().original += " " + w;
+				continue;
+			}
+			PoemWord pw;
+			pw.original = w;
+			pw.norm = norm;
+			pw.line = lineNum;
+			pw.pos = (int)lineWords.size();
+			lineWords.push_back(pw);
+		}
+
+		if (!lineWords.empty()) {
+			poem.push_back(lineWords);
+			lineNum++;
+		}
+	}
+
+	return !poem.empty();
+}
+
+
+
+//////////////////////////////
+//
+// Tool_pliner::getVoices -- Identify each **kern spine paired with the
+//    **text spine that immediately follows it (the convention used
+//    throughout this corpus).
+//
+
+void Tool_pliner::getVoices(HumdrumFile& infile, vector<Voice>& voices) {
+	voices.clear();
+	vector<HTp> starts;
+	infile.getSpineStartList(starts);
+
+	for (int i=0; i<(int)starts.size(); i++) {
+		if (!starts[i]->isKern()) {
+			continue;
+		}
+		Voice voice;
+		voice.kernStart = starts[i];
+		if ((i + 1 < (int)starts.size()) && starts[i+1]->isDataType("**text")) {
+			voice.textStart = starts[i+1];
+		}
+		if (voice.textStart) {
+			voices.push_back(voice);
+		}
+	}
+}
+
+
+
+//////////////////////////////
+//
+// Tool_pliner::normalizeWord -- Lower-case (ASCII only, to avoid
+//    corrupting multi-byte UTF-8 accented characters) and strip common
+//    punctuation/markers so that sung syllables and poem words can be
+//    compared for equality.  Apostrophes are preserved since they are
+//    meaningful within Italian elisions (e.g. "l'alma").  Accented
+//    vowels (a grave/acute, e grave/acute, etc., encoded as two-byte
+//    UTF-8 sequences) are folded down to their plain-vowel equivalent,
+//    since the sung **text underlay and the reference !!@VERSE: text
+//    frequently disagree on whether/which accent to write for the same
+//    word (e.g. poem "e`" vs. sung "e"), and such spelling differences
+//    should not block an otherwise correct word match.
+//
+
+string Tool_pliner::normalizeWord(const string& text) {
+	string out;
+	for (size_t i=0; i<text.size(); i++) {
+		unsigned char c = (unsigned char)text[i];
+		if ((c == '<') || (c == '>')) {
+			continue;
+		}
+		if ((c == ',') || (c == '.') || (c == ':') || (c == ';') ||
+				(c == '!') || (c == '?') || (c == '"')) {
+			continue;
+		}
+		if ((c == 0xC3) && (i + 1 < text.size())) {
+			unsigned char c2 = (unsigned char)text[i+1];
+			char folded = 0;
+			switch (c2) {
+				case 0x80: case 0x81: case 0xA0: case 0xA1: folded = 'a'; break; // A/a grave/acute
+				case 0x88: case 0x89: case 0xA8: case 0xA9: folded = 'e'; break; // E/e grave/acute
+				case 0x8C: case 0x8D: case 0xAC: case 0xAD: folded = 'i'; break; // I/i grave/acute
+				case 0x92: case 0x93: case 0xB2: case 0xB3: folded = 'o'; break; // O/o grave/acute
+				case 0x99: case 0x9A: case 0xB9: case 0xBA: folded = 'u'; break; // U/u grave/acute
+			}
+			if (folded) {
+				out += folded;
+				i++;
+				continue;
+			}
+		}
+		if ((c >= 'A') && (c <= 'Z')) {
+			out += (char)(c - 'A' + 'a');
+		} else {
+			out += (char)c;
+		}
+	}
+	while (!out.empty() && (out.front() == '-')) {
+		out.erase(out.begin());
+	}
+	while (!out.empty() && (out.back() == '-')) {
+		out.pop_back();
+	}
+	return out;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_pliner::cleanSyllable -- (unused helper retained for API symmetry
+//    with normalizeWord; currently a synonym).
+//
+
+string Tool_pliner::cleanSyllable(const string& text) {
+	return normalizeWord(text);
+}
+
+
+
+//////////////////////////////
+//
+// Tool_pliner::buildSungWords -- Walk a **text spine and reconstruct
+//    complete words from (possibly hyphenated) syllable tokens, recording
+//    the token where each word starts and whether the raw syllable began
+//    with a capital letter.
+//
+
+void Tool_pliner::buildSungWords(HTp textStart, vector<SungWord>& words) {
+	words.clear();
+	if (!textStart) {
+		return;
+	}
+
+	auto endsWithContinuationDash = [](const string& s) {
+		string tmp = s;
+		while (!tmp.empty()) {
+			char c = tmp.back();
+			if ((c == ',') || (c == '.') || (c == ':') || (c == ';') ||
+					(c == '!') || (c == '?') || (c == '"') || (c == '>')) {
+				tmp.pop_back();
+				continue;
+			}
+			break;
+		}
+		return !tmp.empty() && (tmp.back() == '-');
+	};
+
+	bool wordOpen = false;
+	string accum;
+	HTp startToken = NULL;
+	bool capitalized = false;
+
+	auto finalize = [&]() {
+		if (wordOpen && !accum.empty()) {
+			SungWord sw;
+			sw.token = startToken;
+			sw.norm = accum;
+			sw.capitalized = capitalized;
+			words.push_back(sw);
+		}
+		wordOpen = false;
+		accum.clear();
+		startToken = NULL;
+		capitalized = false;
+	};
+
+	HTp cur = textStart;
+	while (cur) {
+		if (!cur->isData() || cur->isNull()) {
+			cur = cur->getNextToken();
+			continue;
+		}
+
+		string raw = *cur;
+
+		// A single note token can contain two syllables separated by a
+		// literal space: the tail end of the previous word followed by
+		// the start of the next word (e.g. "-ci as-").
+		vector<string> parts;
+		size_t pos = 0;
+		while (pos <= raw.size()) {
+			size_t sp = raw.find(' ', pos);
+			if (sp == string::npos) {
+				parts.push_back(raw.substr(pos));
+				break;
+			}
+			parts.push_back(raw.substr(pos, sp - pos));
+			pos = sp + 1;
+		}
+
+		for (int idx=0; idx<(int)parts.size(); idx++) {
+			string part = parts[idx];
+			string core = part;
+			if (!core.empty() && (core[0] == '<')) {
+				core = core.substr(1);
+			}
+			bool leadingDash = !core.empty() && (core[0] == '-');
+			bool trailingDash = endsWithContinuationDash(core);
+
+			if ((idx == 0) && wordOpen && leadingDash) {
+				// continuation of the currently open word.
+				accum += normalizeWord(part);
+				if (!trailingDash) {
+					finalize();
+				}
+			} else {
+				// starts a new word (closing any dangling previous word).
+				if (wordOpen) {
+					finalize();
+				}
+				startToken = cur;
+				accum = normalizeWord(part);
+				capitalized = false;
+				for (char c : core) {
+					if (isalpha((unsigned char)c)) {
+						capitalized = isupper((unsigned char)c) != 0;
+						break;
+					}
+				}
+				if (trailingDash) {
+					wordOpen = true;
+				} else {
+					wordOpen = true; // set so finalize() will push it
+					finalize();
+				}
+			}
+		}
+
+		cur = cur->getNextToken();
+	}
+
+	finalize();
+}
+
+
+
+//////////////////////////////
+//
+// Tool_pliner::alignVoice -- Align a voice's sequence of sung words
+//    against the poem, tracking a mostly-forward-moving pointer (repeats
+//    are assumed to stay close by: within the current line or the
+//    immediately preceding line), rather than depending on any
+//    pre-existing editorial markup.  Runs of consecutive words assigned
+//    to the same (line, repeat-state) are collapsed into "spans"; each
+//    span marks one *pline transition.
+//
+//    A span only counts as a repeat ("r") if it does not, by the time it
+//    ends, reach any further into the line than this voice had already
+//    reached before that span began.  This means that an opening
+//    partial ("a"/"b"/"c") block sung before the line has ever been
+//    completed is not a repeat (there is nothing yet to repeat), even if
+//    a later block re-covers that same partial ground again (that later
+//    block *is* a repeat, since it does not go beyond what was already
+//    reached); but the block that eventually pushes on to complete the
+//    line for the first time is not a repeat either, even though it
+//    starts by re-treading already-sung words, because it ends up
+//    covering new ground.
+//
+
+void Tool_pliner::alignVoice(vector<SungWord>& words, vector<vector<PoemWord>>& poem,
+		vector<Span>& spans) {
+	spans.clear();
+	if (poem.empty() || words.empty()) {
+		return;
+	}
+
+	auto lineWordCount = [&](int line) {
+		return (int)poem.at(line).size();
+	};
+
+	int ptrLine = -1;
+	int ptrPos  = -1;
+
+	// tracks, per poem line, the furthest word position this voice has
+	// reached in that line so far (across any span, repeat or not).
+	vector<int> farPosInLine(poem.size(), -1);
+
+	bool haveSpan = false;
+	Span cur;
+	int spanFarAtStart = -1;
+
+	// Furthest position reached in a line, including any progress made
+	// so far in the still-open current span (which has not yet been
+	// committed to farPosInLine via closeSpan()).
+	auto farReached = [&](int line) {
+		int far = farPosInLine.at(line);
+		if (haveSpan && (cur.line == line) && (cur.endPos > far)) {
+			far = cur.endPos;
+		}
+		return far;
+	};
+
+	auto lineReachedEnd = [&](int line) {
+		return farReached(line) >= lineWordCount(line) - 1;
+	};
+
+	// Occasionally the sung setting elides two adjacent poem words into a
+	// single unbroken melisma with no textual break between them (e.g.
+	// "Tanti n'aggiungi" sung as one continuous "tantin'aggiungi").  This
+	// checks whether a normalized sung word (norm) matches the poem word
+	// at (line, pos), optionally also swallowing the next poem word too;
+	// returns 0 (no match), 1 (matches just poem[line][pos]), or 2
+	// (matches the concatenation of poem[line][pos] and poem[line][pos+1]).
+	auto matchLen = [&](int line, int pos, const string& norm) -> int {
+		if ((line < 0) || (line >= (int)poem.size())) {
+			return 0;
+		}
+		if ((pos < 0) || (pos >= lineWordCount(line))) {
+			return 0;
+		}
+		if (poem[line][pos].norm == norm) {
+			return 1;
+		}
+		if (pos + 1 < lineWordCount(line)) {
+			const string& w1 = poem[line][pos].norm;
+			const string& w2 = poem[line][pos+1].norm;
+			if ((w1 + w2) == norm) {
+				return 2;
+			}
+			// Elision contracted across a word boundary that the poem
+			// text itself did not mark with an apostrophe (e.g. "Gli
+			// occhi" written as two separate words but sung/contracted
+			// as "Gl'occhi", dropping the final vowel of the first
+			// word).  If the sung word contains an apostrophe, treat
+			// the part before it as a (possibly truncated) prefix of
+			// the first poem word and the part after it as the second
+			// poem word.
+			size_t apos = norm.find('\'');
+			if (apos != string::npos) {
+				string left  = norm.substr(0, apos);
+				string right = norm.substr(apos + 1);
+				if (!left.empty() && !right.empty() &&
+						(w1.rfind(left, 0) == 0) && (w2 == right)) {
+					return 2;
+				}
+			}
+		}
+		return 0;
+	};
+
+	auto closeSpan = [&]() {
+		cur.repeat = (cur.endPos <= spanFarAtStart);
+		if (cur.endPos > farPosInLine[cur.line]) {
+			farPosInLine[cur.line] = cur.endPos;
+		}
+		spans.push_back(cur);
+	};
+
+	// Scores a candidate placement (line, pos) for the sung word at index
+	// wi by counting how many consecutive sung words (starting at wi,
+	// skipping empties, tolerating word-eliding/apostrophe-contraction
+	// via matchLen) match the poem starting there.  A candidate whose
+	// very first word does not match scores 0.  Capped at a handful of
+	// words since that is already enough to confidently distinguish a
+	// real match from a coincidental one-word overlap (e.g. two
+	// different poem lines both starting with the same short word like
+	// "E").
+	auto scoreRun = [&](size_t wi, int line, int pos) -> int {
+		const int maxRun = 4;
+		int score = 0;
+		size_t k  = wi;
+		int p = pos;
+		while (score < maxRun) {
+			while ((k < words.size()) && words[k].norm.empty()) {
+				k++;
+			}
+			if (k >= words.size()) {
+				break;
+			}
+			int m = matchLen(line, p, words[k].norm);
+			if (m <= 0) {
+				break;
+			}
+			score++;
+			p += m;
+			k++;
+		}
+		return score;
+	};
+
+	// A voice may enter partway through the poem (e.g. a later voice in
+	// an imitative texture that skips the opening line(s) entirely).
+	// Rather than always anchoring a voice's very first sung word to
+	// poem line 0, search a short lookahead window of this voice's
+	// opening words for the (line, pos) placement that gives the best
+	// run of consecutive matches (elision-tolerant, via matchLen/
+	// scoreRun), and anchor there instead. If nothing matches at all
+	// within the lookahead, fall back to (0, 0) as a last resort.
+	auto findInitialAnchor = [&](size_t startIdx, int& outLine, int& outPos) -> bool {
+		const int maxLookahead = 6;
+		vector<size_t> idxs;
+		for (size_t k=startIdx; (k<words.size()) && (idxs.size()<(size_t)maxLookahead); k++) {
+			if (!words[k].norm.empty()) {
+				idxs.push_back(k);
+			}
+		}
+		if (idxs.empty()) {
+			return false;
+		}
+
+		int bestScore = 0;
+		int bestLine  = -1;
+		int bestPos   = -1;
+		for (size_t ki=0; ki<idxs.size(); ki++) {
+			const string& norm = words[idxs[ki]].norm;
+			for (int li=0; li<(int)poem.size(); li++) {
+				for (int pi=0; pi<lineWordCount(li); pi++) {
+					if (matchLen(li, pi, norm) <= 0) {
+						continue;
+					}
+					// Approximate the line's start position by assuming
+					// each of the ki preceding lookahead words consumed
+					// exactly one poem word; scoreRun (which is elision-
+					// aware) below then confirms/refines the actual run
+					// length from that assumed start.
+					int startPos = pi - (int)ki;
+					if (startPos < 0) {
+						continue;
+					}
+					int score = scoreRun(startIdx, li, startPos);
+					if (score > bestScore) {
+						bestScore = score;
+						bestLine  = li;
+						bestPos   = startPos;
+					}
+				}
+			}
+		}
+
+		if (bestScore <= 0) {
+			return false;
+		}
+		outLine = bestLine;
+		outPos  = bestPos;
+		return true;
+	};
+
+	for (size_t wi=0; wi<words.size(); wi++) {
+		SungWord& sw = words[wi];
+		if (sw.norm.empty()) {
+			continue;
+		}
+
+		int candLine = -1;
+		int candPos  = -1;
+		bool matched = false;
+		// Earliest poem position this sung word covers (equal to candPos
+		// unless the word turns out to elide two adjacent poem words
+		// together, in which case candPos advances past both while
+		// candSpanStart records where the coverage actually began).
+		int candSpanStart = -1;
+
+		// Score plausible candidate placements for this word by how many
+		// consecutive words are confirmed in the poem. A multi-word
+		// confirmed match is always preferred over a match based on a
+		// single corresponding syllable/word, no matter which kind of
+		// candidate produced it. Ties in score are broken by the priority
+		// listed below (lower is preferred).
+		struct Cand { int line=-1; int pos=-1; int score=0; int priority=99; };
+		vector<Cand> cands;
+
+		if (ptrLine < 0) {
+			// This voice's very first (non-empty) sung word: don't
+			// assume it starts at poem line 0 -- search for where this
+			// voice's opening words actually match the poem text.
+			int line=-1, pos=-1;
+			if (findInitialAnchor(wi, line, pos)) {
+				cands.push_back({line, pos, scoreRun(wi, line, pos), 0});
+			}
+		} else {
+			// forward candidate: next word in sequence.
+			int fLine, fPos;
+			if (ptrPos + 1 < lineWordCount(ptrLine)) {
+				fLine = ptrLine;
+				fPos  = ptrPos + 1;
+			} else {
+				fLine = ptrLine + 1;
+				fPos  = 0;
+			}
+			if (fLine < (int)poem.size()) {
+				int s = scoreRun(wi, fLine, fPos);
+				if (s > 0) {
+					cands.push_back({fLine, fPos, s, 0});
+				}
+			}
+
+			// skip-ahead candidates: a poem word may be skipped/elided
+			// in this voice's setting (e.g. no note assigned to it).
+			if (ptrPos + 2 < lineWordCount(ptrLine)) {
+				int maxSkip = 4;
+				for (int skip=2; skip<=maxSkip; skip++) {
+					int p = ptrPos + skip;
+					if (p >= lineWordCount(ptrLine)) {
+						break;
+					}
+					int s = scoreRun(wi, ptrLine, p);
+					if (s > 0) {
+						cands.push_back({ptrLine, p, s, 1});
+					}
+				}
+			}
+
+			// bounded backward candidates: current line up to the
+			// pointer, then the immediately preceding line.
+			int lowLine = ptrLine - 1;
+			if (lowLine < 0) {
+				lowLine = 0;
+			}
+			for (int line = ptrLine; line >= lowLine; line--) {
+				int hi = (line == ptrLine) ? ptrPos : (lineWordCount(line) - 1);
+				for (int p = hi; p >= 0; p--) {
+					int s = scoreRun(wi, line, p);
+					if (s > 0) {
+						cands.push_back({line, p, s, 2});
+					}
+				}
+			}
+
+			// A capitalized word may belong to a line that this voice
+			// skips ahead to entirely (e.g. resting through, or
+			// omitting, one or more intervening lines), and it need not
+			// land on that line's very first word either (the voice may
+			// enter only partway into the line, e.g. singing just its
+			// tail). Check every position of a short lookahead of
+			// upcoming lines for the best-confirmed placement.
+			if (sw.capitalized) {
+				int maxLineLookahead = 6;
+				for (int line = ptrLine + 1;
+						(line <= ptrLine + maxLineLookahead) && (line < (int)poem.size());
+						line++) {
+					for (int p = 0; p < lineWordCount(line); p++) {
+						int s = scoreRun(wi, line, p);
+						if (s > 0) {
+							cands.push_back({line, p, s, 3});
+						}
+					}
+				}
+			}
+		}
+
+		if (!cands.empty()) {
+			const Cand* best = &cands[0];
+			for (const Cand& c : cands) {
+				if ((c.score > best->score) ||
+						((c.score == best->score) && (c.priority < best->priority))) {
+					best = &c;
+				}
+			}
+			candLine = best->line;
+			candSpanStart = best->pos;
+			int m = matchLen(candLine, candSpanStart, sw.norm);
+			candPos = candSpanStart + std::max(m, 1) - 1;
+			matched = true;
+		}
+
+		if (!matched && sw.capitalized && (ptrLine >= 0)) {
+			// Nothing matched literally anywhere nearby: spelling of the
+			// sung syllable may not literally match the reference poem
+			// text (e.g. an archaic/dialectal variant), so treat it as a
+			// line-start: if the current line has never been sung in
+			// full yet, assume this is another attempt at that same
+			// (still unfinished) line rather than a jump ahead;
+			// otherwise move to the next line.
+			if (!lineReachedEnd(ptrLine)) {
+				candLine = ptrLine;
+				candPos  = 0;
+				matched  = true;
+			} else if (ptrLine + 1 < (int)poem.size()) {
+				candLine = ptrLine + 1;
+				candPos  = 0;
+				matched  = true;
+			}
+		}
+
+		if (!matched) {
+			// best effort: keep the original forward candidate even
+			// though the text did not match (tolerate normalization
+			// differences without losing linear progress).
+			if (ptrLine < 0) {
+				candLine = 0;
+				candPos  = 0;
+			} else if (ptrPos + 1 < lineWordCount(ptrLine)) {
+				candLine = ptrLine;
+				candPos  = ptrPos + 1;
+			} else if (ptrLine + 1 < (int)poem.size()) {
+				candLine = ptrLine + 1;
+				candPos  = 0;
+			} else {
+				candLine = ptrLine;
+				candPos  = ptrPos;
+			}
+			matched = true;
+		}
+
+		if (candSpanStart < 0) {
+			candSpanStart = candPos;
+		}
+
+		ptrLine = candLine;
+		ptrPos  = candPos;
+
+		bool curIsFull = haveSpan && (cur.startPos == 0) &&
+				(cur.endPos == lineWordCount(cur.line) - 1);
+		bool curWouldBeRepeat = haveSpan && (cur.endPos <= spanFarAtStart);
+		bool nonForward = haveSpan && (cur.line == candLine) &&
+				(curIsFull ? !curWouldBeRepeat : (candSpanStart <= cur.startPos));
+
+		if (!haveSpan || (cur.line != candLine) || nonForward) {
+			if (haveSpan) {
+				closeSpan();
+			}
+			cur = Span();
+			cur.line       = candLine;
+			cur.startPos   = candSpanStart;
+			cur.endPos     = candPos;
+			cur.startToken = sw.token;
+			haveSpan = true;
+			spanFarAtStart = farPosInLine[candLine];
+		} else {
+			if (candPos > cur.endPos) {
+				cur.endPos = candPos;
+			}
+			if (candSpanStart < cur.startPos) {
+				cur.startPos = candSpanStart;
+			}
+		}
+	}
+
+	if (haveSpan) {
+		closeSpan();
+	}
+}
+
+
+
+//////////////////////////////
+//
+// Tool_pliner::getModifier -- Compute the *pline suffix for a span:
+//    "r" if it is a repeat, plus "a"/"b"/"c" depending on whether the
+//    span starts/ends at the line boundaries (no letter if it covers the
+//    full line).
+//
+
+string Tool_pliner::getModifier(vector<vector<PoemWord>>& poem, Span& span) {
+	int lastPos = (int)poem.at(span.line).size() - 1;
+	bool startsAtBegin = (span.startPos == 0);
+	bool endsAtEnd      = (span.endPos == lastPos);
+
+	string modifier;
+	if (span.repeat) {
+		modifier += "r";
+	}
+	if (startsAtBegin && endsAtEnd) {
+		// full line: no letter suffix.
+	} else if (startsAtBegin && !endsAtEnd) {
+		modifier += "a";
+	} else if (!startsAtBegin && endsAtEnd) {
+		modifier += "b";
+	} else {
+		modifier += "c";
+	}
+	return modifier;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_pliner::emitOutput -- Stream the input file back out, injecting
+//    one synthesized interpretation line immediately before each data
+//    line that needs new *pline tokens (merging multiple voices' tokens
+//    into a single line when they coincide).
+//
+
+void Tool_pliner::emitOutput(HumdrumFile& infile, map<int, map<int, string>>& insertions) {
+	for (int i=0; i<infile.getLineCount(); i++) {
+		auto it = insertions.find(i);
+		if (it != insertions.end()) {
+			int fieldCount = infile[i].getFieldCount();
+			vector<string> fields(fieldCount, "*");
+			for (int j=0; j<fieldCount; j++) {
+				int track = infile.token(i, j)->getTrack();
+				auto tit = it->second.find(track);
+				if (tit != it->second.end()) {
+					fields[j] = tit->second;
+				}
+			}
+			for (int j=0; j<fieldCount; j++) {
+				m_humdrum_text << fields[j];
+				if (j < fieldCount - 1) {
+					m_humdrum_text << "\t";
+				}
+			}
+			m_humdrum_text << endl;
+		}
+		m_humdrum_text << infile[i] << endl;
+	}
+}
+
+
+
+
+/////////////////////////////////
+//
 // Tool_gridtest::Tool_pnum -- Set the recognized options for the tool.
 //
 

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mon Jul 27 00:10:44 CEST 2026
+// Last Modified: Mon Jul 27 00:21:27 CEST 2026
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Sat Jul 25 08:37:05 CEST 2026
+// Last Modified: Sun Jul 26 23:03:28 CEST 2026
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11
@@ -10978,7 +10978,7 @@ class Tool_pliner : public HumTool {
 			int pos    = -1;
 		};
 
-		bool     parseVerse        (HumdrumFile& infile, std::vector<std::vector<PoemWord>>& poem);
+		bool     extractPoem       (HumdrumFile& infile, std::vector<std::vector<PoemWord>>& poem);
 
 		// voice model:
 		struct Voice {
@@ -12192,9 +12192,10 @@ class Tool_textract : public HumTool {
 		void     collapseRepeats  (std::vector<SungWord>& words);
 		void     segmentLines     (Voice& voice);
 		int      lineSyllables    (const std::vector<SungWord>& line);
-		int      expectedSyllables(int lineIndex);
 		int      distanceToAllowed(int syllables);
 		bool     isAllowedLength  (int syllables, int tol = 0);
+		int      minAllowedLength (void);
+		int      maxAllowedLength (void);
 		bool     endsWithVowel    (const std::string& norm);
 		bool     startsWithVowel  (const std::string& norm);
 		bool     elidesWith       (const SungWord& left, const SungWord& right);

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mon Jul 27 13:54:29 CEST 2026
+// Last Modified: Fri Jul 31 14:13:03 CEST 2026
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Sun Jul 26 23:12:37 CEST 2026
+// Last Modified: Mon Jul 27 00:10:44 CEST 2026
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mon Jul 27 00:21:27 CEST 2026
+// Last Modified: Mon Jul 27 13:54:29 CEST 2026
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11
@@ -12207,11 +12207,14 @@ class Tool_textract : public HumTool {
 		void     dedupeVoiceLines (Voice& voice);
 		void     reconstructText  (std::vector<Voice>& voices);
 		void     refineLines      (std::vector<std::vector<SungWord>>& lines);
+		int      detectGenreLineCount(HumdrumFile& infile);
+		void     enforceLineCount (std::vector<std::vector<SungWord>>& lines);
 		std::vector<SungWord> consensusLine(LineCluster& cluster);
 		std::string lineToString  (const std::vector<SungWord>& line);
 
 	private:
 		std::vector<int> m_sylCounts; // empty = unused
+		int m_expectedLines = 0;      // 0 = unset / auto
 };
 
 

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -10956,6 +10956,68 @@ class Tool_pline : public HumTool {
 };
 
 
+class Tool_pliner : public HumTool {
+	public:
+		         Tool_pliner     (void);
+		        ~Tool_pliner     () {};
+
+		bool     run               (HumdrumFileSet& infiles);
+		bool     run               (HumdrumFile& infile);
+		bool     run               (const std::string& indata, std::ostream& out);
+		bool     run               (HumdrumFile& infile, std::ostream& out);
+
+	protected:
+		void     initialize        (void);
+		void     processFile       (HumdrumFile& infile);
+
+		// poem model:
+		struct PoemWord {
+			std::string original;
+			std::string norm;
+			int line   = -1;
+			int pos    = -1;
+		};
+
+		bool     parseVerse        (HumdrumFile& infile, std::vector<std::vector<PoemWord>>& poem);
+
+		// voice model:
+		struct Voice {
+			HTp kernStart = NULL;
+			HTp textStart = NULL;
+		};
+
+		struct SungWord {
+			HTp token       = NULL; // starting token of the reconstructed word
+			std::string norm;
+			bool capitalized = false;
+		};
+
+		struct Span {
+			int line      = -1;
+			int startPos  = -1;
+			int endPos    = -1;
+			bool repeat   = false;
+			HTp startToken = NULL;
+		};
+
+		void     getVoices          (HumdrumFile& infile, std::vector<Voice>& voices);
+		void     buildSungWords     (HTp textStart, std::vector<SungWord>& words);
+		std::string cleanSyllable   (const std::string& text);
+		std::string normalizeWord   (const std::string& text);
+		void     alignVoice         (std::vector<SungWord>& words,
+		                             std::vector<std::vector<PoemWord>>& poem,
+		                             std::vector<Span>& spans);
+		std::string getModifier     (std::vector<std::vector<PoemWord>>& poem, Span& span);
+		void     emitOutput         (HumdrumFile& infile,
+		                             std::map<int, std::map<int, std::string>>& insertions);
+
+	private:
+		std::vector<std::vector<PoemWord>> m_poem;
+		std::vector<Voice> m_voices;
+
+};
+
+
 class Tool_pnum : public HumTool {
 	public:
 		      Tool_pnum               (void);

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Mon Jul 20 10:35:12 CEST 2026
+// Last Modified: Sat Jul 25 08:37:05 CEST 2026
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11
@@ -12148,6 +12148,69 @@ class Tool_textdur : public HumTool {
 		bool m_interleaveQ   = false;  // used with -i option
 		HumNum m_RhythmFactor = 1;     // uwed with -1, -2, -8, and later -f #
 
+};
+
+
+class Tool_textract : public HumTool {
+	public:
+		         Tool_textract    (void);
+		        ~Tool_textract    () {};
+
+		bool     run              (HumdrumFileSet& infiles);
+		bool     run              (HumdrumFile& infile);
+		bool     run              (const std::string& indata, std::ostream& out);
+		bool     run              (HumdrumFile& infile, std::ostream& out);
+
+	protected:
+		struct SungWord {
+			std::string original;
+			std::string norm;
+			int  syllables   = 0;
+			bool capitalized = false;
+			bool bis         = false;
+		};
+
+		struct Voice {
+			HTp textStart = NULL;
+			std::vector<SungWord> words;
+			std::vector<std::vector<SungWord>> lines;
+		};
+
+		struct LineCluster {
+			std::vector<std::vector<SungWord>> members; // one entry per contributing voice line
+			std::vector<int> voiceIds;
+			double avgPos = 0.0;
+		};
+
+		void     initialize       (void);
+		void     processFile      (HumdrumFile& infile);
+
+		void     getVoices        (HumdrumFile& infile, std::vector<Voice>& voices);
+		void     buildSungWords   (HTp textStart, std::vector<SungWord>& words);
+		std::string normalizeWord (const std::string& text);
+		std::string cleanOrigPiece(const std::string& text);
+		void     collapseRepeats  (std::vector<SungWord>& words);
+		void     segmentLines     (Voice& voice);
+		int      lineSyllables    (const std::vector<SungWord>& line);
+		int      expectedSyllables(int lineIndex);
+		int      distanceToAllowed(int syllables);
+		bool     isAllowedLength  (int syllables, int tol = 0);
+		bool     endsWithVowel    (const std::string& norm);
+		bool     startsWithVowel  (const std::string& norm);
+		bool     elidesWith       (const SungWord& left, const SungWord& right);
+		bool     likelyLineStart  (const std::string& norm);
+		bool     linesSimilar     (const std::vector<SungWord>& a,
+		                           const std::vector<SungWord>& b);
+		bool     isSubSequence    (const std::vector<SungWord>& shorter,
+		                           const std::vector<SungWord>& longer);
+		void     dedupeVoiceLines (Voice& voice);
+		void     reconstructText  (std::vector<Voice>& voices);
+		void     refineLines      (std::vector<std::vector<SungWord>>& lines);
+		std::vector<SungWord> consensusLine(LineCluster& cluster);
+		std::string lineToString  (const std::vector<SungWord>& line);
+
+	private:
+		std::vector<int> m_sylCounts; // empty = unused
 };
 
 

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Sun Jul 26 23:03:28 CEST 2026
+// Last Modified: Sun Jul 26 23:12:37 CEST 2026
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11

--- a/src/tool-pliner.cpp
+++ b/src/tool-pliner.cpp
@@ -6,15 +6,17 @@
 // vim:           ts=3 noexpandtab
 //
 // Description:   Insert *pline poetic-line annotations into a **kern score
-//                by aligning the sung **text declamation of each voice
-//                against a poem given in a !!@VERSE: global comment block.
+//                by aligning each voice's **text declamation against the
+//                poem reconstructed by textract from the underlay.
 //
 
 #include "tool-pliner.h"
+#include "tool-textract.h"
 #include "HumRegex.h"
 
 #include <algorithm>
 #include <cctype>
+#include <sstream>
 
 using namespace std;
 
@@ -29,7 +31,7 @@ namespace hum {
 //
 
 Tool_pliner::Tool_pliner(void) {
-	// no options currently defined.
+	define("s|syllables|syl=s:", "allowed line lengths passed to textract (comma-separated set; e.g. 7,11)");
 }
 
 
@@ -99,9 +101,8 @@ void Tool_pliner::processFile(HumdrumFile& infile) {
 	m_poem.clear();
 	m_voices.clear();
 
-	bool haveVerse = parseVerse(infile, m_poem);
-	if (!haveVerse) {
-		// Nothing to do: no !!@VERSE: block found, so echo input unchanged.
+	bool havePoem = extractPoem(infile, m_poem);
+	if (!havePoem) {
 		m_humdrum_text << infile;
 		return;
 	}
@@ -160,59 +161,38 @@ void Tool_pliner::processFile(HumdrumFile& infile) {
 
 //////////////////////////////
 //
-// Tool_pliner::parseVerse -- Extract the poem lines/words from the
-//    !!@VERSE: global comment block.  The block starts on a line matching
-//    "!!@VERSE:" and continues on subsequent "!!<text>" global comment
-//    lines (not starting with another "!!@" tag) until the first line that
-//    does not match that pattern (typically a blank "!!" separator line or
-//    the next "!!@" tag).
+// Tool_pliner::extractPoem -- Reconstruct the poem via textract and
+//    split it into normalized PoemWord lines for alignment.
 //
 
-bool Tool_pliner::parseVerse(HumdrumFile& infile, vector<vector<PoemWord>>& poem) {
+bool Tool_pliner::extractPoem(HumdrumFile& infile, vector<vector<PoemWord>>& poem) {
 	poem.clear();
-	HumRegex hre;
 
-	int verseLine = -1;
-	for (int i=0; i<infile.getLineCount(); i++) {
-		if (!infile[i].isCommentGlobal()) {
-			continue;
-		}
-		HTp token = infile.token(i, 0);
-		if (hre.search(token, "^!!@VERSE:\\s*$")) {
-			verseLine = i;
-			break;
-		}
+	Tool_textract textract;
+	vector<string> argv;
+	argv.push_back("textract");
+	if (getBoolean("syllables")) {
+		argv.push_back("-s");
+		argv.push_back(getString("syllables"));
 	}
-	if (verseLine < 0) {
+	textract.process(argv);
+	textract.run(infile);
+
+	string text = textract.getFreeText();
+	if (text.empty()) {
 		return false;
 	}
 
+	HumRegex hre;
+	istringstream stream(text);
+	string line;
 	int lineNum = 0;
-	for (int i=verseLine+1; i<infile.getLineCount(); i++) {
-		if (!infile[i].isCommentGlobal()) {
-			break;
-		}
-		HTp token = infile.token(i, 0);
-		string text = *token;
-		if (hre.search(text, "^!!@VERSE:\\s*$")) {
-			// A poem may be split across multiple stanzas, each
-			// re-introduced by its own repeated "!!@VERSE:" tag; treat
-			// this as a stanza separator and keep collecting lines
-			// rather than stopping the poem here.
+	while (getline(stream, line)) {
+		if (line.empty()) {
 			continue;
 		}
-		if (hre.search(text, "^!!@")) {
-			// start of a different tagged section (e.g. "!!@TVERSE:").
-			break;
-		}
-		if (!hre.search(text, "^!!\\s*(\\S.*)$")) {
-			// blank "!!" separator line (or malformed line): end of poem.
-			break;
-		}
-		string content = hre.getMatch(1);
-
 		vector<string> rawwords;
-		hre.split(rawwords, content, "\\s+");
+		hre.split(rawwords, line, "\\s+");
 
 		vector<PoemWord> lineWords;
 		for (string& w : rawwords) {
@@ -224,12 +204,6 @@ bool Tool_pliner::parseVerse(HumdrumFile& infile, vector<vector<PoemWord>>& poem
 				continue;
 			}
 			if ((norm[0] == '\'') && !lineWords.empty()) {
-				// A word-initial apostrophe with nothing before it (e.g.
-				// the "'n" in "E 'n mia ragion...") is a typographical
-				// elision split off from the previous word by whitespace
-				// in the verse text; rejoin it so that "E" + "'n" reads
-				// as the single elided word "e'n", matching how the
-				// same elision is sung as one word in the **text spines.
 				lineWords.back().norm += norm;
 				lineWords.back().original += " " + w;
 				continue;
@@ -438,6 +412,33 @@ void Tool_pliner::buildSungWords(HTp textStart, vector<SungWord>& words) {
 				accum += normalizeWord(part);
 				if (!trailingDash) {
 					finalize();
+				}
+			} else if (wordOpen && !leadingDash) {
+				// Trailing '-' on the previous syllable already marked the
+				// word open; some files omit the leading '-' on the next
+				// syllable (e.g. "Quan-" / "d'ec-").  Continue unless this
+				// part clearly starts a new word (capital letter).
+				bool newCap = false;
+				for (char c : core) {
+					if (isalpha((unsigned char)c)) {
+						newCap = isupper((unsigned char)c) != 0;
+						break;
+					}
+				}
+				if (!newCap) {
+					accum += normalizeWord(part);
+					if (!trailingDash) {
+						finalize();
+					}
+				} else {
+					finalize();
+					startToken = cur;
+					accum = normalizeWord(part);
+					capitalized = true;
+					wordOpen = true;
+					if (!trailingDash) {
+						finalize();
+					}
 				}
 			} else {
 				// starts a new word (closing any dangling previous word).
@@ -764,16 +765,20 @@ void Tool_pliner::alignVoice(vector<SungWord>& words, vector<vector<PoemWord>>& 
 			// enter only partway into the line, e.g. singing just its
 			// tail).  Check every position of a short lookahead of
 			// upcoming lines for the best-confirmed placement.
-			if (sw.capitalized) {
-				int maxLineLookahead = 6;
-				for (int line = ptrLine + 1;
-						(line <= ptrLine + maxLineLookahead) && (line < (int)poem.size());
-						line++) {
-					for (int p = 0; p < lineWordCount(line); p++) {
-						int s = scoreRun(wi, line, p);
-						if (s > 0) {
-							cands.push_back({line, p, s, 3});
-						}
+			//
+			// Non-capitalized words can also land mid-line ahead of the
+			// pointer (e.g. singing "stille di gielo" of line 5 before
+			// that line's opening "Quand'ecco").  Search them too, but
+			// with lower priority so linear progress still wins ties.
+			int maxLineLookahead = sw.capitalized ? 6 : 2;
+			int lookaheadPriority = sw.capitalized ? 3 : 4;
+			for (int line = ptrLine + 1;
+					(line <= ptrLine + maxLineLookahead) && (line < (int)poem.size());
+					line++) {
+				for (int p = 0; p < lineWordCount(line); p++) {
+					int s = scoreRun(wi, line, p);
+					if (s > 0) {
+						cands.push_back({line, p, s, lookaheadPriority});
 					}
 				}
 			}

--- a/src/tool-pliner.cpp
+++ b/src/tool-pliner.cpp
@@ -1,0 +1,964 @@
+//
+// Programmer:    Alexander Morgan
+// Creation Date: Wed Jul 15 2026
+// Filename:      tool-pliner.cpp
+// Syntax:        C++11; humlib
+// vim:           ts=3 noexpandtab
+//
+// Description:   Insert *pline poetic-line annotations into a **kern score
+//                by aligning the sung **text declamation of each voice
+//                against a poem given in a !!@VERSE: global comment block.
+//
+
+#include "tool-pliner.h"
+#include "HumRegex.h"
+
+#include <algorithm>
+#include <cctype>
+
+using namespace std;
+
+namespace hum {
+
+// START_MERGE
+
+
+/////////////////////////////////
+//
+// Tool_pliner::Tool_pliner -- Set the recognized options for the tool.
+//
+
+Tool_pliner::Tool_pliner(void) {
+	// no options currently defined.
+}
+
+
+
+/////////////////////////////////
+//
+// Tool_pliner::run -- Do the main work of the tool.
+//
+
+bool Tool_pliner::run(HumdrumFileSet& infiles) {
+	bool status = true;
+	for (int i=0; i<infiles.getCount(); i++) {
+		status &= run(infiles[i]);
+	}
+	return status;
+}
+
+
+bool Tool_pliner::run(const string& indata, ostream& out) {
+	HumdrumFile infile(indata);
+	bool status = run(infile);
+	if (hasAnyText()) {
+		getAllText(out);
+	} else {
+		out << infile;
+	}
+	return status;
+}
+
+
+bool Tool_pliner::run(HumdrumFile& infile, ostream& out) {
+	bool status = run(infile);
+	if (hasAnyText()) {
+		getAllText(out);
+	} else {
+		out << infile;
+	}
+	return status;
+}
+
+
+bool Tool_pliner::run(HumdrumFile& infile) {
+	initialize();
+	processFile(infile);
+	return true;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_pliner::initialize --
+//
+
+void Tool_pliner::initialize(void) {
+	// nothing to do yet.
+}
+
+
+
+//////////////////////////////
+//
+// Tool_pliner::processFile --
+//
+
+void Tool_pliner::processFile(HumdrumFile& infile) {
+	m_poem.clear();
+	m_voices.clear();
+
+	bool haveVerse = parseVerse(infile, m_poem);
+	if (!haveVerse) {
+		// Nothing to do: no !!@VERSE: block found, so echo input unchanged.
+		m_humdrum_text << infile;
+		return;
+	}
+
+	getVoices(infile, m_voices);
+
+	if (getenv("PLINER_DEBUG")) {
+		for (size_t li=0; li<m_poem.size(); li++) {
+			cerr << "POEM line=" << li << ":";
+			for (auto& pw : m_poem[li]) {
+				cerr << " [" << pw.norm << "]";
+			}
+			cerr << endl;
+		}
+	}
+
+	map<int, map<int, string>> insertions;
+
+	for (Voice& voice : m_voices) {
+		vector<SungWord> words;
+		buildSungWords(voice.textStart, words);
+
+		if (getenv("PLINER_DEBUG")) {
+			cerr << "VOICE track=" << voice.kernStart->getTrack() << endl;
+			for (auto& w : words) {
+				cerr << "  word=[" << w.norm << "] cap=" << w.capitalized
+				     << " line=" << w.token->getLineIndex() << endl;
+			}
+		}
+
+		vector<Span> spans;
+		alignVoice(words, m_poem, spans);
+
+		int kernTrack = voice.kernStart->getTrack();
+		int textTrack = voice.textStart->getTrack();
+
+		for (Span& span : spans) {
+			if (!span.startToken) {
+				continue;
+			}
+			if ((span.line < 0) || (span.line >= (int)m_poem.size())) {
+				continue;
+			}
+			string modifier = getModifier(m_poem, span);
+			string text = "*pline:" + to_string(span.line + 1) + modifier;
+			int li = span.startToken->getLineIndex();
+			insertions[li][kernTrack] = text;
+			insertions[li][textTrack] = text;
+		}
+	}
+
+	emitOutput(infile, insertions);
+}
+
+
+
+//////////////////////////////
+//
+// Tool_pliner::parseVerse -- Extract the poem lines/words from the
+//    !!@VERSE: global comment block.  The block starts on a line matching
+//    "!!@VERSE:" and continues on subsequent "!!<text>" global comment
+//    lines (not starting with another "!!@" tag) until the first line that
+//    does not match that pattern (typically a blank "!!" separator line or
+//    the next "!!@" tag).
+//
+
+bool Tool_pliner::parseVerse(HumdrumFile& infile, vector<vector<PoemWord>>& poem) {
+	poem.clear();
+	HumRegex hre;
+
+	int verseLine = -1;
+	for (int i=0; i<infile.getLineCount(); i++) {
+		if (!infile[i].isCommentGlobal()) {
+			continue;
+		}
+		HTp token = infile.token(i, 0);
+		if (hre.search(token, "^!!@VERSE:\\s*$")) {
+			verseLine = i;
+			break;
+		}
+	}
+	if (verseLine < 0) {
+		return false;
+	}
+
+	int lineNum = 0;
+	for (int i=verseLine+1; i<infile.getLineCount(); i++) {
+		if (!infile[i].isCommentGlobal()) {
+			break;
+		}
+		HTp token = infile.token(i, 0);
+		string text = *token;
+		if (hre.search(text, "^!!@VERSE:\\s*$")) {
+			// A poem may be split across multiple stanzas, each
+			// re-introduced by its own repeated "!!@VERSE:" tag; treat
+			// this as a stanza separator and keep collecting lines
+			// rather than stopping the poem here.
+			continue;
+		}
+		if (hre.search(text, "^!!@")) {
+			// start of a different tagged section (e.g. "!!@TVERSE:").
+			break;
+		}
+		if (!hre.search(text, "^!!\\s*(\\S.*)$")) {
+			// blank "!!" separator line (or malformed line): end of poem.
+			break;
+		}
+		string content = hre.getMatch(1);
+
+		vector<string> rawwords;
+		hre.split(rawwords, content, "\\s+");
+
+		vector<PoemWord> lineWords;
+		for (string& w : rawwords) {
+			if (w.empty()) {
+				continue;
+			}
+			string norm = normalizeWord(w);
+			if (norm.empty()) {
+				continue;
+			}
+			if ((norm[0] == '\'') && !lineWords.empty()) {
+				// A word-initial apostrophe with nothing before it (e.g.
+				// the "'n" in "E 'n mia ragion...") is a typographical
+				// elision split off from the previous word by whitespace
+				// in the verse text; rejoin it so that "E" + "'n" reads
+				// as the single elided word "e'n", matching how the
+				// same elision is sung as one word in the **text spines.
+				lineWords.back().norm += norm;
+				lineWords.back().original += " " + w;
+				continue;
+			}
+			PoemWord pw;
+			pw.original = w;
+			pw.norm = norm;
+			pw.line = lineNum;
+			pw.pos = (int)lineWords.size();
+			lineWords.push_back(pw);
+		}
+
+		if (!lineWords.empty()) {
+			poem.push_back(lineWords);
+			lineNum++;
+		}
+	}
+
+	return !poem.empty();
+}
+
+
+
+//////////////////////////////
+//
+// Tool_pliner::getVoices -- Identify each **kern spine paired with the
+//    **text spine that immediately follows it (the convention used
+//    throughout this corpus).
+//
+
+void Tool_pliner::getVoices(HumdrumFile& infile, vector<Voice>& voices) {
+	voices.clear();
+	vector<HTp> starts;
+	infile.getSpineStartList(starts);
+
+	for (int i=0; i<(int)starts.size(); i++) {
+		if (!starts[i]->isKern()) {
+			continue;
+		}
+		Voice voice;
+		voice.kernStart = starts[i];
+		if ((i + 1 < (int)starts.size()) && starts[i+1]->isDataType("**text")) {
+			voice.textStart = starts[i+1];
+		}
+		if (voice.textStart) {
+			voices.push_back(voice);
+		}
+	}
+}
+
+
+
+//////////////////////////////
+//
+// Tool_pliner::normalizeWord -- Lower-case (ASCII only, to avoid
+//    corrupting multi-byte UTF-8 accented characters) and strip common
+//    punctuation/markers so that sung syllables and poem words can be
+//    compared for equality.  Apostrophes are preserved since they are
+//    meaningful within Italian elisions (e.g. "l'alma").  Accented
+//    vowels (a grave/acute, e grave/acute, etc., encoded as two-byte
+//    UTF-8 sequences) are folded down to their plain-vowel equivalent,
+//    since the sung **text underlay and the reference !!@VERSE: text
+//    frequently disagree on whether/which accent to write for the same
+//    word (e.g. poem "e`" vs. sung "e"), and such spelling differences
+//    should not block an otherwise correct word match.
+//
+
+string Tool_pliner::normalizeWord(const string& text) {
+	string out;
+	for (size_t i=0; i<text.size(); i++) {
+		unsigned char c = (unsigned char)text[i];
+		if ((c == '<') || (c == '>')) {
+			continue;
+		}
+		if ((c == ',') || (c == '.') || (c == ':') || (c == ';') ||
+				(c == '!') || (c == '?') || (c == '"')) {
+			continue;
+		}
+		if ((c == 0xC3) && (i + 1 < text.size())) {
+			unsigned char c2 = (unsigned char)text[i+1];
+			char folded = 0;
+			switch (c2) {
+				case 0x80: case 0x81: case 0xA0: case 0xA1: folded = 'a'; break; // A/a grave/acute
+				case 0x88: case 0x89: case 0xA8: case 0xA9: folded = 'e'; break; // E/e grave/acute
+				case 0x8C: case 0x8D: case 0xAC: case 0xAD: folded = 'i'; break; // I/i grave/acute
+				case 0x92: case 0x93: case 0xB2: case 0xB3: folded = 'o'; break; // O/o grave/acute
+				case 0x99: case 0x9A: case 0xB9: case 0xBA: folded = 'u'; break; // U/u grave/acute
+			}
+			if (folded) {
+				out += folded;
+				i++;
+				continue;
+			}
+		}
+		if ((c >= 'A') && (c <= 'Z')) {
+			out += (char)(c - 'A' + 'a');
+		} else {
+			out += (char)c;
+		}
+	}
+	while (!out.empty() && (out.front() == '-')) {
+		out.erase(out.begin());
+	}
+	while (!out.empty() && (out.back() == '-')) {
+		out.pop_back();
+	}
+	return out;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_pliner::cleanSyllable -- (unused helper retained for API symmetry
+//    with normalizeWord; currently a synonym).
+//
+
+string Tool_pliner::cleanSyllable(const string& text) {
+	return normalizeWord(text);
+}
+
+
+
+//////////////////////////////
+//
+// Tool_pliner::buildSungWords -- Walk a **text spine and reconstruct
+//    complete words from (possibly hyphenated) syllable tokens, recording
+//    the token where each word starts and whether the raw syllable began
+//    with a capital letter.
+//
+
+void Tool_pliner::buildSungWords(HTp textStart, vector<SungWord>& words) {
+	words.clear();
+	if (!textStart) {
+		return;
+	}
+
+	auto endsWithContinuationDash = [](const string& s) {
+		string tmp = s;
+		while (!tmp.empty()) {
+			char c = tmp.back();
+			if ((c == ',') || (c == '.') || (c == ':') || (c == ';') ||
+					(c == '!') || (c == '?') || (c == '"') || (c == '>')) {
+				tmp.pop_back();
+				continue;
+			}
+			break;
+		}
+		return !tmp.empty() && (tmp.back() == '-');
+	};
+
+	bool wordOpen = false;
+	string accum;
+	HTp startToken = NULL;
+	bool capitalized = false;
+
+	auto finalize = [&]() {
+		if (wordOpen && !accum.empty()) {
+			SungWord sw;
+			sw.token = startToken;
+			sw.norm = accum;
+			sw.capitalized = capitalized;
+			words.push_back(sw);
+		}
+		wordOpen = false;
+		accum.clear();
+		startToken = NULL;
+		capitalized = false;
+	};
+
+	HTp cur = textStart;
+	while (cur) {
+		if (!cur->isData() || cur->isNull()) {
+			cur = cur->getNextToken();
+			continue;
+		}
+
+		string raw = *cur;
+
+		// A single note token can contain two syllables separated by a
+		// literal space: the tail end of the previous word followed by
+		// the start of the next word (e.g. "-ci as-").
+		vector<string> parts;
+		size_t pos = 0;
+		while (pos <= raw.size()) {
+			size_t sp = raw.find(' ', pos);
+			if (sp == string::npos) {
+				parts.push_back(raw.substr(pos));
+				break;
+			}
+			parts.push_back(raw.substr(pos, sp - pos));
+			pos = sp + 1;
+		}
+
+		for (int idx=0; idx<(int)parts.size(); idx++) {
+			string part = parts[idx];
+			string core = part;
+			if (!core.empty() && (core[0] == '<')) {
+				core = core.substr(1);
+			}
+			bool leadingDash = !core.empty() && (core[0] == '-');
+			bool trailingDash = endsWithContinuationDash(core);
+
+			if ((idx == 0) && wordOpen && leadingDash) {
+				// continuation of the currently open word.
+				accum += normalizeWord(part);
+				if (!trailingDash) {
+					finalize();
+				}
+			} else {
+				// starts a new word (closing any dangling previous word).
+				if (wordOpen) {
+					finalize();
+				}
+				startToken = cur;
+				accum = normalizeWord(part);
+				capitalized = false;
+				for (char c : core) {
+					if (isalpha((unsigned char)c)) {
+						capitalized = isupper((unsigned char)c) != 0;
+						break;
+					}
+				}
+				if (trailingDash) {
+					wordOpen = true;
+				} else {
+					wordOpen = true; // set so finalize() will push it
+					finalize();
+				}
+			}
+		}
+
+		cur = cur->getNextToken();
+	}
+
+	finalize();
+}
+
+
+
+//////////////////////////////
+//
+// Tool_pliner::alignVoice -- Align a voice's sequence of sung words
+//    against the poem, tracking a mostly-forward-moving pointer (repeats
+//    are assumed to stay close by: within the current line or the
+//    immediately preceding line), rather than depending on any
+//    pre-existing editorial markup.  Runs of consecutive words assigned
+//    to the same (line, repeat-state) are collapsed into "spans"; each
+//    span marks one *pline transition.
+//
+//    A span only counts as a repeat ("r") if it does not, by the time it
+//    ends, reach any further into the line than this voice had already
+//    reached before that span began.  This means that an opening
+//    partial ("a"/"b"/"c") block sung before the line has ever been
+//    completed is not a repeat (there is nothing yet to repeat), even if
+//    a later block re-covers that same partial ground again (that later
+//    block *is* a repeat, since it does not go beyond what was already
+//    reached); but the block that eventually pushes on to complete the
+//    line for the first time is not a repeat either, even though it
+//    starts by re-treading already-sung words, because it ends up
+//    covering new ground.
+//
+
+void Tool_pliner::alignVoice(vector<SungWord>& words, vector<vector<PoemWord>>& poem,
+		vector<Span>& spans) {
+	spans.clear();
+	if (poem.empty() || words.empty()) {
+		return;
+	}
+
+	auto lineWordCount = [&](int line) {
+		return (int)poem.at(line).size();
+	};
+
+	int ptrLine = -1;
+	int ptrPos  = -1;
+
+	// tracks, per poem line, the furthest word position this voice has
+	// reached in that line so far (across any span, repeat or not).
+	vector<int> farPosInLine(poem.size(), -1);
+
+	bool haveSpan = false;
+	Span cur;
+	int spanFarAtStart = -1;
+
+	// Furthest position reached in a line, including any progress made
+	// so far in the still-open current span (which has not yet been
+	// committed to farPosInLine via closeSpan()).
+	auto farReached = [&](int line) {
+		int far = farPosInLine.at(line);
+		if (haveSpan && (cur.line == line) && (cur.endPos > far)) {
+			far = cur.endPos;
+		}
+		return far;
+	};
+
+	auto lineReachedEnd = [&](int line) {
+		return farReached(line) >= lineWordCount(line) - 1;
+	};
+
+	// Occasionally the sung setting elides two adjacent poem words into a
+	// single unbroken melisma with no textual break between them (e.g.
+	// "Tanti n'aggiungi" sung as one continuous "tantin'aggiungi").  This
+	// checks whether a normalized sung word (norm) matches the poem word
+	// at (line, pos), optionally also swallowing the next poem word too;
+	// returns 0 (no match), 1 (matches just poem[line][pos]), or 2
+	// (matches the concatenation of poem[line][pos] and poem[line][pos+1]).
+	auto matchLen = [&](int line, int pos, const string& norm) -> int {
+		if ((line < 0) || (line >= (int)poem.size())) {
+			return 0;
+		}
+		if ((pos < 0) || (pos >= lineWordCount(line))) {
+			return 0;
+		}
+		if (poem[line][pos].norm == norm) {
+			return 1;
+		}
+		if (pos + 1 < lineWordCount(line)) {
+			const string& w1 = poem[line][pos].norm;
+			const string& w2 = poem[line][pos+1].norm;
+			if ((w1 + w2) == norm) {
+				return 2;
+			}
+			// Elision contracted across a word boundary that the poem
+			// text itself did not mark with an apostrophe (e.g. "Gli
+			// occhi" written as two separate words but sung/contracted
+			// as "Gl'occhi", dropping the final vowel of the first
+			// word).  If the sung word contains an apostrophe, treat
+			// the part before it as a (possibly truncated) prefix of
+			// the first poem word and the part after it as the second
+			// poem word.
+			size_t apos = norm.find('\'');
+			if (apos != string::npos) {
+				string left  = norm.substr(0, apos);
+				string right = norm.substr(apos + 1);
+				if (!left.empty() && !right.empty() &&
+						(w1.rfind(left, 0) == 0) && (w2 == right)) {
+					return 2;
+				}
+			}
+		}
+		return 0;
+	};
+
+	auto closeSpan = [&]() {
+		cur.repeat = (cur.endPos <= spanFarAtStart);
+		if (cur.endPos > farPosInLine[cur.line]) {
+			farPosInLine[cur.line] = cur.endPos;
+		}
+		spans.push_back(cur);
+	};
+
+	// Scores a candidate placement (line, pos) for the sung word at index
+	// wi by counting how many consecutive sung words (starting at wi,
+	// skipping empties, tolerating word-eliding/apostrophe-contraction
+	// via matchLen) match the poem starting there.  A candidate whose
+	// very first word does not match scores 0.  Capped at a handful of
+	// words since that is already enough to confidently distinguish a
+	// real match from a coincidental one-word overlap (e.g. two
+	// different poem lines both starting with the same short word like
+	// "E").
+	auto scoreRun = [&](size_t wi, int line, int pos) -> int {
+		const int maxRun = 4;
+		int score = 0;
+		size_t k  = wi;
+		int p = pos;
+		while (score < maxRun) {
+			while ((k < words.size()) && words[k].norm.empty()) {
+				k++;
+			}
+			if (k >= words.size()) {
+				break;
+			}
+			int m = matchLen(line, p, words[k].norm);
+			if (m <= 0) {
+				break;
+			}
+			score++;
+			p += m;
+			k++;
+		}
+		return score;
+	};
+
+	// A voice may enter partway through the poem (e.g. a later voice in
+	// an imitative texture that skips the opening line(s) entirely).
+	// Rather than always anchoring a voice's very first sung word to
+	// poem line 0, search a short lookahead window of this voice's
+	// opening words for the (line, pos) placement that gives the best
+	// run of consecutive matches (elision-tolerant, via matchLen/
+	// scoreRun), and anchor there instead.  If nothing matches at all
+	// within the lookahead, fall back to (0, 0) as a last resort.
+	auto findInitialAnchor = [&](size_t startIdx, int& outLine, int& outPos) -> bool {
+		const int maxLookahead = 6;
+		vector<size_t> idxs;
+		for (size_t k=startIdx; (k<words.size()) && (idxs.size()<(size_t)maxLookahead); k++) {
+			if (!words[k].norm.empty()) {
+				idxs.push_back(k);
+			}
+		}
+		if (idxs.empty()) {
+			return false;
+		}
+
+		int bestScore = 0;
+		int bestLine  = -1;
+		int bestPos   = -1;
+		for (size_t ki=0; ki<idxs.size(); ki++) {
+			const string& norm = words[idxs[ki]].norm;
+			for (int li=0; li<(int)poem.size(); li++) {
+				for (int pi=0; pi<lineWordCount(li); pi++) {
+					if (matchLen(li, pi, norm) <= 0) {
+						continue;
+					}
+					// Approximate the line's start position by assuming
+					// each of the ki preceding lookahead words consumed
+					// exactly one poem word; scoreRun (which is elision-
+					// aware) below then confirms/refines the actual run
+					// length from that assumed start.
+					int startPos = pi - (int)ki;
+					if (startPos < 0) {
+						continue;
+					}
+					int score = scoreRun(startIdx, li, startPos);
+					if (score > bestScore) {
+						bestScore = score;
+						bestLine  = li;
+						bestPos   = startPos;
+					}
+				}
+			}
+		}
+
+		if (bestScore <= 0) {
+			return false;
+		}
+		outLine = bestLine;
+		outPos  = bestPos;
+		return true;
+	};
+
+	for (size_t wi=0; wi<words.size(); wi++) {
+		SungWord& sw = words[wi];
+		if (sw.norm.empty()) {
+			continue;
+		}
+
+		int candLine = -1;
+		int candPos  = -1;
+		bool matched = false;
+		// Earliest poem position this sung word covers (equal to candPos
+		// unless the word turns out to elide two adjacent poem words
+		// together, in which case candPos advances past both while
+		// candSpanStart records where the coverage actually began).
+		int candSpanStart = -1;
+
+		// Gather every plausible candidate placement for this word and
+		// score each by how many consecutive words it (and the words
+		// that follow) actually confirm in the poem.  A multi-word
+		// confirmed match is always preferred over a match based on a
+		// single corresponding syllable/word, no matter which kind of
+		// candidate (forward continuation, skipped-word, backward
+		// repeat, or a jump to a later line) produced it; a single-word
+		// match is only used as a fallback when nothing stronger can be
+		// found anywhere.  Ties in score are broken by the priority
+		// listed below (lower is preferred), reflecting that the text
+		// declamation is almost always linear.
+		struct Cand { int line=-1; int pos=-1; int score=0; int priority=99; };
+		vector<Cand> cands;
+
+		if (ptrLine < 0) {
+			// This voice's very first (non-empty) sung word: don't
+			// assume it starts at poem line 0 -- search for where this
+			// voice's opening words actually match the poem text.
+			int line=-1, pos=-1;
+			if (findInitialAnchor(wi, line, pos)) {
+				cands.push_back({line, pos, scoreRun(wi, line, pos), 0});
+			}
+		} else {
+			// forward candidate: next word in sequence.
+			int fLine, fPos;
+			if (ptrPos + 1 < lineWordCount(ptrLine)) {
+				fLine = ptrLine;
+				fPos  = ptrPos + 1;
+			} else {
+				fLine = ptrLine + 1;
+				fPos  = 0;
+			}
+			if (fLine < (int)poem.size()) {
+				int s = scoreRun(wi, fLine, fPos);
+				if (s > 0) {
+					cands.push_back({fLine, fPos, s, 0});
+				}
+			}
+
+			// skip-ahead candidates: a poem word may be skipped/elided
+			// in this voice's setting (e.g. no note assigned to it).
+			if (ptrPos + 2 < lineWordCount(ptrLine)) {
+				int maxSkip = 4;
+				for (int skip=2; skip<=maxSkip; skip++) {
+					int p = ptrPos + skip;
+					if (p >= lineWordCount(ptrLine)) {
+						break;
+					}
+					int s = scoreRun(wi, ptrLine, p);
+					if (s > 0) {
+						cands.push_back({ptrLine, p, s, 1});
+					}
+				}
+			}
+
+			// bounded backward candidates: current line up to the
+			// pointer, then the immediately preceding line.
+			int lowLine = ptrLine - 1;
+			if (lowLine < 0) {
+				lowLine = 0;
+			}
+			for (int line = ptrLine; line >= lowLine; line--) {
+				int hi = (line == ptrLine) ? ptrPos : (lineWordCount(line) - 1);
+				for (int p = hi; p >= 0; p--) {
+					int s = scoreRun(wi, line, p);
+					if (s > 0) {
+						cands.push_back({line, p, s, 2});
+					}
+				}
+			}
+
+			// A capitalized word may belong to a line that this voice
+			// skips ahead to entirely (e.g. resting through, or
+			// omitting, one or more intervening lines), and it need not
+			// land on that line's very first word either (the voice may
+			// enter only partway into the line, e.g. singing just its
+			// tail).  Check every position of a short lookahead of
+			// upcoming lines for the best-confirmed placement.
+			if (sw.capitalized) {
+				int maxLineLookahead = 6;
+				for (int line = ptrLine + 1;
+						(line <= ptrLine + maxLineLookahead) && (line < (int)poem.size());
+						line++) {
+					for (int p = 0; p < lineWordCount(line); p++) {
+						int s = scoreRun(wi, line, p);
+						if (s > 0) {
+							cands.push_back({line, p, s, 3});
+						}
+					}
+				}
+			}
+		}
+
+		if (!cands.empty()) {
+			const Cand* best = &cands[0];
+			for (const Cand& c : cands) {
+				if ((c.score > best->score) ||
+						((c.score == best->score) && (c.priority < best->priority))) {
+					best = &c;
+				}
+			}
+			candLine = best->line;
+			candSpanStart = best->pos;
+			int m = matchLen(candLine, candSpanStart, sw.norm);
+			candPos = candSpanStart + std::max(m, 1) - 1;
+			matched = true;
+		}
+
+		if (!matched && sw.capitalized && (ptrLine >= 0)) {
+			// Nothing matched literally anywhere nearby: spelling of the
+			// sung syllable may not literally match the reference poem
+			// text (e.g. an archaic/dialectal variant), so treat it as a
+			// line-start: if the current line has never been sung in
+			// full yet, assume this is another attempt at that same
+			// (still unfinished) line rather than a jump ahead;
+			// otherwise move to the next line.
+			if (!lineReachedEnd(ptrLine)) {
+				candLine = ptrLine;
+				candPos  = 0;
+				matched  = true;
+			} else if (ptrLine + 1 < (int)poem.size()) {
+				candLine = ptrLine + 1;
+				candPos  = 0;
+				matched  = true;
+			}
+		}
+
+		if (!matched) {
+			// best effort: keep the original forward candidate even
+			// though the text did not match (tolerate normalization
+			// differences without losing linear progress).
+			if (ptrLine < 0) {
+				candLine = 0;
+				candPos  = 0;
+			} else if (ptrPos + 1 < lineWordCount(ptrLine)) {
+				candLine = ptrLine;
+				candPos  = ptrPos + 1;
+			} else if (ptrLine + 1 < (int)poem.size()) {
+				candLine = ptrLine + 1;
+				candPos  = 0;
+			} else {
+				candLine = ptrLine;
+				candPos  = ptrPos;
+			}
+			matched = true;
+		}
+
+		if (candSpanStart < 0) {
+			candSpanStart = candPos;
+		}
+
+		ptrLine = candLine;
+		ptrPos  = candPos;
+
+		// Landing back at or before the position where the current span
+		// itself began (within the same line) marks the start of a
+		// fresh declamation block (e.g. two separate partial attempts
+		// at a line before it has ever been completed in full, or two
+		// separate full repeats of a line separated by a rest).  A
+		// backward step that stays strictly after the span's own start
+		// (e.g. immediately re-singing the tail end of a line, or a
+		// word repeated for emphasis) is treated as a decorative
+		// extension of the same ongoing statement instead -- unless the
+		// current span has already covered the line in full, in which
+		// case a backward step all the way back to the line's own
+		// start still begins a new (fresh, complete) statement.  A
+		// lesser backward step (a tail-only fragment sung again right
+		// after a full statement) is split out into its own *pline
+		// transition only if that preceding full statement was itself
+		// the line's original (non-repeat) statement -- i.e. this tail
+		// fragment is the line's first true repeat and deserves its
+		// own tag.  If the preceding full statement was already itself
+		// a repeat, a further tail-only echo right after it is instead
+		// treated as a decorative extension folded into that span.
+		bool curIsFull = haveSpan && (cur.startPos == 0) &&
+				(cur.endPos == lineWordCount(cur.line) - 1);
+		bool curWouldBeRepeat = haveSpan && (cur.endPos <= spanFarAtStart);
+		bool nonForward = haveSpan && (cur.line == candLine) &&
+				(curIsFull ? !curWouldBeRepeat : (candSpanStart <= cur.startPos));
+
+		if (!haveSpan || (cur.line != candLine) || nonForward) {
+			if (haveSpan) {
+				closeSpan();
+			}
+			cur = Span();
+			cur.line       = candLine;
+			cur.startPos   = candSpanStart;
+			cur.endPos     = candPos;
+			cur.startToken = sw.token;
+			haveSpan = true;
+			spanFarAtStart = farPosInLine[candLine];
+		} else {
+			if (candPos > cur.endPos) {
+				cur.endPos = candPos;
+			}
+			if (candSpanStart < cur.startPos) {
+				cur.startPos = candSpanStart;
+			}
+		}
+	}
+
+	if (haveSpan) {
+		closeSpan();
+	}
+}
+
+
+
+//////////////////////////////
+//
+// Tool_pliner::getModifier -- Compute the *pline suffix for a span:
+//    "r" if it is a repeat, plus "a"/"b"/"c" depending on whether the
+//    span starts/ends at the line boundaries (no letter if it covers the
+//    full line).
+//
+
+string Tool_pliner::getModifier(vector<vector<PoemWord>>& poem, Span& span) {
+	int lastPos = (int)poem.at(span.line).size() - 1;
+	bool startsAtBegin = (span.startPos == 0);
+	bool endsAtEnd      = (span.endPos == lastPos);
+
+	string modifier;
+	if (span.repeat) {
+		modifier += "r";
+	}
+	if (startsAtBegin && endsAtEnd) {
+		// full line: no letter suffix.
+	} else if (startsAtBegin && !endsAtEnd) {
+		modifier += "a";
+	} else if (!startsAtBegin && endsAtEnd) {
+		modifier += "b";
+	} else {
+		modifier += "c";
+	}
+	return modifier;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_pliner::emitOutput -- Stream the input file back out, injecting
+//    one synthesized interpretation line immediately before each data
+//    line that needs new *pline tokens (merging multiple voices' tokens
+//    into a single line when they coincide).
+//
+
+void Tool_pliner::emitOutput(HumdrumFile& infile, map<int, map<int, string>>& insertions) {
+	for (int i=0; i<infile.getLineCount(); i++) {
+		auto it = insertions.find(i);
+		if (it != insertions.end()) {
+			int fieldCount = infile[i].getFieldCount();
+			vector<string> fields(fieldCount, "*");
+			for (int j=0; j<fieldCount; j++) {
+				int track = infile.token(i, j)->getTrack();
+				auto tit = it->second.find(track);
+				if (tit != it->second.end()) {
+					fields[j] = tit->second;
+				}
+			}
+			for (int j=0; j<fieldCount; j++) {
+				m_humdrum_text << fields[j];
+				if (j < fieldCount - 1) {
+					m_humdrum_text << "\t";
+				}
+			}
+			m_humdrum_text << endl;
+		}
+		m_humdrum_text << infile[i] << endl;
+	}
+}
+
+
+// END_MERGE
+
+} // end namespace hum

--- a/src/tool-pliner.cpp
+++ b/src/tool-pliner.cpp
@@ -32,6 +32,7 @@ namespace hum {
 
 Tool_pliner::Tool_pliner(void) {
 	define("s|syllables|syl=s:", "allowed line lengths passed to textract (comma-separated set; e.g. 7,11)");
+	define("l|lines=i:0", "expected poem line count passed to textract (0=auto; sonetto→14)");
 }
 
 
@@ -174,6 +175,11 @@ bool Tool_pliner::extractPoem(HumdrumFile& infile, vector<vector<PoemWord>>& poe
 	if (getBoolean("syllables")) {
 		argv.push_back("-s");
 		argv.push_back(getString("syllables"));
+	}
+	int linesOpt = getInteger("lines");
+	if (linesOpt > 0) {
+		argv.push_back("-l");
+		argv.push_back(to_string(linesOpt));
 	}
 	textract.process(argv);
 	textract.run(infile);

--- a/src/tool-pliner.cpp
+++ b/src/tool-pliner.cpp
@@ -474,12 +474,12 @@ void Tool_pliner::buildSungWords(HTp textStart, vector<SungWord>& words) {
 //////////////////////////////
 //
 // Tool_pliner::alignVoice -- Align a voice's sequence of sung words
-//    against the poem, tracking a mostly-forward-moving pointer (repeats
-//    are assumed to stay close by: within the current line or the
-//    immediately preceding line), rather than depending on any
-//    pre-existing editorial markup.  Runs of consecutive words assigned
-//    to the same (line, repeat-state) are collapsed into "spans"; each
-//    span marks one *pline transition.
+//    against the poem, tracking a mostly-forward-moving pointer.  Local
+//    repeats are sought within the current line and a short lookback of
+//    preceding lines (a closing-stanza repeat may jump back more than
+//    one line, e.g. from line 14 back to line 12).  Runs of consecutive
+//    words assigned to the same (line, repeat-state) are collapsed into
+//    "spans"; each span marks one *pline transition.
 //
 //    A span only counts as a repeat ("r") if it does not, by the time it
 //    ends, reach any further into the line than this voice had already
@@ -493,7 +493,6 @@ void Tool_pliner::buildSungWords(HTp textStart, vector<SungWord>& words) {
 //    starts by re-treading already-sung words, because it ends up
 //    covering new ground.
 //
-
 void Tool_pliner::alignVoice(vector<SungWord>& words, vector<vector<PoemWord>>& poem,
 		vector<Span>& spans) {
 	spans.clear();
@@ -743,8 +742,13 @@ void Tool_pliner::alignVoice(vector<SungWord>& words, vector<vector<PoemWord>>& 
 			}
 
 			// bounded backward candidates: current line up to the
-			// pointer, then the immediately preceding line.
-			int lowLine = ptrLine - 1;
+			// pointer, then a short lookback of preceding lines.
+			// Capitalized re-entries (typical line openings of a
+			// repeated tercet/quatrain) may jump back several lines;
+			// non-capitals stay closer so common words do not snap to
+			// distant earlier matches.
+			int maxLineLookback = sw.capitalized ? 6 : 2;
+			int lowLine = ptrLine - maxLineLookback;
 			if (lowLine < 0) {
 				lowLine = 0;
 			}
@@ -753,7 +757,12 @@ void Tool_pliner::alignVoice(vector<SungWord>& words, vector<vector<PoemWord>>& 
 				for (int p = hi; p >= 0; p--) {
 					int s = scoreRun(wi, line, p);
 					if (s > 0) {
-						cands.push_back({line, p, s, 2});
+						int backDist = ptrLine - line;
+						// Near repeats (same/previous line) keep priority
+						// 2; farther lookbacks are weaker than forward
+						// progress so only a clearly better scoreRun wins.
+						int pri = (backDist <= 1) ? 2 : 5;
+						cands.push_back({line, p, s, pri});
 					}
 				}
 			}

--- a/src/tool-pliner.cpp
+++ b/src/tool-pliner.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <fstream>
 #include <sstream>
 
 using namespace std;
@@ -33,6 +34,7 @@ namespace hum {
 Tool_pliner::Tool_pliner(void) {
 	define("s|syllables|syl=s:", "allowed line lengths passed to textract (comma-separated set; e.g. 7,11)");
 	define("l|lines=i:0", "expected poem line count passed to textract (0=auto; sonetto→14)");
+	define("t|text=s:", "poem text file (skip textract; empty lines discarded, lines trimmed)");
 }
 
 
@@ -162,29 +164,46 @@ void Tool_pliner::processFile(HumdrumFile& infile) {
 
 //////////////////////////////
 //
-// Tool_pliner::extractPoem -- Reconstruct the poem via textract and
-//    split it into normalized PoemWord lines for alignment.
+// Tool_pliner::extractPoem -- Load the poem either from a user-specified
+//    text file (-t/--text) or via textract from the underlay, then split
+//    it into normalized PoemWord lines for alignment.
 //
 
 bool Tool_pliner::extractPoem(HumdrumFile& infile, vector<vector<PoemWord>>& poem) {
 	poem.clear();
 
-	Tool_textract textract;
-	vector<string> argv;
-	argv.push_back("textract");
-	if (getBoolean("syllables")) {
-		argv.push_back("-s");
-		argv.push_back(getString("syllables"));
+	string text;
+	if (getBoolean("text")) {
+		string path = getString("text");
+		if (path.empty()) {
+			return false;
+		}
+		ifstream in(path.c_str());
+		if (!in) {
+			cerr << "Error: cannot open text file: " << path << endl;
+			return false;
+		}
+		ostringstream oss;
+		oss << in.rdbuf();
+		text = oss.str();
+	} else {
+		Tool_textract textract;
+		vector<string> argv;
+		argv.push_back("textract");
+		if (getBoolean("syllables")) {
+			argv.push_back("-s");
+			argv.push_back(getString("syllables"));
+		}
+		int linesOpt = getInteger("lines");
+		if (linesOpt > 0) {
+			argv.push_back("-l");
+			argv.push_back(to_string(linesOpt));
+		}
+		textract.process(argv);
+		textract.run(infile);
+		text = textract.getFreeText();
 	}
-	int linesOpt = getInteger("lines");
-	if (linesOpt > 0) {
-		argv.push_back("-l");
-		argv.push_back(to_string(linesOpt));
-	}
-	textract.process(argv);
-	textract.run(infile);
 
-	string text = textract.getFreeText();
 	if (text.empty()) {
 		return false;
 	}
@@ -194,9 +213,14 @@ bool Tool_pliner::extractPoem(HumdrumFile& infile, vector<vector<PoemWord>>& poe
 	string line;
 	int lineNum = 0;
 	while (getline(stream, line)) {
-		if (line.empty()) {
+		// Trim leading/trailing whitespace; skip empty lines.
+		size_t start = line.find_first_not_of(" \t\r\n");
+		if (start == string::npos) {
 			continue;
 		}
+		size_t end = line.find_last_not_of(" \t\r\n");
+		line = line.substr(start, end - start + 1);
+
 		vector<string> rawwords;
 		hre.split(rawwords, line, "\\s+");
 

--- a/src/tool-textract.cpp
+++ b/src/tool-textract.cpp
@@ -1,0 +1,1118 @@
+//
+// Programmer:    Alexander Morgan
+// Creation Date: Fri Jul 24 2026
+// Filename:      tool-textract.cpp
+// Syntax:        C++11; humlib
+// vim:           ts=3 noexpandtab
+//
+// Description:   Reconstruct the poetic text being set in a score by
+//                examining each voice's **text underlay.  Musical
+//                repetitions are collapsed; lines present in a majority
+//                of voices are kept, ordered by each voice's mostly-
+//                linear declamation.
+//
+
+#include "tool-textract.h"
+#include "HumRegex.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <map>
+#include <set>
+
+using namespace std;
+
+namespace hum {
+
+// START_MERGE
+
+
+//////////////////////////////
+//
+// Tool_textract::Tool_textract --
+//
+
+Tool_textract::Tool_textract(void) {
+	define("s|syllables|syl=s:", "expected line lengths in syllables (comma-separated, cycles; e.g. 11,7)");
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::run --
+//
+
+bool Tool_textract::run(HumdrumFileSet& infiles) {
+	bool status = true;
+	for (int i=0; i<infiles.getCount(); i++) {
+		status &= run(infiles[i]);
+	}
+	return status;
+}
+
+
+bool Tool_textract::run(const string& indata, ostream& out) {
+	HumdrumFile infile(indata);
+	bool status = run(infile);
+	if (hasAnyText()) {
+		getAllText(out);
+	} else {
+		out << infile;
+	}
+	return status;
+}
+
+
+bool Tool_textract::run(HumdrumFile& infile, ostream& out) {
+	bool status = run(infile);
+	if (hasAnyText()) {
+		getAllText(out);
+	} else {
+		out << infile;
+	}
+	return status;
+}
+
+
+bool Tool_textract::run(HumdrumFile& infile) {
+	initialize();
+	processFile(infile);
+	return true;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::initialize --
+//
+
+void Tool_textract::initialize(void) {
+	m_sylCounts.clear();
+
+	if (getBoolean("syllables")) {
+		HumRegex hre;
+		vector<string> pieces;
+		hre.split(pieces, getString("syllables"), "\\s*,\\s*");
+		for (string& p : pieces) {
+			if (p.empty()) {
+				continue;
+			}
+			try {
+				int n = stoi(p);
+				if (n > 0) {
+					m_sylCounts.push_back(n);
+				}
+			} catch (...) {
+				// ignore malformed entries
+			}
+		}
+	}
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::processFile --
+//
+
+void Tool_textract::processFile(HumdrumFile& infile) {
+	vector<Voice> voices;
+	getVoices(infile, voices);
+
+	for (Voice& voice : voices) {
+		buildSungWords(voice.textStart, voice.words);
+		collapseRepeats(voice.words);
+		segmentLines(voice);
+		dedupeVoiceLines(voice);
+	}
+
+	reconstructText(voices);
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::getVoices -- Pair each **kern with its following **text.
+//
+
+void Tool_textract::getVoices(HumdrumFile& infile, vector<Voice>& voices) {
+	voices.clear();
+	vector<HTp> starts;
+	infile.getSpineStartList(starts);
+
+	for (int i=0; i<(int)starts.size(); i++) {
+		if (!starts[i]->isKern()) {
+			continue;
+		}
+		if ((i + 1 < (int)starts.size()) && starts[i+1]->isDataType("**text")) {
+			Voice voice;
+			voice.textStart = starts[i+1];
+			voices.push_back(voice);
+		}
+	}
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::normalizeWord -- Lower-case ASCII, strip punctuation,
+//    fold common accented vowels, keep apostrophes.
+//
+
+string Tool_textract::normalizeWord(const string& text) {
+	string out;
+	for (size_t i=0; i<text.size(); i++) {
+		unsigned char c = (unsigned char)text[i];
+		if ((c == '<') || (c == '>')) {
+			continue;
+		}
+		if ((c == ',') || (c == '.') || (c == ':') || (c == ';') ||
+				(c == '!') || (c == '?') || (c == '"')) {
+			continue;
+		}
+		if ((c == 0xC3) && (i + 1 < text.size())) {
+			unsigned char c2 = (unsigned char)text[i+1];
+			char folded = 0;
+			switch (c2) {
+				case 0x80: case 0x81: case 0xA0: case 0xA1: folded = 'a'; break;
+				case 0x88: case 0x89: case 0xA8: case 0xA9: folded = 'e'; break;
+				case 0x8C: case 0x8D: case 0xAC: case 0xAD: folded = 'i'; break;
+				case 0x92: case 0x93: case 0xB2: case 0xB3: folded = 'o'; break;
+				case 0x99: case 0x9A: case 0xB9: case 0xBA: folded = 'u'; break;
+			}
+			if (folded) {
+				out += folded;
+				i++;
+				continue;
+			}
+		}
+		// "e1"/"a1"/... grave encoding used in some underlays
+		if (((c >= 'a') && (c <= 'z')) || ((c >= 'A') && (c <= 'Z'))) {
+			char base = (char)tolower(c);
+			if ((i + 1 < text.size()) && (text[i+1] == '1') &&
+					((base == 'a') || (base == 'e') || (base == 'i') ||
+					 (base == 'o') || (base == 'u'))) {
+				out += base;
+				i++;
+				continue;
+			}
+			out += base;
+			continue;
+		}
+		if (c == '-') {
+			continue;
+		}
+		out += (char)c;
+	}
+	return out;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::cleanOrigPiece -- Strip hyphens/markers from one syllable
+//    for display joining.
+//
+
+string Tool_textract::cleanOrigPiece(const string& text) {
+	string out;
+	for (size_t i=0; i<text.size(); i++) {
+		unsigned char c = (unsigned char)text[i];
+		if ((c == '<') || (c == '>') || (c == '-')) {
+			continue;
+		}
+		if ((c == ',') || (c == '.') || (c == ':') || (c == ';') ||
+				(c == '!') || (c == '?') || (c == '"')) {
+			continue;
+		}
+		out += (char)c;
+	}
+	return out;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::buildSungWords -- Reconstruct words from hyphenated
+//    syllables; track capitalization, syllable counts, and <bis> spans.
+//
+
+void Tool_textract::buildSungWords(HTp textStart, vector<SungWord>& words) {
+	words.clear();
+	if (!textStart) {
+		return;
+	}
+
+	auto endsWithContinuationDash = [](const string& s) {
+		string tmp = s;
+		while (!tmp.empty()) {
+			char c = tmp.back();
+			if ((c == ',') || (c == '.') || (c == ':') || (c == ';') ||
+					(c == '!') || (c == '?') || (c == '"') || (c == '>')) {
+				tmp.pop_back();
+				continue;
+			}
+			break;
+		}
+		return !tmp.empty() && (tmp.back() == '-');
+	};
+
+	bool wordOpen = false;
+	string accumNorm;
+	string accumOrig;
+	int sylCount = 0;
+	bool capitalized = false;
+	bool bis = false;
+	bool inBis = false;
+
+	auto finalize = [&]() {
+		if (wordOpen && !accumNorm.empty()) {
+			SungWord sw;
+			sw.original = accumOrig;
+			sw.norm = accumNorm;
+			sw.syllables = max(sylCount, 1);
+			sw.capitalized = capitalized;
+			sw.bis = bis;
+			words.push_back(sw);
+		}
+		wordOpen = false;
+		accumNorm.clear();
+		accumOrig.clear();
+		sylCount = 0;
+		capitalized = false;
+		bis = false;
+	};
+
+	HTp cur = textStart;
+	while (cur) {
+		if (!cur->isData() || cur->isNull()) {
+			cur = cur->getNextToken();
+			continue;
+		}
+
+		string raw = *cur;
+		if (raw.find('<') != string::npos) {
+			inBis = true;
+		}
+
+		vector<string> parts;
+		size_t pos = 0;
+		while (pos <= raw.size()) {
+			size_t sp = raw.find(' ', pos);
+			if (sp == string::npos) {
+				parts.push_back(raw.substr(pos));
+				break;
+			}
+			parts.push_back(raw.substr(pos, sp - pos));
+			pos = sp + 1;
+		}
+
+		for (int idx=0; idx<(int)parts.size(); idx++) {
+			string part = parts[idx];
+			if (part.empty()) {
+				continue;
+			}
+			string core = part;
+			if (!core.empty() && (core[0] == '<')) {
+				core = core.substr(1);
+			}
+			bool leadingDash = !core.empty() && (core[0] == '-');
+			bool trailingDash = endsWithContinuationDash(core);
+			string n = normalizeWord(part);
+			string o = cleanOrigPiece(part);
+			if (n.empty() && o.empty()) {
+				continue;
+			}
+
+			if ((idx == 0) && wordOpen && leadingDash) {
+				accumNorm += n;
+				accumOrig += o;
+				sylCount++;
+				if (!trailingDash) {
+					finalize();
+				}
+			} else {
+				if (wordOpen) {
+					finalize();
+				}
+				capitalized = false;
+				for (char c : core) {
+					if (isalpha((unsigned char)c)) {
+						capitalized = isupper((unsigned char)c) != 0;
+						break;
+					}
+				}
+				bis = inBis;
+				accumNorm = n;
+				accumOrig = o;
+				sylCount = 1;
+				wordOpen = true;
+				if (!trailingDash) {
+					finalize();
+				}
+			}
+		}
+
+		if (raw.find('>') != string::npos) {
+			inBis = false;
+		}
+		cur = cur->getNextToken();
+	}
+	finalize();
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::collapseRepeats -- Remove immediate repeated blocks
+//    (musical re-iterations of the same words).
+//
+
+void Tool_textract::collapseRepeats(vector<SungWord>& words) {
+	// Drop editorial <bis> content entirely: it restates already-sung text.
+	{
+		vector<SungWord> filtered;
+		for (SungWord& w : words) {
+			if (!w.bis) {
+				filtered.push_back(w);
+			}
+		}
+		words.swap(filtered);
+	}
+
+	bool changed = true;
+	while (changed) {
+		changed = false;
+		int n = (int)words.size();
+		for (int L = n / 2; L >= 1; L--) {
+			for (int i = 0; i + 2 * L <= (int)words.size(); i++) {
+				bool match = true;
+				for (int k = 0; k < L; k++) {
+					if (words[i + k].norm != words[i + L + k].norm) {
+						match = false;
+						break;
+					}
+				}
+				if (match) {
+					words.erase(words.begin() + i + L, words.begin() + i + 2 * L);
+					changed = true;
+					break;
+				}
+			}
+			if (changed) {
+				break;
+			}
+		}
+	}
+
+	// Drop a word that restates the previous two concatenated ("che"+"volgi"→"chevolgi").
+	for (int i = 2; i < (int)words.size(); ) {
+		if (words[i].norm == words[i-2].norm + words[i-1].norm) {
+			words.erase(words.begin() + i);
+			continue;
+		}
+		i++;
+	}
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::endsWithVowel -- Last alphabetic char is a vowel sound.
+//
+
+bool Tool_textract::endsWithVowel(const string& norm) {
+	for (int i=(int)norm.size()-1; i>=0; i--) {
+		unsigned char c = (unsigned char)norm[i];
+		if (c == '\'') {
+			continue;
+		}
+		if (!isalpha(c)) {
+			continue;
+		}
+		char l = (char)tolower(c);
+		return (l == 'a') || (l == 'e') || (l == 'i') || (l == 'o') || (l == 'u');
+	}
+	return false;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::startsWithVowel -- First alphabetic char is a vowel sound.
+//
+
+bool Tool_textract::startsWithVowel(const string& norm) {
+	for (size_t i=0; i<norm.size(); i++) {
+		unsigned char c = (unsigned char)norm[i];
+		if (c == '\'') {
+			// Leading apostrophe ("'n") is an elision remnant, not a vowel start.
+			return false;
+		}
+		if (!isalpha(c)) {
+			continue;
+		}
+		char l = (char)tolower(c);
+		return (l == 'a') || (l == 'e') || (l == 'i') || (l == 'o') || (l == 'u');
+	}
+	return false;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::elidesWith -- Synaloepha / apostrophe elision between words.
+//    Mirrors pliner's apostrophe-aware matching: split on ' and check
+//    prefix/suffix relationships, plus vowel-vowel synaloepha.
+//
+
+bool Tool_textract::elidesWith(const SungWord& left, const SungWord& right) {
+	const string& a = left.norm;
+	const string& b = right.norm;
+	if (a.empty() || b.empty()) {
+		return false;
+	}
+
+	// Elision remnant attached to the next word ("E" + "'n").
+	if (b[0] == '\'') {
+		return true;
+	}
+
+	// Apostrophe contraction across a split underlay ("gli" + "occhi" with
+	// one side written "gl'occhi"-style).  Split on ' and compare pieces
+	// with startswith/endswith, as in pliner.
+	auto apostropheElision = [](const string& x, const string& y) -> bool {
+		size_t apos = x.find('\'');
+		if (apos == string::npos) {
+			return false;
+		}
+		string pre = x.substr(0, apos);
+		string suf = x.substr(apos + 1);
+		if (!pre.empty() && !suf.empty() && !y.empty()) {
+			// x = pre'suf; y matches suf (startswith) or pre (endswith of y
+			// when y is the left word — handled by swapping args).
+			if (y.compare(0, suf.size(), suf) == 0) {
+				return true;
+			}
+			if (y.size() >= pre.size() &&
+					(y.compare(y.size() - pre.size(), pre.size(), pre) == 0)) {
+				return true;
+			}
+			// Truncated prefix: "gl" vs "gli".
+			if ((pre.size() >= 2) && (y.size() >= 2) &&
+					(y.rfind(pre, 0) == 0 || pre.rfind(y, 0) == 0)) {
+				return true;
+			}
+		}
+		return false;
+	};
+	if (apostropheElision(a, b) || apostropheElision(b, a)) {
+		return true;
+	}
+
+	// Synaloepha: vowel-final + vowel-initial (also across line boundaries).
+	return endsWithVowel(a) && startsWithVowel(b);
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::lineSyllables -- Written syllable sum minus elisions
+//    (synaloepha / apostrophe) between adjacent words, including across
+//    what may later become a line boundary when lines are merged.
+//
+
+int Tool_textract::lineSyllables(const vector<SungWord>& line) {
+	if (line.empty()) {
+		return 0;
+	}
+	int n = 0;
+	for (const SungWord& w : line) {
+		n += w.syllables;
+	}
+	for (size_t i=0; i+1 < line.size(); i++) {
+		if (elidesWith(line[i], line[i+1])) {
+			n--;
+		}
+	}
+	return (n > 0) ? n : 0;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::expectedSyllables -- Positional target; list cycles.
+//
+
+int Tool_textract::expectedSyllables(int lineIndex) {
+	if (m_sylCounts.empty()) {
+		return 0;
+	}
+	return m_sylCounts[lineIndex % (int)m_sylCounts.size()];
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::distanceToAllowed -- Min distance to any -s length.
+//
+
+int Tool_textract::distanceToAllowed(int syllables) {
+	if (m_sylCounts.empty()) {
+		return abs(syllables);
+	}
+	int best = abs(syllables - m_sylCounts[0]);
+	for (int t : m_sylCounts) {
+		best = min(best, abs(syllables - t));
+	}
+	return best;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::isAllowedLength -- True if syllables matches a -s value.
+//
+
+bool Tool_textract::isAllowedLength(int syllables, int tol) {
+	if (m_sylCounts.empty()) {
+		return false;
+	}
+	for (int t : m_sylCounts) {
+		if (abs(syllables - t) <= tol) {
+			return true;
+		}
+	}
+	return false;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::segmentLines -- Split a voice on capitalized words.
+//    Mid-line capitals (not common line-starters) may stay in the current
+//    line.  Syllable targets (-s) are applied later in refineLines.
+//
+
+void Tool_textract::segmentLines(Voice& voice) {
+	voice.lines.clear();
+	if (voice.words.empty()) {
+		return;
+	}
+
+	vector<SungWord> cur;
+	auto flush = [&]() {
+		if (!cur.empty()) {
+			voice.lines.push_back(cur);
+			cur.clear();
+		}
+	};
+
+	for (SungWord& w : voice.words) {
+		if (!cur.empty() && w.capitalized) {
+			bool doBreak = true;
+			if (!likelyLineStart(w.norm)) {
+				// Mid-line exception, e.g. "Amore" in "Sciogli pietoso Amore".
+				if ((int)cur.size() <= 2) {
+					doBreak = false;
+				} else if (!m_sylCounts.empty()) {
+					int have = lineSyllables(cur);
+					if (!isAllowedLength(have, 1)) {
+						doBreak = false;
+					}
+				}
+			}
+			if (doBreak) {
+				flush();
+			}
+		}
+		cur.push_back(w);
+	}
+	flush();
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::likelyLineStart -- Common poetic line-initial words;
+//    capitals outside this set are more often mid-line exceptions.
+//
+
+bool Tool_textract::likelyLineStart(const string& norm) {
+	static const set<string> starters = {
+		"e", "ed", "a", "ad", "di", "de", "del", "che", "chi",
+		"la", "le", "il", "lo", "gli", "ne", "ma", "per", "se",
+		"non", "un", "una", "uno", "i", "o", "oh", "ah", "quando",
+		"come", "cosi", "poi", "anzi", "hor", "or", "ora", "ore",
+		"sol", "solo", "su", "sul", "tra", "fra", "con", "da", "dal"
+	};
+	if (starters.count(norm)) {
+		return true;
+	}
+	// "E'n", "Né", "Sol' io" folded forms.
+	if ((norm == "ne") || (norm.rfind("sol", 0) == 0) ||
+			(norm.rfind("e'", 0) == 0) || (norm.rfind("ne'", 0) == 0)) {
+		return true;
+	}
+	return false;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::linesSimilar -- Soft equality via token LCS ratio.
+//
+
+bool Tool_textract::linesSimilar(const vector<SungWord>& a,
+		const vector<SungWord>& b) {
+	if (a.empty() || b.empty()) {
+		return false;
+	}
+	if (a.size() == b.size()) {
+		bool exact = true;
+		for (size_t i=0; i<a.size(); i++) {
+			if (a[i].norm != b[i].norm) {
+				exact = false;
+				break;
+			}
+		}
+		if (exact) {
+			return true;
+		}
+	}
+	int maxLen = (int)max(a.size(), b.size());
+	int minLen = (int)min(a.size(), b.size());
+	if (maxLen - minLen > max(2, minLen / 2)) {
+		return false;
+	}
+	// LCS length
+	vector<vector<int>> dp(a.size() + 1, vector<int>(b.size() + 1, 0));
+	for (size_t i=1; i<=a.size(); i++) {
+		for (size_t j=1; j<=b.size(); j++) {
+			if (a[i-1].norm == b[j-1].norm) {
+				dp[i][j] = dp[i-1][j-1] + 1;
+			} else {
+				dp[i][j] = max(dp[i-1][j], dp[i][j-1]);
+			}
+		}
+	}
+	double ratio = (double)dp[a.size()][b.size()] / (double)maxLen;
+	return ratio >= 0.75;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::isSubSequence -- Contiguous sub-sequence test on norms.
+//
+
+bool Tool_textract::isSubSequence(const vector<SungWord>& shorter,
+		const vector<SungWord>& longer) {
+	if (shorter.size() >= longer.size()) {
+		return false;
+	}
+	if (shorter.empty()) {
+		return false;
+	}
+	for (size_t i=0; i + shorter.size() <= longer.size(); i++) {
+		bool ok = true;
+		for (size_t k=0; k<shorter.size(); k++) {
+			if (shorter[k].norm != longer[i+k].norm) {
+				ok = false;
+				break;
+			}
+		}
+		if (ok) {
+			return true;
+		}
+	}
+	return false;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::dedupeVoiceLines -- Drop musical re-statements of a line;
+//    keep the fuller version when one line contains another.
+//
+
+void Tool_textract::dedupeVoiceLines(Voice& voice) {
+	vector<vector<SungWord>> uniq;
+	for (auto& line : voice.lines) {
+		if (line.empty()) {
+			continue;
+		}
+		bool absorbed = false;
+		for (int i=0; i<(int)uniq.size(); i++) {
+			if (linesSimilar(line, uniq[i]) || isSubSequence(line, uniq[i])) {
+				absorbed = true;
+				break;
+			}
+			if (isSubSequence(uniq[i], line)) {
+				uniq[i] = line;
+				absorbed = true;
+				break;
+			}
+		}
+		if (!absorbed) {
+			uniq.push_back(line);
+		}
+	}
+	voice.lines.swap(uniq);
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::lineToString --
+//
+
+string Tool_textract::lineToString(const vector<SungWord>& line) {
+	string out;
+	for (size_t i=0; i<line.size(); i++) {
+		if (i) {
+			out += " ";
+		}
+		out += line[i].original;
+	}
+	return out;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::consensusLine -- Prefer the most common wording; break
+//    ties toward the longest non-repetitious form.
+//
+
+vector<Tool_textract::SungWord> Tool_textract::consensusLine(LineCluster& cluster) {
+	if (cluster.members.empty()) {
+		return {};
+	}
+	if (cluster.members.size() == 1) {
+		return cluster.members[0];
+	}
+
+	// Median length: trailing junk / local re-iterations often make outliers long.
+	vector<int> lengths;
+	for (auto& m : cluster.members) {
+		lengths.push_back((int)m.size());
+	}
+	sort(lengths.begin(), lengths.end());
+	int medianLen = lengths[lengths.size() / 2];
+
+	int bestIdx = 0;
+	double bestScore = -1e9;
+	for (int i=0; i<(int)cluster.members.size(); i++) {
+		auto& m = cluster.members[i];
+		double score = 0;
+		for (int j=0; j<(int)cluster.members.size(); j++) {
+			if (linesSimilar(m, cluster.members[j])) {
+				score += 1.0;
+				// Bonus when lengths agree (same wording, not a padded variant).
+				if (m.size() == cluster.members[j].size()) {
+					score += 0.5;
+				}
+			}
+		}
+		score -= 0.75 * fabs((double)m.size() - (double)medianLen);
+
+		// Penalize an immediate repeated half of the line.
+		int n = (int)m.size();
+		if ((n >= 4) && (n % 2 == 0)) {
+			bool half = true;
+			for (int k=0; k<n/2; k++) {
+				if (m[k].norm != m[n/2 + k].norm) {
+					half = false;
+					break;
+				}
+			}
+			if (half) {
+				score -= 5.0;
+			}
+		}
+		// Penalize a word that is the concatenation of the previous two
+		// (e.g. "che" + "volgi" restated as "chevolgi").
+		for (int k=2; k<n; k++) {
+			if (m[k].norm == m[k-2].norm + m[k-1].norm) {
+				score -= 2.0;
+			}
+			if ((k >= 3) && (m[k-1].norm + m[k].norm == m[k-3].norm + m[k-2].norm)) {
+				score -= 1.0;
+			}
+		}
+		if (score > bestScore) {
+			bestScore = score;
+			bestIdx = i;
+		}
+	}
+
+	vector<SungWord> result = cluster.members[bestIdx];
+	// Trim trailing words absent from a majority of members (local debris).
+	while (result.size() > 1) {
+		int idx = (int)result.size() - 1;
+		int withWord = 0;
+		for (auto& m : cluster.members) {
+			if (((int)m.size() > idx) && (m[idx].norm == result[idx].norm)) {
+				withWord++;
+			}
+		}
+		if (withWord * 2 < (int)cluster.members.size()) {
+			result.pop_back();
+		} else {
+			break;
+		}
+	}
+	return result;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::reconstructText -- Cluster lines across voices, keep
+//    majority-supported lines, order by typical singing order, emit text.
+//
+
+void Tool_textract::reconstructText(vector<Voice>& voices) {
+	if (voices.empty()) {
+		return;
+	}
+
+	vector<LineCluster> clusters;
+
+	for (int vi=0; vi<(int)voices.size(); vi++) {
+		for (int li=0; li<(int)voices[vi].lines.size(); li++) {
+			auto& line = voices[vi].lines[li];
+			int best = -1;
+			for (int ci=0; ci<(int)clusters.size(); ci++) {
+				auto rep = consensusLine(clusters[ci]);
+				bool similar = linesSimilar(line, rep);
+				bool lineInRep = isSubSequence(line, rep);
+				bool repInLine = isSubSequence(rep, line);
+				if (!similar && !lineInRep && !repInLine) {
+					continue;
+				}
+				// Short fragments only merge if they cover most of the other line.
+				if (!similar && lineInRep &&
+						((int)line.size() * 2 < (int)rep.size())) {
+					continue;
+				}
+				if (!similar && repInLine &&
+						((int)rep.size() * 2 < (int)line.size())) {
+					continue;
+				}
+				// Require shared first word when both are capitalized starts.
+				if (!line.empty() && !rep.empty() &&
+						line[0].capitalized && rep[0].capitalized &&
+						(line[0].norm != rep[0].norm)) {
+					continue;
+				}
+				best = ci;
+				break;
+			}
+			if (best >= 0) {
+				clusters[best].members.push_back(line);
+				clusters[best].voiceIds.push_back(vi);
+				// Prefer storing fuller versions first for later consensus.
+				if (line.size() > clusters[best].members[0].size()) {
+					swap(clusters[best].members[0],
+							clusters[best].members.back());
+				}
+			} else {
+				LineCluster c;
+				c.members.push_back(line);
+				c.voiceIds.push_back(vi);
+				clusters.push_back(c);
+			}
+		}
+	}
+
+	int nVoices = (int)voices.size();
+	int majority = (nVoices + 1) / 2;
+
+	// Compute average position among contributing voices.
+	for (LineCluster& c : clusters) {
+		double sum = 0;
+		int count = 0;
+		set<int> seen;
+		for (int k=0; k<(int)c.voiceIds.size(); k++) {
+			int vi = c.voiceIds[k];
+			if (seen.count(vi)) {
+				continue;
+			}
+			seen.insert(vi);
+			// position = index of this line among that voice's lines
+			auto rep = consensusLine(c);
+			for (int li=0; li<(int)voices[vi].lines.size(); li++) {
+				if (linesSimilar(voices[vi].lines[li], rep) ||
+						isSubSequence(voices[vi].lines[li], rep) ||
+						isSubSequence(rep, voices[vi].lines[li])) {
+					sum += li;
+					count++;
+					break;
+				}
+			}
+		}
+		c.avgPos = (count > 0) ? (sum / count) : 0;
+	}
+
+	vector<int> keep;
+	for (int ci=0; ci<(int)clusters.size(); ci++) {
+		set<int> uniqVoices(clusters[ci].voiceIds.begin(), clusters[ci].voiceIds.end());
+		if ((int)uniqVoices.size() >= majority) {
+			keep.push_back(ci);
+		}
+	}
+
+	stable_sort(keep.begin(), keep.end(), [&](int a, int b) {
+		if (fabs(clusters[a].avgPos - clusters[b].avgPos) > 1e-6) {
+			return clusters[a].avgPos < clusters[b].avgPos;
+		}
+		return a < b;
+	});
+
+	vector<vector<SungWord>> poem;
+	for (int ci : keep) {
+		auto line = consensusLine(clusters[ci]);
+		collapseRepeats(line);
+		if (!line.empty()) {
+			poem.push_back(line);
+		}
+	}
+
+	refineLines(poem);
+
+	for (auto& line : poem) {
+		if (!line.empty()) {
+			m_free_text << lineToString(line) << endl;
+		}
+	}
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::refineLines -- Apply -s lengths (list cycles; any listed
+//    length is allowed).  Metrical counts subtract synaloepha/apostrophe
+//    elision between adjacent words, including across a merge boundary.
+//
+
+void Tool_textract::refineLines(vector<vector<SungWord>>& lines) {
+	if (lines.empty() || m_sylCounts.empty()) {
+		return;
+	}
+
+	vector<vector<SungWord>> out;
+	int i = 0;
+	while (i < (int)lines.size()) {
+		int target = expectedSyllables((int)out.size());
+		int syl = lineSyllables(lines[i]);
+
+		if (isAllowedLength(syl) || (syl == target)) {
+			out.push_back(lines[i]);
+			i++;
+			continue;
+		}
+
+		if (i + 1 < (int)lines.size()) {
+			int nextSyl = lineSyllables(lines[i+1]);
+			bool nextComplete = isAllowedLength(nextSyl);
+			vector<SungWord> combined = lines[i];
+			combined.insert(combined.end(), lines[i+1].begin(), lines[i+1].end());
+			int combSyl = lineSyllables(combined); // includes cross-line elision
+			bool hits = isAllowedLength(combSyl) || (combSyl == target);
+			bool improves = distanceToAllowed(combSyl) < distanceToAllowed(syl);
+
+			// Never absorb a complete following line unless the merge exactly hits.
+			bool allowMerge = hits || (improves && !nextComplete);
+			if (allowMerge && !hits && !lines[i+1].empty() &&
+					likelyLineStart(lines[i+1][0].norm) && nextComplete) {
+				allowMerge = false;
+			}
+
+			if (allowMerge) {
+				int j = i + 2;
+				while (j < (int)lines.size() && !isAllowedLength(lineSyllables(combined))) {
+					if (isAllowedLength(lineSyllables(lines[j]))) {
+						break;
+					}
+					vector<SungWord> trial = combined;
+					trial.insert(trial.end(), lines[j].begin(), lines[j].end());
+					int t2 = lineSyllables(combined);
+					int t3 = lineSyllables(trial);
+					if (distanceToAllowed(t3) <= distanceToAllowed(t2)) {
+						combined.swap(trial);
+						j++;
+					} else {
+						break;
+					}
+				}
+				out.push_back(combined);
+				i = j;
+				continue;
+			}
+		}
+
+		int maxAllowed = m_sylCounts[0];
+		for (int t : m_sylCounts) {
+			maxAllowed = max(maxAllowed, t);
+		}
+		if (syl > maxAllowed + 1) {
+			int bestBreak = -1;
+			int bestDist = 9999;
+			for (int k=1; k<(int)lines[i].size(); k++) {
+				if (!lines[i][k].capitalized) {
+					continue;
+				}
+				vector<SungWord> left(lines[i].begin(), lines[i].begin() + k);
+				int leftSyl = lineSyllables(left);
+				int dist = distanceToAllowed(leftSyl);
+				if (isAllowedLength(leftSyl, 1) && (dist < bestDist)) {
+					bestDist = dist;
+					bestBreak = k;
+				}
+			}
+			if (bestBreak > 0) {
+				vector<SungWord> left(lines[i].begin(), lines[i].begin() + bestBreak);
+				vector<SungWord> right(lines[i].begin() + bestBreak, lines[i].end());
+				out.push_back(left);
+				lines[i] = right;
+				continue;
+			}
+		}
+
+		out.push_back(lines[i]);
+		i++;
+	}
+	lines.swap(out);
+}
+
+
+// END_MERGE
+
+} // end namespace hum

--- a/src/tool-textract.cpp
+++ b/src/tool-textract.cpp
@@ -35,6 +35,7 @@ namespace hum {
 
 Tool_textract::Tool_textract(void) {
 	define("s|syllables|syl=s:", "allowed line lengths in syllables (comma-separated set; e.g. 7,11)");
+	define("l|lines=i:0", "expected number of poem lines (0=auto; !!@GENRE sonetto→14)");
 }
 
 
@@ -91,6 +92,7 @@ bool Tool_textract::run(HumdrumFile& infile) {
 
 void Tool_textract::initialize(void) {
 	m_sylCounts.clear();
+	m_expectedLines = 0;
 
 	if (getBoolean("syllables")) {
 		HumRegex hre;
@@ -110,6 +112,11 @@ void Tool_textract::initialize(void) {
 			}
 		}
 	}
+
+	int linesOpt = getInteger("lines");
+	if (linesOpt > 0) {
+		m_expectedLines = linesOpt;
+	}
 }
 
 
@@ -128,6 +135,10 @@ void Tool_textract::processFile(HumdrumFile& infile) {
 		collapseRepeats(voice.words);
 		segmentLines(voice);
 		dedupeVoiceLines(voice);
+	}
+
+	if (m_expectedLines <= 0) {
+		m_expectedLines = detectGenreLineCount(infile);
 	}
 
 	reconstructText(voices);
@@ -1165,6 +1176,7 @@ void Tool_textract::reconstructText(vector<Voice>& voices) {
 	}
 
 	refineLines(poem);
+	enforceLineCount(poem);
 
 	for (auto& line : poem) {
 		if (!line.empty()) {
@@ -1315,6 +1327,177 @@ void Tool_textract::refineLines(vector<vector<SungWord>>& lines) {
 		i++;
 	}
 	lines.swap(out);
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::detectGenreLineCount -- If the score has
+//    !!@GENRE: sonetto (spaces or tabs after the colon), return 14;
+//    otherwise 0.
+//
+
+int Tool_textract::detectGenreLineCount(HumdrumFile& infile) {
+	HumRegex hre;
+	for (int i=0; i<infile.getLineCount(); i++) {
+		const string& line = infile[i].getText();
+		if (hre.search(line, "^!!@GENRE:\\s*sonetto\\b", "i")) {
+			return 14;
+		}
+	}
+	return 0;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::enforceLineCount -- Nudge the poem toward
+//    m_expectedLines by merging extras or splitting shorts.
+//
+
+void Tool_textract::enforceLineCount(vector<vector<SungWord>>& lines) {
+	if (lines.empty() || (m_expectedLines <= 0)) {
+		return;
+	}
+
+	auto mergeScore = [&](int i) -> double {
+		// Lower is better.  Prefer merges that hit -s lengths; avoid
+		// gluing two strong line-starters when possible.
+		if ((i < 0) || (i + 1 >= (int)lines.size())) {
+			return 1e9;
+		}
+		vector<SungWord> combined = lines[i];
+		combined.insert(combined.end(), lines[i+1].begin(), lines[i+1].end());
+		int combSyl = lineSyllables(combined);
+		double score = 0;
+		if (!m_sylCounts.empty()) {
+			score += distanceToAllowed(combSyl);
+			if (isAllowedLength(combSyl, 1)) {
+				score -= 3.0;
+			}
+		} else {
+			score += (double)combined.size() * 0.01;
+		}
+		bool leftStart = !lines[i].empty() && likelyLineStart(lines[i][0].norm);
+		bool rightStart = !lines[i+1].empty() && likelyLineStart(lines[i+1][0].norm);
+		if (leftStart && rightStart) {
+			score += 5.0;
+		} else if (!lines[i+1].empty() && lines[i+1][0].capitalized &&
+				!likelyLineStart(lines[i+1][0].norm)) {
+			// Mid-line capital continuation — good merge candidate.
+			score -= 1.0;
+		}
+		// Prefer merging a very short fragment.
+		int leftSyl = lineSyllables(lines[i]);
+		int rightSyl = lineSyllables(lines[i+1]);
+		if (!m_sylCounts.empty()) {
+			if (!isAllowedLength(leftSyl, 1)) {
+				score -= 1.5;
+			}
+			if (!isAllowedLength(rightSyl, 1)) {
+				score -= 1.5;
+			}
+		} else {
+			if (lines[i].size() <= 2) {
+				score -= 1.0;
+			}
+			if (lines[i+1].size() <= 2) {
+				score -= 1.0;
+			}
+		}
+		return score;
+	};
+
+	// Too many lines: repeatedly merge the best adjacent pair.
+	int guard = 0;
+	while (((int)lines.size() > m_expectedLines) && (guard++ < 100)) {
+		int best = -1;
+		double bestScore = 1e9;
+		for (int i=0; i+1 < (int)lines.size(); i++) {
+			double s = mergeScore(i);
+			if (s < bestScore) {
+				bestScore = s;
+				best = i;
+			}
+		}
+		if (best < 0) {
+			break;
+		}
+		// If every remaining pair is two strong starters and we still
+		// must reduce count, take the least-bad (already chosen).
+		lines[best].insert(lines[best].end(),
+				lines[best+1].begin(), lines[best+1].end());
+		lines.erase(lines.begin() + best + 1);
+	}
+
+	auto splitCandidate = [&](int li, int& breakAt) -> double {
+		// Lower is better.  Returns 1e9 if no capital split exists.
+		breakAt = -1;
+		if ((li < 0) || (li >= (int)lines.size()) || (lines[li].size() < 2)) {
+			return 1e9;
+		}
+		double best = 1e9;
+		for (int k=1; k<(int)lines[li].size(); k++) {
+			if (!lines[li][k].capitalized) {
+				continue;
+			}
+			vector<SungWord> left(lines[li].begin(), lines[li].begin() + k);
+			vector<SungWord> right(lines[li].begin() + k, lines[li].end());
+			if (left.empty() || right.empty()) {
+				continue;
+			}
+			int leftSyl = lineSyllables(left);
+			int rightSyl = lineSyllables(right);
+			double score = 0;
+			if (!m_sylCounts.empty()) {
+				score += distanceToAllowed(leftSyl) + distanceToAllowed(rightSyl);
+				if (isAllowedLength(leftSyl, 1)) {
+					score -= 2.0;
+				}
+				if (isAllowedLength(rightSyl, 1)) {
+					score -= 2.0;
+				}
+			} else {
+				score += fabs((double)left.size() - (double)right.size()) * 0.1;
+			}
+			if (likelyLineStart(lines[li][k].norm)) {
+				score -= 1.5;
+			}
+			if (score < best) {
+				best = score;
+				breakAt = k;
+			}
+		}
+		return best;
+	};
+
+	// Too few lines: split the best oversized / capital-bearing line.
+	guard = 0;
+	while (((int)lines.size() < m_expectedLines) && (guard++ < 100)) {
+		int bestLine = -1;
+		int bestBreak = -1;
+		double bestScore = 1e9;
+		for (int li=0; li<(int)lines.size(); li++) {
+			int br = -1;
+			double s = splitCandidate(li, br);
+			if ((br > 0) && (s < bestScore)) {
+				bestScore = s;
+				bestLine = li;
+				bestBreak = br;
+			}
+		}
+		if ((bestLine < 0) || (bestBreak <= 0)) {
+			break;
+		}
+		vector<SungWord> left(lines[bestLine].begin(),
+				lines[bestLine].begin() + bestBreak);
+		vector<SungWord> right(lines[bestLine].begin() + bestBreak,
+				lines[bestLine].end());
+		lines[bestLine] = left;
+		lines.insert(lines.begin() + bestLine + 1, right);
+	}
 }
 
 

--- a/src/tool-textract.cpp
+++ b/src/tool-textract.cpp
@@ -1224,25 +1224,39 @@ void Tool_textract::refineLines(vector<vector<SungWord>>& lines) {
 		// Too short: try merging following incomplete fragments until the
 		// combination hits an allowed length (or stops improving).
 		if ((syl < minAllow) && (i + 1 < (int)lines.size())) {
-			// Never glue two capital-started openings together (e.g. a
-			// partial "Aviene" onto "Sì duro...").
+			vector<SungWord> combined = lines[i];
+			combined.insert(combined.end(), lines[i+1].begin(), lines[i+1].end());
+			int firstCombSyl = lineSyllables(combined);
+
+			// Two capital openings are usually different lines (e.g.
+			// partial "Aviene" before "Sì duro..."), but allow the merge
+			// when the combination itself hits an allowed length (e.g.
+			// "Tra" + "Giove in Cielo..." → 11).
 			if (!lines[i].empty() && lines[i][0].capitalized &&
-					!lines[i+1].empty() && lines[i+1][0].capitalized) {
+					!lines[i+1].empty() && lines[i+1][0].capitalized &&
+					!isAllowedLength(firstCombSyl, 1)) {
 				out.push_back(lines[i]);
 				i++;
 				continue;
 			}
-			vector<SungWord> combined = lines[i];
+
+			combined = lines[i];
 			int j = i + 1;
 			while (j < (int)lines.size()) {
 				int nextSyl = lineSyllables(lines[j]);
-				// Do not absorb a following line that is already complete.
-				if (isAllowedLength(nextSyl, 1)) {
+				// Do not absorb a following line that is already complete,
+				// unless attaching the short prefix makes an allowed length
+				// (handled by the first-iteration check above via hits).
+				if (isAllowedLength(nextSyl, 1) && j > i + 1) {
 					break;
 				}
-				if (!lines[j].empty() && lines[j][0].capitalized &&
+				if (j > i + 1 && !lines[j].empty() && lines[j][0].capitalized &&
 						!combined.empty() && combined[0].capitalized) {
-					break;
+					vector<SungWord> trialCap = combined;
+					trialCap.insert(trialCap.end(), lines[j].begin(), lines[j].end());
+					if (!isAllowedLength(lineSyllables(trialCap), 1)) {
+						break;
+					}
 				}
 				vector<SungWord> trial = combined;
 				trial.insert(trial.end(), lines[j].begin(), lines[j].end());

--- a/src/tool-textract.cpp
+++ b/src/tool-textract.cpp
@@ -687,7 +687,12 @@ void Tool_textract::segmentLines(Voice& voice) {
 			bool doBreak = true;
 			if (!likelyLineStart(w.norm)) {
 				// Mid-line exception, e.g. "Amore" in "Sciogli pietoso Amore".
-				if ((int)cur.size() <= 2) {
+				// Do not apply it to a lone capitalized word: that is usually
+				// an incomplete line-start (partial *pline:a* attempt) and
+				// must stay separate from the next capital ("Aviene" | "Sì").
+				if ((int)cur.size() == 1 && cur[0].capitalized) {
+					doBreak = true;
+				} else if ((int)cur.size() <= 2) {
 					doBreak = false;
 				} else if (!m_sylCounts.empty()) {
 					// With -s, suppress the break only while the current
@@ -723,10 +728,11 @@ void Tool_textract::segmentLines(Voice& voice) {
 bool Tool_textract::likelyLineStart(const string& norm) {
 	static const set<string> starters = {
 		"e", "ed", "a", "ad", "di", "de", "del", "che", "chi",
-		"la", "le", "il", "lo", "gli", "ne", "ma", "per", "se",
+		"la", "le", "il", "lo", "gli", "ne", "ma", "per", "se", "si",
 		"non", "un", "una", "uno", "i", "o", "oh", "ah", "deh", "quando",
 		"come", "cosi", "poi", "anzi", "hor", "or", "ora", "ore",
-		"sol", "solo", "su", "sul", "tra", "fra", "con", "da", "dal"
+		"sol", "solo", "su", "sul", "tra", "fra", "con", "da", "dal",
+		"lasso", "mentre"
 	};
 	if (starters.count(norm)) {
 		return true;
@@ -1168,12 +1174,24 @@ void Tool_textract::refineLines(vector<vector<SungWord>>& lines) {
 		// Too short: try merging following incomplete fragments until the
 		// combination hits an allowed length (or stops improving).
 		if ((syl < minAllow) && (i + 1 < (int)lines.size())) {
+			// Never glue two capital-started openings together (e.g. a
+			// partial "Aviene" onto "Sì duro...").
+			if (!lines[i].empty() && lines[i][0].capitalized &&
+					!lines[i+1].empty() && lines[i+1][0].capitalized) {
+				out.push_back(lines[i]);
+				i++;
+				continue;
+			}
 			vector<SungWord> combined = lines[i];
 			int j = i + 1;
 			while (j < (int)lines.size()) {
 				int nextSyl = lineSyllables(lines[j]);
 				// Do not absorb a following line that is already complete.
 				if (isAllowedLength(nextSyl, 1)) {
+					break;
+				}
+				if (!lines[j].empty() && lines[j][0].capitalized &&
+						!combined.empty() && combined[0].capitalized) {
 					break;
 				}
 				vector<SungWord> trial = combined;

--- a/src/tool-textract.cpp
+++ b/src/tool-textract.cpp
@@ -34,7 +34,7 @@ namespace hum {
 //
 
 Tool_textract::Tool_textract(void) {
-	define("s|syllables|syl=s:", "expected line lengths in syllables (comma-separated, cycles; e.g. 11,7)");
+	define("s|syllables|syl=s:", "allowed line lengths in syllables (comma-separated set; e.g. 7,11)");
 }
 
 
@@ -271,7 +271,7 @@ void Tool_textract::buildSungWords(HTp textStart, vector<SungWord>& words) {
 	int sylCount = 0;
 	bool capitalized = false;
 	bool bis = false;
-	bool inBis = false;
+	int bisDepth = 0;
 
 	auto finalize = [&]() {
 		if (wordOpen && !accumNorm.empty()) {
@@ -299,9 +299,6 @@ void Tool_textract::buildSungWords(HTp textStart, vector<SungWord>& words) {
 		}
 
 		string raw = *cur;
-		if (raw.find('<') != string::npos) {
-			inBis = true;
-		}
 
 		vector<string> parts;
 		size_t pos = 0;
@@ -320,6 +317,12 @@ void Tool_textract::buildSungWords(HTp textStart, vector<SungWord>& words) {
 			if (part.empty()) {
 				continue;
 			}
+			for (char c : part) {
+				if (c == '<') {
+					bisDepth++;
+				}
+			}
+			bool inBis = (bisDepth > 0);
 			string core = part;
 			if (!core.empty() && (core[0] == '<')) {
 				core = core.substr(1);
@@ -328,6 +331,13 @@ void Tool_textract::buildSungWords(HTp textStart, vector<SungWord>& words) {
 			bool trailingDash = endsWithContinuationDash(core);
 			string n = normalizeWord(part);
 			string o = cleanOrigPiece(part);
+			for (char c : part) {
+				if (c == '>') {
+					if (bisDepth > 0) {
+						bisDepth--;
+					}
+				}
+			}
 			if (n.empty() && o.empty()) {
 				continue;
 			}
@@ -338,6 +348,34 @@ void Tool_textract::buildSungWords(HTp textStart, vector<SungWord>& words) {
 				sylCount++;
 				if (!trailingDash) {
 					finalize();
+				}
+			} else if (wordOpen && !leadingDash) {
+				// Previous syllable had trailing '-'; next may omit leading '-'.
+				bool newCap = false;
+				for (char c : core) {
+					if (isalpha((unsigned char)c)) {
+						newCap = isupper((unsigned char)c) != 0;
+						break;
+					}
+				}
+				if (!newCap) {
+					accumNorm += n;
+					accumOrig += o;
+					sylCount++;
+					if (!trailingDash) {
+						finalize();
+					}
+				} else {
+					finalize();
+					capitalized = true;
+					bis = inBis;
+					accumNorm = n;
+					accumOrig = o;
+					sylCount = 1;
+					wordOpen = true;
+					if (!trailingDash) {
+						finalize();
+					}
 				}
 			} else {
 				if (wordOpen) {
@@ -361,9 +399,6 @@ void Tool_textract::buildSungWords(HTp textStart, vector<SungWord>& words) {
 			}
 		}
 
-		if (raw.find('>') != string::npos) {
-			inBis = false;
-		}
 		cur = cur->getNextToken();
 	}
 	finalize();
@@ -555,20 +590,6 @@ int Tool_textract::lineSyllables(const vector<SungWord>& line) {
 
 //////////////////////////////
 //
-// Tool_textract::expectedSyllables -- Positional target; list cycles.
-//
-
-int Tool_textract::expectedSyllables(int lineIndex) {
-	if (m_sylCounts.empty()) {
-		return 0;
-	}
-	return m_sylCounts[lineIndex % (int)m_sylCounts.size()];
-}
-
-
-
-//////////////////////////////
-//
 // Tool_textract::distanceToAllowed -- Min distance to any -s length.
 //
 
@@ -606,6 +627,42 @@ bool Tool_textract::isAllowedLength(int syllables, int tol) {
 
 //////////////////////////////
 //
+// Tool_textract::minAllowedLength -- Smallest length in the -s set.
+//
+
+int Tool_textract::minAllowedLength(void) {
+	if (m_sylCounts.empty()) {
+		return 0;
+	}
+	int m = m_sylCounts[0];
+	for (int t : m_sylCounts) {
+		m = min(m, t);
+	}
+	return m;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_textract::maxAllowedLength -- Largest length in the -s set.
+//
+
+int Tool_textract::maxAllowedLength(void) {
+	if (m_sylCounts.empty()) {
+		return 0;
+	}
+	int m = m_sylCounts[0];
+	for (int t : m_sylCounts) {
+		m = max(m, t);
+	}
+	return m;
+}
+
+
+
+//////////////////////////////
+//
 // Tool_textract::segmentLines -- Split a voice on capitalized words.
 //    Mid-line capitals (not common line-starters) may stay in the current
 //    line.  Syllable targets (-s) are applied later in refineLines.
@@ -633,8 +690,15 @@ void Tool_textract::segmentLines(Voice& voice) {
 				if ((int)cur.size() <= 2) {
 					doBreak = false;
 				} else if (!m_sylCounts.empty()) {
+					// With -s, suppress the break only while the current
+					// line is still short of every allowed length (still
+					// being built).  Once it is at/near an allowed length,
+					// or has overshot the longest allowed length, break so
+					// a missed boundary cannot glue the rest of the poem
+					// into one mega-line.
 					int have = lineSyllables(cur);
-					if (!isAllowedLength(have, 1)) {
+					if (!isAllowedLength(have, 1) &&
+							(have <= maxAllowedLength() + 1)) {
 						doBreak = false;
 					}
 				}
@@ -660,16 +724,17 @@ bool Tool_textract::likelyLineStart(const string& norm) {
 	static const set<string> starters = {
 		"e", "ed", "a", "ad", "di", "de", "del", "che", "chi",
 		"la", "le", "il", "lo", "gli", "ne", "ma", "per", "se",
-		"non", "un", "una", "uno", "i", "o", "oh", "ah", "quando",
+		"non", "un", "una", "uno", "i", "o", "oh", "ah", "deh", "quando",
 		"come", "cosi", "poi", "anzi", "hor", "or", "ora", "ore",
 		"sol", "solo", "su", "sul", "tra", "fra", "con", "da", "dal"
 	};
 	if (starters.count(norm)) {
 		return true;
 	}
-	// "E'n", "Né", "Sol' io" folded forms.
+	// "E'n", "Né", "Sol' io", "Quand'ecco" folded forms.
 	if ((norm == "ne") || (norm.rfind("sol", 0) == 0) ||
-			(norm.rfind("e'", 0) == 0) || (norm.rfind("ne'", 0) == 0)) {
+			(norm.rfind("e'", 0) == 0) || (norm.rfind("ne'", 0) == 0) ||
+			(norm.rfind("quand", 0) == 0)) {
 		return true;
 	}
 	return false;
@@ -716,7 +781,7 @@ bool Tool_textract::linesSimilar(const vector<SungWord>& a,
 		}
 	}
 	double ratio = (double)dp[a.size()][b.size()] / (double)maxLen;
-	return ratio >= 0.75;
+	return ratio >= 0.65;
 }
 
 
@@ -893,8 +958,8 @@ vector<Tool_textract::SungWord> Tool_textract::consensusLine(LineCluster& cluste
 
 //////////////////////////////
 //
-// Tool_textract::reconstructText -- Cluster lines across voices, keep
-//    majority-supported lines, order by typical singing order, emit text.
+// Tool_textract::reconstructText -- Cluster lines across voices, resolve
+//    wording conflicts by majority, order by typical singing order, emit text.
 //
 
 void Tool_textract::reconstructText(vector<Voice>& voices) {
@@ -916,7 +981,6 @@ void Tool_textract::reconstructText(vector<Voice>& voices) {
 				if (!similar && !lineInRep && !repInLine) {
 					continue;
 				}
-				// Short fragments only merge if they cover most of the other line.
 				if (!similar && lineInRep &&
 						((int)line.size() * 2 < (int)rep.size())) {
 					continue;
@@ -925,7 +989,6 @@ void Tool_textract::reconstructText(vector<Voice>& voices) {
 						((int)rep.size() * 2 < (int)line.size())) {
 					continue;
 				}
-				// Require shared first word when both are capitalized starts.
 				if (!line.empty() && !rep.empty() &&
 						line[0].capitalized && rep[0].capitalized &&
 						(line[0].norm != rep[0].norm)) {
@@ -937,7 +1000,6 @@ void Tool_textract::reconstructText(vector<Voice>& voices) {
 			if (best >= 0) {
 				clusters[best].members.push_back(line);
 				clusters[best].voiceIds.push_back(vi);
-				// Prefer storing fuller versions first for later consensus.
 				if (line.size() > clusters[best].members[0].size()) {
 					swap(clusters[best].members[0],
 							clusters[best].members.back());
@@ -951,10 +1013,6 @@ void Tool_textract::reconstructText(vector<Voice>& voices) {
 		}
 	}
 
-	int nVoices = (int)voices.size();
-	int majority = (nVoices + 1) / 2;
-
-	// Compute average position among contributing voices.
 	for (LineCluster& c : clusters) {
 		double sum = 0;
 		int count = 0;
@@ -965,7 +1023,6 @@ void Tool_textract::reconstructText(vector<Voice>& voices) {
 				continue;
 			}
 			seen.insert(vi);
-			// position = index of this line among that voice's lines
 			auto rep = consensusLine(c);
 			for (int li=0; li<(int)voices[vi].lines.size(); li++) {
 				if (linesSimilar(voices[vi].lines[li], rep) ||
@@ -980,17 +1037,62 @@ void Tool_textract::reconstructText(vector<Voice>& voices) {
 		c.avgPos = (count > 0) ? (sum / count) : 0;
 	}
 
+	// Merge clusters that are conflicting readings of the same line.
+	bool merged = true;
+	while (merged) {
+		merged = false;
+		for (int i=0; i<(int)clusters.size() && !merged; i++) {
+			auto ri = consensusLine(clusters[i]);
+			for (int j=i+1; j<(int)clusters.size(); j++) {
+				auto rj = consensusLine(clusters[j]);
+				bool similar = linesSimilar(ri, rj);
+				bool iInJ = isSubSequence(ri, rj);
+				bool jInI = isSubSequence(rj, ri);
+				if (!similar && !iInJ && !jInI) {
+					continue;
+				}
+				if (!similar && iInJ && ((int)ri.size() * 2 < (int)rj.size())) {
+					continue;
+				}
+				if (!similar && jInI && ((int)rj.size() * 2 < (int)ri.size())) {
+					continue;
+				}
+				if (!ri.empty() && !rj.empty() &&
+						ri[0].capitalized && rj[0].capitalized &&
+						(ri[0].norm != rj[0].norm)) {
+					continue;
+				}
+				clusters[i].members.insert(clusters[i].members.end(),
+						clusters[j].members.begin(), clusters[j].members.end());
+				clusters[i].voiceIds.insert(clusters[i].voiceIds.end(),
+						clusters[j].voiceIds.begin(), clusters[j].voiceIds.end());
+				int ni = (int)set<int>(clusters[i].voiceIds.begin(),
+						clusters[i].voiceIds.end()).size();
+				int nj = (int)set<int>(clusters[j].voiceIds.begin(),
+						clusters[j].voiceIds.end()).size();
+				clusters[i].avgPos = (clusters[i].avgPos * ni + clusters[j].avgPos * nj)
+						/ max(ni + nj, 1);
+				clusters.erase(clusters.begin() + j);
+				merged = true;
+				break;
+			}
+		}
+	}
+
 	vector<int> keep;
 	for (int ci=0; ci<(int)clusters.size(); ci++) {
-		set<int> uniqVoices(clusters[ci].voiceIds.begin(), clusters[ci].voiceIds.end());
-		if ((int)uniqVoices.size() >= majority) {
-			keep.push_back(ci);
-		}
+		keep.push_back(ci);
 	}
 
 	stable_sort(keep.begin(), keep.end(), [&](int a, int b) {
 		if (fabs(clusters[a].avgPos - clusters[b].avgPos) > 1e-6) {
 			return clusters[a].avgPos < clusters[b].avgPos;
+		}
+		// More widely attested readings first on a position tie.
+		int na = (int)set<int>(clusters[a].voiceIds.begin(), clusters[a].voiceIds.end()).size();
+		int nb = (int)set<int>(clusters[b].voiceIds.begin(), clusters[b].voiceIds.end()).size();
+		if (na != nb) {
+			return na > nb;
 		}
 		return a < b;
 	});
@@ -999,7 +1101,27 @@ void Tool_textract::reconstructText(vector<Voice>& voices) {
 	for (int ci : keep) {
 		auto line = consensusLine(clusters[ci]);
 		collapseRepeats(line);
-		if (!line.empty()) {
+		if (line.empty()) {
+			continue;
+		}
+		bool skip = false;
+		for (size_t pi=0; pi<poem.size(); pi++) {
+			auto& prev = poem[pi];
+			if (linesSimilar(line, prev)) {
+				skip = true;
+				break;
+			}
+			if (isSubSequence(line, prev)) {
+				skip = true;
+				break;
+			}
+			if (isSubSequence(prev, line)) {
+				poem[pi] = line;
+				skip = true;
+				break;
+			}
+		}
+		if (!skip) {
 			poem.push_back(line);
 		}
 	}
@@ -1017,9 +1139,11 @@ void Tool_textract::reconstructText(vector<Voice>& voices) {
 
 //////////////////////////////
 //
-// Tool_textract::refineLines -- Apply -s lengths (list cycles; any listed
-//    length is allowed).  Metrical counts subtract synaloepha/apostrophe
-//    elision between adjacent words, including across a merge boundary.
+// Tool_textract::refineLines -- Apply -s lengths as a set of allowed
+//    metrical counts (not an alternating cycle).  Too-short lines may be
+//    merged; too-long lines may be split on capitals.  Metrical counts
+//    subtract synaloepha/apostrophe elision between adjacent words,
+//    including across a merge boundary.
 //
 
 void Tool_textract::refineLines(vector<vector<SungWord>>& lines) {
@@ -1027,62 +1151,57 @@ void Tool_textract::refineLines(vector<vector<SungWord>>& lines) {
 		return;
 	}
 
+	const int minAllow = minAllowedLength();
+	const int maxAllow = maxAllowedLength();
+
 	vector<vector<SungWord>> out;
 	int i = 0;
 	while (i < (int)lines.size()) {
-		int target = expectedSyllables((int)out.size());
 		int syl = lineSyllables(lines[i]);
 
-		if (isAllowedLength(syl) || (syl == target)) {
+		if (isAllowedLength(syl, 1)) {
 			out.push_back(lines[i]);
 			i++;
 			continue;
 		}
 
-		if (i + 1 < (int)lines.size()) {
-			int nextSyl = lineSyllables(lines[i+1]);
-			bool nextComplete = isAllowedLength(nextSyl);
+		// Too short: try merging following incomplete fragments until the
+		// combination hits an allowed length (or stops improving).
+		if ((syl < minAllow) && (i + 1 < (int)lines.size())) {
 			vector<SungWord> combined = lines[i];
-			combined.insert(combined.end(), lines[i+1].begin(), lines[i+1].end());
-			int combSyl = lineSyllables(combined); // includes cross-line elision
-			bool hits = isAllowedLength(combSyl) || (combSyl == target);
-			bool improves = distanceToAllowed(combSyl) < distanceToAllowed(syl);
-
-			// Never absorb a complete following line unless the merge exactly hits.
-			bool allowMerge = hits || (improves && !nextComplete);
-			if (allowMerge && !hits && !lines[i+1].empty() &&
-					likelyLineStart(lines[i+1][0].norm) && nextComplete) {
-				allowMerge = false;
-			}
-
-			if (allowMerge) {
-				int j = i + 2;
-				while (j < (int)lines.size() && !isAllowedLength(lineSyllables(combined))) {
-					if (isAllowedLength(lineSyllables(lines[j]))) {
-						break;
-					}
-					vector<SungWord> trial = combined;
-					trial.insert(trial.end(), lines[j].begin(), lines[j].end());
-					int t2 = lineSyllables(combined);
-					int t3 = lineSyllables(trial);
-					if (distanceToAllowed(t3) <= distanceToAllowed(t2)) {
-						combined.swap(trial);
-						j++;
-					} else {
-						break;
-					}
+			int j = i + 1;
+			while (j < (int)lines.size()) {
+				int nextSyl = lineSyllables(lines[j]);
+				// Do not absorb a following line that is already complete.
+				if (isAllowedLength(nextSyl, 1)) {
+					break;
 				}
+				vector<SungWord> trial = combined;
+				trial.insert(trial.end(), lines[j].begin(), lines[j].end());
+				int combSyl = lineSyllables(trial);
+				if (isAllowedLength(combSyl, 1)) {
+					combined.swap(trial);
+					j++;
+					break;
+				}
+				if (distanceToAllowed(combSyl) < distanceToAllowed(lineSyllables(combined))
+						&& (combSyl <= maxAllow + 1)) {
+					combined.swap(trial);
+					j++;
+					continue;
+				}
+				break;
+			}
+			if (j > i + 1 || isAllowedLength(lineSyllables(combined), 1)) {
 				out.push_back(combined);
 				i = j;
 				continue;
 			}
 		}
 
-		int maxAllowed = m_sylCounts[0];
-		for (int t : m_sylCounts) {
-			maxAllowed = max(maxAllowed, t);
-		}
-		if (syl > maxAllowed + 1) {
+		// Too long: split on a capital so the left side matches an allowed
+		// length (prefer the earliest such break).
+		if (syl > maxAllow + 1) {
 			int bestBreak = -1;
 			int bestDist = 9999;
 			for (int k=1; k<(int)lines[i].size(); k++) {
@@ -1095,6 +1214,10 @@ void Tool_textract::refineLines(vector<vector<SungWord>>& lines) {
 				if (isAllowedLength(leftSyl, 1) && (dist < bestDist)) {
 					bestDist = dist;
 					bestBreak = k;
+					// Earliest exact-ish hit is enough.
+					if (dist == 0) {
+						break;
+					}
 				}
 			}
 			if (bestBreak > 0) {

--- a/src/tool-textract.cpp
+++ b/src/tool-textract.cpp
@@ -700,7 +700,10 @@ void Tool_textract::segmentLines(Voice& voice) {
 					// being built).  Once it is at/near an allowed length,
 					// or has overshot the longest allowed length, break so
 					// a missed boundary cannot glue the rest of the poem
-					// into one mega-line.
+					// into one mega-line.  Mid-line capitals after a shorter
+					// allowed hit (e.g. "Amor" after a 7 when -s is 7,11)
+					// are repaired later in refineLines by folding a short
+					// trailing fragment back into the previous line.
 					int have = lineSyllables(cur);
 					if (!isAllowedLength(have, 1) &&
 							(have <= maxAllowedLength() + 1)) {
@@ -911,6 +914,18 @@ vector<Tool_textract::SungWord> Tool_textract::consensusLine(LineCluster& cluste
 		}
 		score -= 0.75 * fabs((double)m.size() - (double)medianLen);
 
+		// Prefer a reading whose metrical count hits an allowed -s length
+		// (e.g. full "Riso tra perle..." at 11 over a mid-entry
+		// "Tra perle..." at 9 when -s 7,11).
+		if (!m_sylCounts.empty()) {
+			int syl = lineSyllables(m);
+			if (isAllowedLength(syl, 1)) {
+				score += 3.0;
+			} else {
+				score -= distanceToAllowed(syl);
+			}
+		}
+
 		// Penalize an immediate repeated half of the line.
 		int n = (int)m.size();
 		if ((n >= 4) && (n % 2 == 0)) {
@@ -997,7 +1012,12 @@ void Tool_textract::reconstructText(vector<Voice>& voices) {
 				}
 				if (!line.empty() && !rep.empty() &&
 						line[0].capitalized && rep[0].capitalized &&
-						(line[0].norm != rep[0].norm)) {
+						(line[0].norm != rep[0].norm) &&
+						!lineInRep && !repInLine) {
+					// Different line openings usually mean different
+					// poem lines, but not when one reading is a mid-line
+					// entry into the other ("Tra perle..." vs
+					// "Riso tra perle...").
 					continue;
 				}
 				best = ci;
@@ -1065,7 +1085,8 @@ void Tool_textract::reconstructText(vector<Voice>& voices) {
 				}
 				if (!ri.empty() && !rj.empty() &&
 						ri[0].capitalized && rj[0].capitalized &&
-						(ri[0].norm != rj[0].norm)) {
+						(ri[0].norm != rj[0].norm) &&
+						!iInJ && !jInI) {
 					continue;
 				}
 				clusters[i].members.insert(clusters[i].members.end(),
@@ -1113,16 +1134,27 @@ void Tool_textract::reconstructText(vector<Voice>& voices) {
 		bool skip = false;
 		for (size_t pi=0; pi<poem.size(); pi++) {
 			auto& prev = poem[pi];
-			if (linesSimilar(line, prev)) {
-				skip = true;
-				break;
-			}
-			if (isSubSequence(line, prev)) {
-				skip = true;
-				break;
-			}
-			if (isSubSequence(prev, line)) {
-				poem[pi] = line;
+			if (linesSimilar(line, prev) || isSubSequence(line, prev) ||
+					isSubSequence(prev, line)) {
+				// Same poem line attested in fuller/partial forms: keep
+				// the metrically better (or longer) reading.
+				bool lineBetter = false;
+				if (!m_sylCounts.empty()) {
+					int sylNew = lineSyllables(line);
+					int sylOld = lineSyllables(prev);
+					int dNew = distanceToAllowed(sylNew);
+					int dOld = distanceToAllowed(sylOld);
+					if (dNew < dOld) {
+						lineBetter = true;
+					} else if ((dNew == dOld) && (line.size() > prev.size())) {
+						lineBetter = true;
+					}
+				} else if (line.size() > prev.size()) {
+					lineBetter = true;
+				}
+				if (lineBetter) {
+					poem[pi] = line;
+				}
 				skip = true;
 				break;
 			}
@@ -1164,6 +1196,24 @@ void Tool_textract::refineLines(vector<vector<SungWord>>& lines) {
 	int i = 0;
 	while (i < (int)lines.size()) {
 		int syl = lineSyllables(lines[i]);
+
+		// Short trailing fragment after a line that already hit a shorter
+		// allowed length (e.g. "Ma che…schivargli" at 7 + "Amor ci toglie"):
+		// fold back if the combination hits an allowed length and the
+		// fragment does not open with a typical line-starter.
+		if (!isAllowedLength(syl, 1) && !out.empty()) {
+			if (lines[i].empty() || !likelyLineStart(lines[i][0].norm)) {
+				vector<SungWord> combined = out.back();
+				combined.insert(combined.end(), lines[i].begin(), lines[i].end());
+				int combSyl = lineSyllables(combined);
+				if (isAllowedLength(combSyl, 1) &&
+						(distanceToAllowed(combSyl) <= distanceToAllowed(lineSyllables(out.back())))) {
+					out.back().swap(combined);
+					i++;
+					continue;
+				}
+			}
+		}
 
 		if (isAllowedLength(syl, 1)) {
 			out.push_back(lines[i]);


### PR DESCRIPTION
textract: extract and print out the poem by processing the various vocal parts. Optional params to specify expected syllable counts, and expected line counts (-s and -l respectively). If !!@GENRE is found and has a value of "sonetto" and the user hasn't specified an expected line count, `-l 14` will be used. Gets used internally by pliner.

pliner: uses textract to get the lines of the poem set in the piece, and then adds pline annotation to the score accordingly. textract's `-s` and `-l` params can be passed here to so they get passed on to the internal call to textract. Generally works pretty well but the tool can get confused by typos or minor issues in the text setting.

Example usage:

`bin/pliner -s 7,11 test_file_5.krn > trm0707a_plineroutput.krn`

pliner could get merged into pline and the distinction could be handled via parameters if that's preferred. For simplicity I've kept them separate but I don't have a strong opinion here.