### PR TITLE
Add "closing" tool

### DIFF
--- a/cli/closing.cpp
+++ b/cli/closing.cpp
@@ -1,0 +1,13 @@
+//
+// Programmer:    Alexander Morgan
+// Creation Date: Sun Aug 16 2026
+// Filename:      cli/closing.cpp
+// Syntax:        C++11
+// vim:           ts=3 noexpandtab nowrap
+//
+// Description:   Count the voices that stop sounding at each observation point.
+//
+
+#include "humlib.h"
+
+STREAM_INTERFACE(Tool_closing)

--- a/include/HumdrumFileContent.h
+++ b/include/HumdrumFileContent.h
@@ -48,6 +48,13 @@ class HumdrumFileContent : public HumdrumFileStructure {
 		bool   doHandAnalysis             (bool attacksOnlyQ = false);
 		bool   doHandAnalysis             (HTp startSpine, bool attacksOnlyQ = false);
 
+		// in HumdrumFileContent-closing.cpp
+		bool  analyzeClosingRests         (void);
+		bool  analyzeClosingRests         (HTp spinestart);
+		bool  isClosingRest               (HTp token);
+		bool  isClosingAttack             (HTp token);
+		bool  isClosingEvent              (HTp token);
+
 		// in HumdrumFileContent-kern.cpp
 		std::vector<int> getTrackToKernIndex (void);
 

--- a/include/humlib.h
+++ b/include/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Sun Aug 16 11:39:45 CEST 2026
+// Last Modified: Sun Aug 16 12:52:36 CEST 2026
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11
@@ -6863,16 +6863,12 @@ class Tool_closing : public HumTool {
 		void     countClosingVoices  (HumdrumFile& infile);
 		void     markClosingEvents   (HumdrumFile& infile);
 		void     addAnalysisSpine    (HumdrumFile& infile);
-		void     printRawAnalysis    (HumdrumFile& infile);
 
 	private:
 		// m_counts: closing voice count for each line, or -1 for lines that get
 		// no analysis value (such as non-data lines).
 		std::vector<int> m_counts;
-		bool        m_prependQ     = false;
 		bool        m_markQ        = false;
-		bool        m_rawQ         = false;
-		int         m_minimum      = 0;
 		std::string m_attackMarker = "@";
 		std::string m_restMarker   = "N";
 		std::string m_attackColor  = "dodgerblue";

--- a/include/humlib.h
+++ b/include/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Thu Jul 16 11:57:52 CEST 2026
+// Last Modified: Sun Aug 16 11:39:45 CEST 2026
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11
@@ -2538,6 +2538,13 @@ class HumdrumFileContent : public HumdrumFileStructure {
 		// in HumdrumFileContent-hand.cpp
 		bool   doHandAnalysis             (bool attacksOnlyQ = false);
 		bool   doHandAnalysis             (HTp startSpine, bool attacksOnlyQ = false);
+
+		// in HumdrumFileContent-closing.cpp
+		bool  analyzeClosingRests         (void);
+		bool  analyzeClosingRests         (HTp spinestart);
+		bool  isClosingRest               (HTp token);
+		bool  isClosingAttack             (HTp token);
+		bool  isClosingEvent              (HTp token);
 
 		// in HumdrumFileContent-kern.cpp
 		std::vector<int> getTrackToKernIndex (void);
@@ -6182,7 +6189,7 @@ class Tool_autocadence : public HumTool {
 		void        addCadenceLabel            (std::string definition, std::string label);
 		void        addCadenceDefinition       (const std::string& funcL, const std::string& funcU,
 		                                        const std::string& name, const std::string& regex);
-		void        prepareLowestPitches       (void);
+		void        prepareLowestPitches       (HumdrumFile& infile);
 		void        preparePitchInfo           (HumdrumFile& infile);
 		void        prepareDiatonicPitches     (HumdrumFile& infile);
 		void        printExtractedPitchInfo    (HumdrumFile& infile);
@@ -6226,6 +6233,7 @@ class Tool_autocadence : public HumTool {
 		bool        getPhrygian                (HumdrumFile& infile, int index);
 		std::string getIntervalName            (const std::string& b40);
 		std::string getTriadData               (HumdrumFile& infile, int line);
+		std::string getCadenceLabel            (const std::string& cvflabel, HumdrumFile& infile, int index);
 
 	private:
 
@@ -6241,6 +6249,9 @@ class Tool_autocadence : public HumTool {
 		// m_lowestPitch: the lowest sounding pitch at every instance in the score.
 		// the pitch is stored as an absolute diatonic pitch, middle C is 28, 0 is a rest
 		std::vector<int> m_lowestPitch;
+
+		// m_lowestPitchIndex: the lowest sounding pitch field index.
+		std::vector<int> m_lowestPitchIndex;
 
 		// m_intervals: The counterpoint intervals for each pair of notes.
 		// The data is store in a 3-D vector, where the first dimension is the
@@ -6338,6 +6349,7 @@ class Tool_autocadence : public HumTool {
 		std::vector<std::string> m_root;
 		bool m_foundEmpytTriad = false;
 		bool m_hasTriadColor = false;
+		bool m_removeWeakQ = false;
 };
 
 
@@ -6832,6 +6844,39 @@ class Tool_cint : public HumTool {
 		std::string SearchString;
 		std::string Spacer;
 
+};
+
+
+class Tool_closing : public HumTool {
+	public:
+		         Tool_closing        (void);
+		        ~Tool_closing        () {};
+
+		bool     run                 (HumdrumFileSet& infiles);
+		bool     run                 (HumdrumFile& infile);
+		bool     run                 (const std::string& indata, std::ostream& out);
+		bool     run                 (HumdrumFile& infile, std::ostream& out);
+
+	protected:
+		void     initialize          (void);
+		void     processFile         (HumdrumFile& infile);
+		void     countClosingVoices  (HumdrumFile& infile);
+		void     markClosingEvents   (HumdrumFile& infile);
+		void     addAnalysisSpine    (HumdrumFile& infile);
+		void     printRawAnalysis    (HumdrumFile& infile);
+
+	private:
+		// m_counts: closing voice count for each line, or -1 for lines that get
+		// no analysis value (such as non-data lines).
+		std::vector<int> m_counts;
+		bool        m_prependQ     = false;
+		bool        m_markQ        = false;
+		bool        m_rawQ         = false;
+		int         m_minimum      = 0;
+		std::string m_attackMarker = "@";
+		std::string m_restMarker   = "N";
+		std::string m_attackColor  = "dodgerblue";
+		std::string m_restColor    = "orange";
 };
 
 
@@ -10973,7 +11018,7 @@ class Tool_pliner : public HumTool {
 			int pos    = -1;
 		};
 
-		bool     parseVerse        (HumdrumFile& infile, std::vector<std::vector<PoemWord>>& poem);
+		bool     extractPoem       (HumdrumFile& infile, std::vector<std::vector<PoemWord>>& poem);
 
 		// voice model:
 		struct Voice {
@@ -12143,6 +12188,73 @@ class Tool_textdur : public HumTool {
 		bool m_interleaveQ   = false;  // used with -i option
 		HumNum m_RhythmFactor = 1;     // uwed with -1, -2, -8, and later -f #
 
+};
+
+
+class Tool_textract : public HumTool {
+	public:
+		         Tool_textract    (void);
+		        ~Tool_textract    () {};
+
+		bool     run              (HumdrumFileSet& infiles);
+		bool     run              (HumdrumFile& infile);
+		bool     run              (const std::string& indata, std::ostream& out);
+		bool     run              (HumdrumFile& infile, std::ostream& out);
+
+	protected:
+		struct SungWord {
+			std::string original;
+			std::string norm;
+			int  syllables   = 0;
+			bool capitalized = false;
+			bool bis         = false;
+		};
+
+		struct Voice {
+			HTp textStart = NULL;
+			std::vector<SungWord> words;
+			std::vector<std::vector<SungWord>> lines;
+		};
+
+		struct LineCluster {
+			std::vector<std::vector<SungWord>> members; // one entry per contributing voice line
+			std::vector<int> voiceIds;
+			double avgPos = 0.0;
+		};
+
+		void     initialize       (void);
+		void     processFile      (HumdrumFile& infile);
+
+		void     getVoices        (HumdrumFile& infile, std::vector<Voice>& voices);
+		void     buildSungWords   (HTp textStart, std::vector<SungWord>& words);
+		std::string normalizeWord (const std::string& text);
+		std::string cleanOrigPiece(const std::string& text);
+		void     collapseRepeats  (std::vector<SungWord>& words);
+		void     segmentLines     (Voice& voice);
+		int      lineSyllables    (const std::vector<SungWord>& line);
+		int      distanceToAllowed(int syllables);
+		bool     isAllowedLength  (int syllables, int tol = 0);
+		int      minAllowedLength (void);
+		int      maxAllowedLength (void);
+		bool     endsWithVowel    (const std::string& norm);
+		bool     startsWithVowel  (const std::string& norm);
+		bool     elidesWith       (const SungWord& left, const SungWord& right);
+		bool     likelyLineStart  (const std::string& norm);
+		bool     linesSimilar     (const std::vector<SungWord>& a,
+		                           const std::vector<SungWord>& b);
+		bool     isSubSequence    (const std::vector<SungWord>& shorter,
+		                           const std::vector<SungWord>& longer);
+		void     dedupeVoiceLines (Voice& voice);
+		void     reconstructText  (std::vector<Voice>& voices);
+		void     refineLines      (std::vector<std::vector<SungWord>>& lines);
+		int      detectGenreLineCount(HumdrumFile& infile);
+		void     enforceLineCount (std::vector<std::vector<SungWord>>& lines);
+		std::vector<SungWord> consensusLine(LineCluster& cluster);
+		std::string lineToString  (const std::vector<SungWord>& line);
+
+	private:
+		std::vector<int> m_sylCounts; // empty = unused
+		int m_expectedLines = 0;      // 0 = unset / auto
 };
 
 

--- a/include/tool-closing.h
+++ b/include/tool-closing.h
@@ -1,0 +1,63 @@
+//
+// Programmer:    Alexander Morgan
+// Creation Date: Sun Aug 16 2026
+// Filename:      tool-closing.h
+// Syntax:        C++11; humlib
+// vim:           ts=3 noexpandtab
+//
+// Description:   Count how many voices stop sounding at each observation point
+//                of a score, which is used to evaluate potential cadence
+//                points.
+//
+
+#ifndef _TOOL_CLOSING_H
+#define _TOOL_CLOSING_H
+
+#include "HumTool.h"
+#include "HumdrumFileSet.h"
+
+#include <ostream>
+#include <string>
+#include <vector>
+
+namespace hum {
+
+// START_MERGE
+
+class Tool_closing : public HumTool {
+	public:
+		         Tool_closing        (void);
+		        ~Tool_closing        () {};
+
+		bool     run                 (HumdrumFileSet& infiles);
+		bool     run                 (HumdrumFile& infile);
+		bool     run                 (const std::string& indata, std::ostream& out);
+		bool     run                 (HumdrumFile& infile, std::ostream& out);
+
+	protected:
+		void     initialize          (void);
+		void     processFile         (HumdrumFile& infile);
+		void     countClosingVoices  (HumdrumFile& infile);
+		void     markClosingEvents   (HumdrumFile& infile);
+		void     addAnalysisSpine    (HumdrumFile& infile);
+		void     printRawAnalysis    (HumdrumFile& infile);
+
+	private:
+		// m_counts: closing voice count for each line, or -1 for lines that get
+		// no analysis value (such as non-data lines).
+		std::vector<int> m_counts;
+		bool        m_prependQ     = false;
+		bool        m_markQ        = false;
+		bool        m_rawQ         = false;
+		int         m_minimum      = 0;
+		std::string m_attackMarker = "@";
+		std::string m_restMarker   = "N";
+		std::string m_attackColor  = "dodgerblue";
+		std::string m_restColor    = "orange";
+};
+
+// END_MERGE
+
+} // end namespace hum
+
+#endif /* _TOOL_CLOSING_H */

--- a/include/tool-closing.h
+++ b/include/tool-closing.h
@@ -40,16 +40,12 @@ class Tool_closing : public HumTool {
 		void     countClosingVoices  (HumdrumFile& infile);
 		void     markClosingEvents   (HumdrumFile& infile);
 		void     addAnalysisSpine    (HumdrumFile& infile);
-		void     printRawAnalysis    (HumdrumFile& infile);
 
 	private:
 		// m_counts: closing voice count for each line, or -1 for lines that get
 		// no analysis value (such as non-data lines).
 		std::vector<int> m_counts;
-		bool        m_prependQ     = false;
 		bool        m_markQ        = false;
-		bool        m_rawQ         = false;
-		int         m_minimum      = 0;
 		std::string m_attackMarker = "@";
 		std::string m_restMarker   = "N";
 		std::string m_attackColor  = "dodgerblue";

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Fri Jul 31 14:13:03 CEST 2026
+// Last Modified: Sun Aug 16 11:39:45 CEST 2026
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -26703,6 +26703,128 @@ void HumdrumFileContent::markBeamSpanMembers(HTp beamstart, HTp beamend) {
 	}
 }
 
+
+
+
+
+
+//////////////////////////////
+//
+// HumdrumFileContent::analyzeClosingRests -- Mark the closing rests and closing
+//     attacks in every **kern voice.  Returns true if there was a voice to
+//     process.
+//
+
+bool HumdrumFileContent::analyzeClosingRests(void) {
+	bool output = false;
+	for (HTp kernstart : getKernSpineStartList()) {
+		output |= analyzeClosingRests(kernstart);
+	}
+	return output;
+}
+
+
+
+//////////////////////////////
+//
+// HumdrumFileContent::analyzeClosingRests -- Process a single voice, marking
+//     each closingRest (the first rest after one or more notes) and the matching
+//     closingAttack (the last note attack before that rest).  The end of the
+//     voice counts as a rest, so the last attack of the voice is a closingAttack
+//     even when no rest follows it.
+//
+//     Subspines (layers) are followed as separate paths, and a path stops where
+//     it meets a token that another path already processed (i.e., where
+//     subspines merge again).
+//
+
+bool HumdrumFileContent::analyzeClosingRests(HTp spinestart) {
+	if (!spinestart || !spinestart->isStaffLike()) {
+		return false;
+	}
+
+	// Each entry is a token to process, paired with the most recent note attack
+	// before it (NULL if the previous event was a rest or there was no note).
+	vector<pair<HTp, HTp>> tovisit;
+	tovisit.push_back(make_pair(spinestart, (HTp)NULL));
+	set<HTp> visited;
+
+	while (!tovisit.empty()) {
+		HTp current    = tovisit.back().first;
+		HTp lastattack = tovisit.back().second;
+		tovisit.pop_back();
+		if (!current || visited.count(current)) {
+			continue;
+		}
+		visited.insert(current);
+
+		if (current->isData() && !current->isNull()) {
+			if (current->isRest()) {
+				if (lastattack) {
+					current->setValue("auto", "closingRest", "1");
+					lastattack->setValue("auto", "closingAttack", "1");
+					lastattack = NULL;
+				}
+			} else if (current->isNoteAttack()) {
+				lastattack = current;
+			}
+			// A tied continuation keeps the attack that started it.
+		}
+
+		int count = current->getNextTokenCount();
+		if ((count == 0) && lastattack) {
+			// The end of the voice acts as a rest, so its last attack closes.
+			lastattack->setValue("auto", "closingAttack", "1");
+		}
+
+		// Pushed in reverse so that the first subspine is processed first and
+		// its state is the one that carries past a merge.
+		for (int i=count-1; i>=0; i--) {
+			tovisit.push_back(make_pair(current->getNextToken(i), lastattack));
+		}
+	}
+
+	return true;
+}
+
+
+
+//////////////////////////////
+//
+// HumdrumFileContent::isClosingRest -- Returns true if the token is the first
+//     rest after one or more notes in its voice.  Run analyzeClosingRests()
+//     first.
+//
+
+bool HumdrumFileContent::isClosingRest(HTp token) {
+	return token && token->getValueBool("auto", "closingRest");
+}
+
+
+
+//////////////////////////////
+//
+// HumdrumFileContent::isClosingAttack -- Returns true if the token is the last
+//     note attack in its voice before a closing rest or before the end of the
+//     voice.  Run analyzeClosingRests() first.
+//
+
+bool HumdrumFileContent::isClosingAttack(HTp token) {
+	return token && token->getValueBool("auto", "closingAttack");
+}
+
+
+
+//////////////////////////////
+//
+// HumdrumFileContent::isClosingEvent -- Returns true if the token is a
+//     closingAttack or a closingRest, meaning that its voice stops sounding at
+//     this event or at its next attack.  Run analyzeClosingRests() first.
+//
+
+bool HumdrumFileContent::isClosingEvent(HTp token) {
+	return isClosingAttack(token) || isClosingRest(token);
+}
 
 
 
@@ -71021,6 +71143,225 @@ void Tool_cint::usage(const string& command) {
 
 
 
+
+/////////////////////////////////
+//
+// Tool_closing::Tool_closing -- Set the recognized options for the tool.
+//
+
+Tool_closing::Tool_closing(void) {
+	define("p|prepend=b",    "prepend analysis spine instead of appending it");
+	define("m|mark=b",       "mark closing attacks and closing rests in the score");
+	define("r|raw=b",        "print analysis as a plain text table");
+	define("n|minimum=i:0",  "only report counts of at least this size");
+}
+
+
+
+/////////////////////////////////
+//
+// Tool_closing::run -- Do the main work of the tool.
+//
+
+bool Tool_closing::run(HumdrumFileSet& infiles) {
+	bool status = true;
+	for (int i=0; i<infiles.getCount(); i++) {
+		status &= run(infiles[i]);
+	}
+	return status;
+}
+
+
+bool Tool_closing::run(const string& indata, ostream& out) {
+	HumdrumFile infile;
+	infile.readString(indata);
+	bool status = run(infile);
+	if (hasAnyText()) {
+		getAllText(out);
+	} else {
+		out << infile;
+	}
+	return status;
+}
+
+
+bool Tool_closing::run(HumdrumFile& infile, ostream& out) {
+	bool status = run(infile);
+	if (hasAnyText()) {
+		getAllText(out);
+	} else {
+		out << infile;
+	}
+	return status;
+}
+
+
+bool Tool_closing::run(HumdrumFile& infile) {
+	initialize();
+	processFile(infile);
+	return true;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_closing::initialize --
+//
+
+void Tool_closing::initialize(void) {
+	m_prependQ = getBoolean("prepend");
+	m_markQ    = getBoolean("mark");
+	m_rawQ     = getBoolean("raw");
+	m_minimum  = getInteger("minimum");
+	if (m_minimum < 0) {
+		// keep non-negative so that the -1 of non-data lines is never printed
+		m_minimum = 0;
+	}
+}
+
+
+
+//////////////////////////////
+//
+// Tool_closing::processFile --
+//
+
+void Tool_closing::processFile(HumdrumFile& infile) {
+	infile.analyzeClosingRests();
+	countClosingVoices(infile);
+
+	if (m_rawQ) {
+		printRawAnalysis(infile);
+		return;
+	}
+
+	if (m_markQ) {
+		markClosingEvents(infile);
+	}
+	addAnalysisSpine(infile);
+	m_humdrum_text << infile;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_closing::countClosingVoices -- For each observation point in the
+//     composite rhythm of all of the parts, count the voices whose event at
+//     that point is a closingAttack or a closingRest.  Every data line is an
+//     observation point, including lines where all of the voices are resting.
+//
+
+void Tool_closing::countClosingVoices(HumdrumFile& infile) {
+	m_counts.clear();
+	m_counts.resize(infile.getLineCount(), -1);
+
+	// A staff with more than one layer can have several closing events on the
+	// same line, but it is a single voice, so count each track only once.
+	vector<bool> counted(infile.getTrackCount() + 1, false);
+
+	for (int i=0; i<infile.getLineCount(); i++) {
+		if (!infile[i].isData()) {
+			continue;
+		}
+		fill(counted.begin(), counted.end(), false);
+		int sum = 0;
+		for (int j=0; j<infile[i].getFieldCount(); j++) {
+			HTp token = infile.token(i, j);
+			if (!infile.isClosingEvent(token)) {
+				continue;
+			}
+			int track = token->getTrack();
+			if (counted[track]) {
+				continue;
+			}
+			counted[track] = true;
+			sum++;
+		}
+		m_counts[i] = sum;
+	}
+}
+
+
+
+//////////////////////////////
+//
+// Tool_closing::markClosingEvents -- Mark each closing attack and each closing
+//     rest so that they can be seen in the notation.
+//
+
+void Tool_closing::markClosingEvents(HumdrumFile& infile) {
+	for (int i=0; i<infile.getLineCount(); i++) {
+		if (!infile[i].isData()) {
+			continue;
+		}
+		for (int j=0; j<infile[i].getFieldCount(); j++) {
+			HTp token = infile.token(i, j);
+			if (infile.isClosingAttack(token)) {
+				token->setText(*token + m_attackMarker);
+			} else if (infile.isClosingRest(token)) {
+				token->setText(*token + m_restMarker);
+			}
+		}
+	}
+	infile.createLinesFromTokens();
+
+	infile.appendLine("!!!RDF**kern: " + m_attackMarker
+			+ " = marked note, closing attack, color=\"" + m_attackColor + "\"");
+	infile.appendLine("!!!RDF**kern: " + m_restMarker
+			+ " = marked note, closing rest, color=\"" + m_restColor + "\"");
+}
+
+
+
+//////////////////////////////
+//
+// Tool_closing::addAnalysisSpine -- Add a **closing spine containing the number
+//     of closing voices at each observation point.
+//
+
+void Tool_closing::addAnalysisSpine(HumdrumFile& infile) {
+	vector<string> data(infile.getLineCount());
+	for (int i=0; i<infile.getLineCount(); i++) {
+		if (m_counts[i] < m_minimum) {
+			continue;
+		}
+		data[i] = to_string(m_counts[i]);
+	}
+	if (m_prependQ) {
+		infile.prependDataSpine(data, "", "**closing");
+	} else {
+		infile.appendDataSpine(data, "", "**closing");
+	}
+}
+
+
+
+//////////////////////////////
+//
+// Tool_closing::printRawAnalysis -- Print one line for each reported observation
+//     point: its line number in the input, its time in quarter notes from the
+//     start of the score, and the number of closing voices.
+//
+
+void Tool_closing::printRawAnalysis(HumdrumFile& infile) {
+	m_humdrum_text << "!!!voice-count: " << infile.getKernSpineStartList().size() << endl;
+	m_humdrum_text << "**line\t**qbeat\t**closing" << endl;
+	for (int i=0; i<infile.getLineCount(); i++) {
+		if (m_counts[i] < m_minimum) {
+			continue;
+		}
+		m_humdrum_text << i+1
+		               << "\t" << infile[i].getDurationFromStart().getFloat()
+		               << "\t" << m_counts[i]
+		               << endl;
+	}
+	m_humdrum_text << "*-\t*-\t*-" << endl;
+}
+
+
+
 double cmr_note_info::m_syncopationWeight = 1.0;
 double cmr_note_info::m_leapWeight = 0.5;
 
@@ -95307,6 +95648,8 @@ bool Tool_filter::run(HumdrumFileSet& infiles) {
 			RUNTOOL(chord, infile, commands[i].second, status);
 		} else if (commands[i].first == "cint") {
 			RUNTOOL(cint, infile, commands[i].second, status);
+		} else if (commands[i].first == "closing") {
+			RUNTOOL(closing, infile, commands[i].second, status);
 		} else if (commands[i].first == "cmr") {
 			RUNTOOL(cmr, infile, commands[i].second, status);
 		} else if (commands[i].first == "composite") {
@@ -127841,6 +128184,7 @@ Tool_pliner::Tool_pliner(void) {
 // Tool_pliner::run -- Do the main work of the tool.
 //
 
+
 bool Tool_pliner::run(HumdrumFileSet& infiles) {
 	bool status = true;
 	for (int i=0; i<infiles.getCount(); i++) {
@@ -127848,6 +128192,7 @@ bool Tool_pliner::run(HumdrumFileSet& infiles) {
 	}
 	return status;
 }
+
 
 
 bool Tool_pliner::run(const string& indata, ostream& out) {
@@ -127980,7 +128325,7 @@ bool Tool_pliner::extractPoem(HumdrumFile& infile, vector<vector<PoemWord>>& poe
 			cerr << "Error: cannot open text file: " << path << endl;
 			return false;
 		}
-		ostringstream oss;
+		std::ostringstream oss;
 		oss << in.rdbuf();
 		text = oss.str();
 	} else {
@@ -128006,7 +128351,7 @@ bool Tool_pliner::extractPoem(HumdrumFile& infile, vector<vector<PoemWord>>& poe
 	}
 
 	HumRegex hre;
-	istringstream stream(text);
+	std::istringstream stream(text);
 	string line;
 	int lineNum = 0;
 	while (getline(stream, line)) {
@@ -144072,7 +144417,7 @@ void Tool_textract::buildSungWords(HTp textStart, vector<SungWord>& words) {
 			SungWord sw;
 			sw.original = accumOrig;
 			sw.norm = accumNorm;
-			sw.syllables = max(sylCount, 1);
+			sw.syllables = std::max(sylCount, 1);
 			sw.capitalized = capitalized;
 			sw.bis = bis;
 			words.push_back(sw);
@@ -144393,7 +144738,7 @@ int Tool_textract::distanceToAllowed(int syllables) {
 	}
 	int best = abs(syllables - m_sylCounts[0]);
 	for (int t : m_sylCounts) {
-		best = min(best, abs(syllables - t));
+		best = std::min(best, abs(syllables - t));
 	}
 	return best;
 }
@@ -144430,7 +144775,7 @@ int Tool_textract::minAllowedLength(void) {
 	}
 	int m = m_sylCounts[0];
 	for (int t : m_sylCounts) {
-		m = min(m, t);
+		m = std::min(m, t);
 	}
 	return m;
 }
@@ -144448,7 +144793,7 @@ int Tool_textract::maxAllowedLength(void) {
 	}
 	int m = m_sylCounts[0];
 	for (int t : m_sylCounts) {
-		m = max(m, t);
+		m = std::max(m, t);
 	}
 	return m;
 }
@@ -144567,9 +144912,9 @@ bool Tool_textract::linesSimilar(const vector<SungWord>& a,
 			return true;
 		}
 	}
-	int maxLen = (int)max(a.size(), b.size());
-	int minLen = (int)min(a.size(), b.size());
-	if (maxLen - minLen > max(2, minLen / 2)) {
+	int maxLen = (int)std::max(a.size(), b.size());
+	int minLen = (int)std::min(a.size(), b.size());
+	if (maxLen - minLen > std::max(2, minLen / 2)) {
 		return false;
 	}
 	// LCS length
@@ -144579,7 +144924,7 @@ bool Tool_textract::linesSimilar(const vector<SungWord>& a,
 			if (a[i-1].norm == b[j-1].norm) {
 				dp[i][j] = dp[i-1][j-1] + 1;
 			} else {
-				dp[i][j] = max(dp[i-1][j], dp[i][j-1]);
+				dp[i][j] = std::max(dp[i-1][j], dp[i][j-1]);
 			}
 		}
 	}
@@ -144892,7 +145237,7 @@ void Tool_textract::reconstructText(vector<Voice>& voices) {
 				int nj = (int)set<int>(clusters[j].voiceIds.begin(),
 						clusters[j].voiceIds.end()).size();
 				clusters[i].avgPos = (clusters[i].avgPos * ni + clusters[j].avgPos * nj)
-						/ max(ni + nj, 1);
+						/ std::max(ni + nj, 1);
 				clusters.erase(clusters.begin() + j);
 				merged = true;
 				break;

--- a/min/humlib.cpp
+++ b/min/humlib.cpp
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Sun Aug 16 11:39:45 CEST 2026
+// Last Modified: Sun Aug 16 12:57:50 CEST 2026
 // Filename:      min/humlib.cpp
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.cpp
 // Syntax:        C++11
@@ -71150,10 +71150,7 @@ void Tool_cint::usage(const string& command) {
 //
 
 Tool_closing::Tool_closing(void) {
-	define("p|prepend=b",    "prepend analysis spine instead of appending it");
-	define("m|mark=b",       "mark closing attacks and closing rests in the score");
-	define("r|raw=b",        "print analysis as a plain text table");
-	define("n|minimum=i:0",  "only report counts of at least this size");
+	define("m|mark=b", "mark closing attacks and closing rests in the score");
 }
 
 
@@ -71210,14 +71207,7 @@ bool Tool_closing::run(HumdrumFile& infile) {
 //
 
 void Tool_closing::initialize(void) {
-	m_prependQ = getBoolean("prepend");
-	m_markQ    = getBoolean("mark");
-	m_rawQ     = getBoolean("raw");
-	m_minimum  = getInteger("minimum");
-	if (m_minimum < 0) {
-		// keep non-negative so that the -1 of non-data lines is never printed
-		m_minimum = 0;
-	}
+	m_markQ = getBoolean("mark");
 }
 
 
@@ -71230,11 +71220,6 @@ void Tool_closing::initialize(void) {
 void Tool_closing::processFile(HumdrumFile& infile) {
 	infile.analyzeClosingRests();
 	countClosingVoices(infile);
-
-	if (m_rawQ) {
-		printRawAnalysis(infile);
-		return;
-	}
 
 	if (m_markQ) {
 		markClosingEvents(infile);
@@ -71324,40 +71309,12 @@ void Tool_closing::markClosingEvents(HumdrumFile& infile) {
 void Tool_closing::addAnalysisSpine(HumdrumFile& infile) {
 	vector<string> data(infile.getLineCount());
 	for (int i=0; i<infile.getLineCount(); i++) {
-		if (m_counts[i] < m_minimum) {
+		if (m_counts[i] < 0) {
 			continue;
 		}
 		data[i] = to_string(m_counts[i]);
 	}
-	if (m_prependQ) {
-		infile.prependDataSpine(data, "", "**closing");
-	} else {
-		infile.appendDataSpine(data, "", "**closing");
-	}
-}
-
-
-
-//////////////////////////////
-//
-// Tool_closing::printRawAnalysis -- Print one line for each reported observation
-//     point: its line number in the input, its time in quarter notes from the
-//     start of the score, and the number of closing voices.
-//
-
-void Tool_closing::printRawAnalysis(HumdrumFile& infile) {
-	m_humdrum_text << "!!!voice-count: " << infile.getKernSpineStartList().size() << endl;
-	m_humdrum_text << "**line\t**qbeat\t**closing" << endl;
-	for (int i=0; i<infile.getLineCount(); i++) {
-		if (m_counts[i] < m_minimum) {
-			continue;
-		}
-		m_humdrum_text << i+1
-		               << "\t" << infile[i].getDurationFromStart().getFloat()
-		               << "\t" << m_counts[i]
-		               << endl;
-	}
-	m_humdrum_text << "*-\t*-\t*-" << endl;
+	infile.appendDataSpine(data, "", "**closing");
 }
 
 

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Sun Aug 16 11:39:45 CEST 2026
+// Last Modified: Sun Aug 16 12:57:50 CEST 2026
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11
@@ -6863,16 +6863,12 @@ class Tool_closing : public HumTool {
 		void     countClosingVoices  (HumdrumFile& infile);
 		void     markClosingEvents   (HumdrumFile& infile);
 		void     addAnalysisSpine    (HumdrumFile& infile);
-		void     printRawAnalysis    (HumdrumFile& infile);
 
 	private:
 		// m_counts: closing voice count for each line, or -1 for lines that get
 		// no analysis value (such as non-data lines).
 		std::vector<int> m_counts;
-		bool        m_prependQ     = false;
 		bool        m_markQ        = false;
-		bool        m_rawQ         = false;
-		int         m_minimum      = 0;
 		std::string m_attackMarker = "@";
 		std::string m_restMarker   = "N";
 		std::string m_attackColor  = "dodgerblue";

--- a/min/humlib.h
+++ b/min/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Fri Jul 31 14:13:03 CEST 2026
+// Last Modified: Sun Aug 16 11:39:45 CEST 2026
 // Filename:      min/humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/min/humlib.h
 // Syntax:        C++11
@@ -2538,6 +2538,13 @@ class HumdrumFileContent : public HumdrumFileStructure {
 		// in HumdrumFileContent-hand.cpp
 		bool   doHandAnalysis             (bool attacksOnlyQ = false);
 		bool   doHandAnalysis             (HTp startSpine, bool attacksOnlyQ = false);
+
+		// in HumdrumFileContent-closing.cpp
+		bool  analyzeClosingRests         (void);
+		bool  analyzeClosingRests         (HTp spinestart);
+		bool  isClosingRest               (HTp token);
+		bool  isClosingAttack             (HTp token);
+		bool  isClosingEvent              (HTp token);
 
 		// in HumdrumFileContent-kern.cpp
 		std::vector<int> getTrackToKernIndex (void);
@@ -6837,6 +6844,39 @@ class Tool_cint : public HumTool {
 		std::string SearchString;
 		std::string Spacer;
 
+};
+
+
+class Tool_closing : public HumTool {
+	public:
+		         Tool_closing        (void);
+		        ~Tool_closing        () {};
+
+		bool     run                 (HumdrumFileSet& infiles);
+		bool     run                 (HumdrumFile& infile);
+		bool     run                 (const std::string& indata, std::ostream& out);
+		bool     run                 (HumdrumFile& infile, std::ostream& out);
+
+	protected:
+		void     initialize          (void);
+		void     processFile         (HumdrumFile& infile);
+		void     countClosingVoices  (HumdrumFile& infile);
+		void     markClosingEvents   (HumdrumFile& infile);
+		void     addAnalysisSpine    (HumdrumFile& infile);
+		void     printRawAnalysis    (HumdrumFile& infile);
+
+	private:
+		// m_counts: closing voice count for each line, or -1 for lines that get
+		// no analysis value (such as non-data lines).
+		std::vector<int> m_counts;
+		bool        m_prependQ     = false;
+		bool        m_markQ        = false;
+		bool        m_rawQ         = false;
+		int         m_minimum      = 0;
+		std::string m_attackMarker = "@";
+		std::string m_restMarker   = "N";
+		std::string m_attackColor  = "dodgerblue";
+		std::string m_restColor    = "orange";
 };
 
 

--- a/src/HumdrumFileContent-closing.cpp
+++ b/src/HumdrumFileContent-closing.cpp
@@ -1,0 +1,157 @@
+//
+// Programmer:    Alexander Morgan
+// Creation Date: Sun Aug 16 2026
+// Filename:      HumdrumFileContent-closing.cpp
+// URL:           https://github.com/craigsapp/humlib/blob/master/src/HumdrumFileContent-closing.cpp
+// Syntax:        C++11; humlib
+// vim:           syntax=cpp ts=3 noexpandtab nowrap
+//
+// Description:   Identify where each voice stops sounding.  A "closingRest" is
+//                the first rest after one or more notes in a voice, and the
+//                "closingAttack" is the last note attack in that voice before
+//                that rest, or before the end of the voice, which counts as a
+//                rest as well.  Both are stored as "auto" token parameters:
+//
+//                    closingRest   == "1" on the rest that ends a note group
+//                    closingAttack == "1" on the last attack before that rest
+//
+//                Together they mark the events where a voice is about to drop
+//                out, which Tool_closing sums across voices to evaluate
+//                potential cadence points.
+//
+
+#include "HumdrumFileContent.h"
+
+#include <set>
+#include <utility>
+
+using namespace std;
+
+namespace hum {
+
+// START_MERGE
+
+
+
+//////////////////////////////
+//
+// HumdrumFileContent::analyzeClosingRests -- Mark the closing rests and closing
+//     attacks in every **kern voice.  Returns true if there was a voice to
+//     process.
+//
+
+bool HumdrumFileContent::analyzeClosingRests(void) {
+	bool output = false;
+	for (HTp kernstart : getKernSpineStartList()) {
+		output |= analyzeClosingRests(kernstart);
+	}
+	return output;
+}
+
+
+
+//////////////////////////////
+//
+// HumdrumFileContent::analyzeClosingRests -- Process a single voice, marking
+//     each closingRest (the first rest after one or more notes) and the matching
+//     closingAttack (the last note attack before that rest).  The end of the
+//     voice counts as a rest, so the last attack of the voice is a closingAttack
+//     even when no rest follows it.
+//
+//     Subspines (layers) are followed as separate paths, and a path stops where
+//     it meets a token that another path already processed (i.e., where
+//     subspines merge again).
+//
+
+bool HumdrumFileContent::analyzeClosingRests(HTp spinestart) {
+	if (!spinestart || !spinestart->isStaffLike()) {
+		return false;
+	}
+
+	// Each entry is a token to process, paired with the most recent note attack
+	// before it (NULL if the previous event was a rest or there was no note).
+	vector<pair<HTp, HTp>> tovisit;
+	tovisit.push_back(make_pair(spinestart, (HTp)NULL));
+	set<HTp> visited;
+
+	while (!tovisit.empty()) {
+		HTp current    = tovisit.back().first;
+		HTp lastattack = tovisit.back().second;
+		tovisit.pop_back();
+		if (!current || visited.count(current)) {
+			continue;
+		}
+		visited.insert(current);
+
+		if (current->isData() && !current->isNull()) {
+			if (current->isRest()) {
+				if (lastattack) {
+					current->setValue("auto", "closingRest", "1");
+					lastattack->setValue("auto", "closingAttack", "1");
+					lastattack = NULL;
+				}
+			} else if (current->isNoteAttack()) {
+				lastattack = current;
+			}
+			// A tied continuation keeps the attack that started it.
+		}
+
+		int count = current->getNextTokenCount();
+		if ((count == 0) && lastattack) {
+			// The end of the voice acts as a rest, so its last attack closes.
+			lastattack->setValue("auto", "closingAttack", "1");
+		}
+
+		// Pushed in reverse so that the first subspine is processed first and
+		// its state is the one that carries past a merge.
+		for (int i=count-1; i>=0; i--) {
+			tovisit.push_back(make_pair(current->getNextToken(i), lastattack));
+		}
+	}
+
+	return true;
+}
+
+
+
+//////////////////////////////
+//
+// HumdrumFileContent::isClosingRest -- Returns true if the token is the first
+//     rest after one or more notes in its voice.  Run analyzeClosingRests()
+//     first.
+//
+
+bool HumdrumFileContent::isClosingRest(HTp token) {
+	return token && token->getValueBool("auto", "closingRest");
+}
+
+
+
+//////////////////////////////
+//
+// HumdrumFileContent::isClosingAttack -- Returns true if the token is the last
+//     note attack in its voice before a closing rest or before the end of the
+//     voice.  Run analyzeClosingRests() first.
+//
+
+bool HumdrumFileContent::isClosingAttack(HTp token) {
+	return token && token->getValueBool("auto", "closingAttack");
+}
+
+
+
+//////////////////////////////
+//
+// HumdrumFileContent::isClosingEvent -- Returns true if the token is a
+//     closingAttack or a closingRest, meaning that its voice stops sounding at
+//     this event or at its next attack.  Run analyzeClosingRests() first.
+//
+
+bool HumdrumFileContent::isClosingEvent(HTp token) {
+	return isClosingAttack(token) || isClosingRest(token);
+}
+
+
+// END_MERGE
+
+} // end namespace hum

--- a/src/tool-closing.cpp
+++ b/src/tool-closing.cpp
@@ -37,10 +37,7 @@ namespace hum {
 //
 
 Tool_closing::Tool_closing(void) {
-	define("p|prepend=b",    "prepend analysis spine instead of appending it");
-	define("m|mark=b",       "mark closing attacks and closing rests in the score");
-	define("r|raw=b",        "print analysis as a plain text table");
-	define("n|minimum=i:0",  "only report counts of at least this size");
+	define("m|mark=b", "mark closing attacks and closing rests in the score");
 }
 
 
@@ -97,14 +94,7 @@ bool Tool_closing::run(HumdrumFile& infile) {
 //
 
 void Tool_closing::initialize(void) {
-	m_prependQ = getBoolean("prepend");
-	m_markQ    = getBoolean("mark");
-	m_rawQ     = getBoolean("raw");
-	m_minimum  = getInteger("minimum");
-	if (m_minimum < 0) {
-		// keep non-negative so that the -1 of non-data lines is never printed
-		m_minimum = 0;
-	}
+	m_markQ = getBoolean("mark");
 }
 
 
@@ -117,11 +107,6 @@ void Tool_closing::initialize(void) {
 void Tool_closing::processFile(HumdrumFile& infile) {
 	infile.analyzeClosingRests();
 	countClosingVoices(infile);
-
-	if (m_rawQ) {
-		printRawAnalysis(infile);
-		return;
-	}
 
 	if (m_markQ) {
 		markClosingEvents(infile);
@@ -211,40 +196,12 @@ void Tool_closing::markClosingEvents(HumdrumFile& infile) {
 void Tool_closing::addAnalysisSpine(HumdrumFile& infile) {
 	vector<string> data(infile.getLineCount());
 	for (int i=0; i<infile.getLineCount(); i++) {
-		if (m_counts[i] < m_minimum) {
+		if (m_counts[i] < 0) {
 			continue;
 		}
 		data[i] = to_string(m_counts[i]);
 	}
-	if (m_prependQ) {
-		infile.prependDataSpine(data, "", "**closing");
-	} else {
-		infile.appendDataSpine(data, "", "**closing");
-	}
-}
-
-
-
-//////////////////////////////
-//
-// Tool_closing::printRawAnalysis -- Print one line for each reported observation
-//     point: its line number in the input, its time in quarter notes from the
-//     start of the score, and the number of closing voices.
-//
-
-void Tool_closing::printRawAnalysis(HumdrumFile& infile) {
-	m_humdrum_text << "!!!voice-count: " << infile.getKernSpineStartList().size() << endl;
-	m_humdrum_text << "**line\t**qbeat\t**closing" << endl;
-	for (int i=0; i<infile.getLineCount(); i++) {
-		if (m_counts[i] < m_minimum) {
-			continue;
-		}
-		m_humdrum_text << i+1
-		               << "\t" << infile[i].getDurationFromStart().getFloat()
-		               << "\t" << m_counts[i]
-		               << endl;
-	}
-	m_humdrum_text << "*-\t*-\t*-" << endl;
+	infile.appendDataSpine(data, "", "**closing");
 }
 
 

--- a/src/tool-closing.cpp
+++ b/src/tool-closing.cpp
@@ -1,0 +1,253 @@
+//
+// Programmer:    Alexander Morgan
+// Creation Date: Sun Aug 16 2026
+// Filename:      tool-closing.cpp
+// Syntax:        C++11; humlib
+// vim:           ts=3 noexpandtab
+//
+// Description:   Count how many voices stop sounding at each observation point
+//                of a score in order to evaluate potential cadence points.
+//
+//                A voice is counted when its event there is a closingRest (the
+//                voice falls silent at that point) or a closingAttack (the voice
+//                rests, or the piece ends, at its next attack), both marked by
+//                HumdrumFileContent::analyzeClosingRests().  Counts range from 0
+//                to the number of voices, and a high count means that many of
+//                the voices sounding just before that point drop out at it,
+//                which is typical of a cadence.  Every data line is an
+//                observation point, including lines where all voices are
+//                resting.
+//
+
+#include "tool-closing.h"
+
+#include <algorithm>
+#include <string>
+
+using namespace std;
+
+namespace hum {
+
+// START_MERGE
+
+
+/////////////////////////////////
+//
+// Tool_closing::Tool_closing -- Set the recognized options for the tool.
+//
+
+Tool_closing::Tool_closing(void) {
+	define("p|prepend=b",    "prepend analysis spine instead of appending it");
+	define("m|mark=b",       "mark closing attacks and closing rests in the score");
+	define("r|raw=b",        "print analysis as a plain text table");
+	define("n|minimum=i:0",  "only report counts of at least this size");
+}
+
+
+
+/////////////////////////////////
+//
+// Tool_closing::run -- Do the main work of the tool.
+//
+
+bool Tool_closing::run(HumdrumFileSet& infiles) {
+	bool status = true;
+	for (int i=0; i<infiles.getCount(); i++) {
+		status &= run(infiles[i]);
+	}
+	return status;
+}
+
+
+bool Tool_closing::run(const string& indata, ostream& out) {
+	HumdrumFile infile;
+	infile.readString(indata);
+	bool status = run(infile);
+	if (hasAnyText()) {
+		getAllText(out);
+	} else {
+		out << infile;
+	}
+	return status;
+}
+
+
+bool Tool_closing::run(HumdrumFile& infile, ostream& out) {
+	bool status = run(infile);
+	if (hasAnyText()) {
+		getAllText(out);
+	} else {
+		out << infile;
+	}
+	return status;
+}
+
+
+bool Tool_closing::run(HumdrumFile& infile) {
+	initialize();
+	processFile(infile);
+	return true;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_closing::initialize --
+//
+
+void Tool_closing::initialize(void) {
+	m_prependQ = getBoolean("prepend");
+	m_markQ    = getBoolean("mark");
+	m_rawQ     = getBoolean("raw");
+	m_minimum  = getInteger("minimum");
+	if (m_minimum < 0) {
+		// keep non-negative so that the -1 of non-data lines is never printed
+		m_minimum = 0;
+	}
+}
+
+
+
+//////////////////////////////
+//
+// Tool_closing::processFile --
+//
+
+void Tool_closing::processFile(HumdrumFile& infile) {
+	infile.analyzeClosingRests();
+	countClosingVoices(infile);
+
+	if (m_rawQ) {
+		printRawAnalysis(infile);
+		return;
+	}
+
+	if (m_markQ) {
+		markClosingEvents(infile);
+	}
+	addAnalysisSpine(infile);
+	m_humdrum_text << infile;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_closing::countClosingVoices -- For each observation point in the
+//     composite rhythm of all of the parts, count the voices whose event at
+//     that point is a closingAttack or a closingRest.  Every data line is an
+//     observation point, including lines where all of the voices are resting.
+//
+
+void Tool_closing::countClosingVoices(HumdrumFile& infile) {
+	m_counts.clear();
+	m_counts.resize(infile.getLineCount(), -1);
+
+	// A staff with more than one layer can have several closing events on the
+	// same line, but it is a single voice, so count each track only once.
+	vector<bool> counted(infile.getTrackCount() + 1, false);
+
+	for (int i=0; i<infile.getLineCount(); i++) {
+		if (!infile[i].isData()) {
+			continue;
+		}
+		fill(counted.begin(), counted.end(), false);
+		int sum = 0;
+		for (int j=0; j<infile[i].getFieldCount(); j++) {
+			HTp token = infile.token(i, j);
+			if (!infile.isClosingEvent(token)) {
+				continue;
+			}
+			int track = token->getTrack();
+			if (counted[track]) {
+				continue;
+			}
+			counted[track] = true;
+			sum++;
+		}
+		m_counts[i] = sum;
+	}
+}
+
+
+
+//////////////////////////////
+//
+// Tool_closing::markClosingEvents -- Mark each closing attack and each closing
+//     rest so that they can be seen in the notation.
+//
+
+void Tool_closing::markClosingEvents(HumdrumFile& infile) {
+	for (int i=0; i<infile.getLineCount(); i++) {
+		if (!infile[i].isData()) {
+			continue;
+		}
+		for (int j=0; j<infile[i].getFieldCount(); j++) {
+			HTp token = infile.token(i, j);
+			if (infile.isClosingAttack(token)) {
+				token->setText(*token + m_attackMarker);
+			} else if (infile.isClosingRest(token)) {
+				token->setText(*token + m_restMarker);
+			}
+		}
+	}
+	infile.createLinesFromTokens();
+
+	infile.appendLine("!!!RDF**kern: " + m_attackMarker
+			+ " = marked note, closing attack, color=\"" + m_attackColor + "\"");
+	infile.appendLine("!!!RDF**kern: " + m_restMarker
+			+ " = marked note, closing rest, color=\"" + m_restColor + "\"");
+}
+
+
+
+//////////////////////////////
+//
+// Tool_closing::addAnalysisSpine -- Add a **closing spine containing the number
+//     of closing voices at each observation point.
+//
+
+void Tool_closing::addAnalysisSpine(HumdrumFile& infile) {
+	vector<string> data(infile.getLineCount());
+	for (int i=0; i<infile.getLineCount(); i++) {
+		if (m_counts[i] < m_minimum) {
+			continue;
+		}
+		data[i] = to_string(m_counts[i]);
+	}
+	if (m_prependQ) {
+		infile.prependDataSpine(data, "", "**closing");
+	} else {
+		infile.appendDataSpine(data, "", "**closing");
+	}
+}
+
+
+
+//////////////////////////////
+//
+// Tool_closing::printRawAnalysis -- Print one line for each reported observation
+//     point: its line number in the input, its time in quarter notes from the
+//     start of the score, and the number of closing voices.
+//
+
+void Tool_closing::printRawAnalysis(HumdrumFile& infile) {
+	m_humdrum_text << "!!!voice-count: " << infile.getKernSpineStartList().size() << endl;
+	m_humdrum_text << "**line\t**qbeat\t**closing" << endl;
+	for (int i=0; i<infile.getLineCount(); i++) {
+		if (m_counts[i] < m_minimum) {
+			continue;
+		}
+		m_humdrum_text << i+1
+		               << "\t" << infile[i].getDurationFromStart().getFloat()
+		               << "\t" << m_counts[i]
+		               << endl;
+	}
+	m_humdrum_text << "*-\t*-\t*-" << endl;
+}
+
+
+// END_MERGE
+
+} // end namespace hum

--- a/src/tool-filter.cpp
+++ b/src/tool-filter.cpp
@@ -30,6 +30,7 @@
 #include "tool-chooser.h"
 #include "tool-chord.h"
 #include "tool-cint.h"
+#include "tool-closing.h"
 #include "tool-cmr.h"
 #include "tool-colorgroups.h"
 #include "tool-colortriads.h"
@@ -283,6 +284,8 @@ bool Tool_filter::run(HumdrumFileSet& infiles) {
 			RUNTOOL(chord, infile, commands[i].second, status);
 		} else if (commands[i].first == "cint") {
 			RUNTOOL(cint, infile, commands[i].second, status);
+		} else if (commands[i].first == "closing") {
+			RUNTOOL(closing, infile, commands[i].second, status);
 		} else if (commands[i].first == "cmr") {
 			RUNTOOL(cmr, infile, commands[i].second, status);
 		} else if (commands[i].first == "composite") {

--- a/src/tool-pliner.cpp
+++ b/src/tool-pliner.cpp
@@ -185,7 +185,7 @@ bool Tool_pliner::extractPoem(HumdrumFile& infile, vector<vector<PoemWord>>& poe
 			cerr << "Error: cannot open text file: " << path << endl;
 			return false;
 		}
-		ostringstream oss;
+		std::ostringstream oss;
 		oss << in.rdbuf();
 		text = oss.str();
 	} else {
@@ -211,7 +211,7 @@ bool Tool_pliner::extractPoem(HumdrumFile& infile, vector<vector<PoemWord>>& poe
 	}
 
 	HumRegex hre;
-	istringstream stream(text);
+	std::istringstream stream(text);
 	string line;
 	int lineNum = 0;
 	while (getline(stream, line)) {

--- a/src/tool-textract.cpp
+++ b/src/tool-textract.cpp
@@ -289,7 +289,7 @@ void Tool_textract::buildSungWords(HTp textStart, vector<SungWord>& words) {
 			SungWord sw;
 			sw.original = accumOrig;
 			sw.norm = accumNorm;
-			sw.syllables = max(sylCount, 1);
+			sw.syllables = std::max(sylCount, 1);
 			sw.capitalized = capitalized;
 			sw.bis = bis;
 			words.push_back(sw);
@@ -610,7 +610,7 @@ int Tool_textract::distanceToAllowed(int syllables) {
 	}
 	int best = abs(syllables - m_sylCounts[0]);
 	for (int t : m_sylCounts) {
-		best = min(best, abs(syllables - t));
+		best = std::min(best, abs(syllables - t));
 	}
 	return best;
 }
@@ -647,7 +647,7 @@ int Tool_textract::minAllowedLength(void) {
 	}
 	int m = m_sylCounts[0];
 	for (int t : m_sylCounts) {
-		m = min(m, t);
+		m = std::min(m, t);
 	}
 	return m;
 }
@@ -665,7 +665,7 @@ int Tool_textract::maxAllowedLength(void) {
 	}
 	int m = m_sylCounts[0];
 	for (int t : m_sylCounts) {
-		m = max(m, t);
+		m = std::max(m, t);
 	}
 	return m;
 }
@@ -784,9 +784,9 @@ bool Tool_textract::linesSimilar(const vector<SungWord>& a,
 			return true;
 		}
 	}
-	int maxLen = (int)max(a.size(), b.size());
-	int minLen = (int)min(a.size(), b.size());
-	if (maxLen - minLen > max(2, minLen / 2)) {
+	int maxLen = (int)std::max(a.size(), b.size());
+	int minLen = (int)std::min(a.size(), b.size());
+	if (maxLen - minLen > std::max(2, minLen / 2)) {
 		return false;
 	}
 	// LCS length
@@ -796,7 +796,7 @@ bool Tool_textract::linesSimilar(const vector<SungWord>& a,
 			if (a[i-1].norm == b[j-1].norm) {
 				dp[i][j] = dp[i-1][j-1] + 1;
 			} else {
-				dp[i][j] = max(dp[i-1][j], dp[i][j-1]);
+				dp[i][j] = std::max(dp[i-1][j], dp[i][j-1]);
 			}
 		}
 	}
@@ -1109,7 +1109,7 @@ void Tool_textract::reconstructText(vector<Voice>& voices) {
 				int nj = (int)set<int>(clusters[j].voiceIds.begin(),
 						clusters[j].voiceIds.end()).size();
 				clusters[i].avgPos = (clusters[i].avgPos * ni + clusters[j].avgPos * nj)
-						/ max(ni + nj, 1);
+						/ std::max(ni + nj, 1);
 				clusters.erase(clusters.begin() + j);
 				merged = true;
 				break;


### PR DESCRIPTION
Closing tool provides the total count of note attacks or rests that are "closing" at each moment in the piece. A note attack is "closing" if it is the last attack before a rest or the end of the piece in that voice. A rest is "closing" if it's the first rest after one or more notes in a piece.
The -m option also colors these attacks and rests blue and orange respectively.
The name "closing" could be better, but it was the best I could come up with and has the nice quality of working equally well for the notes and rests.
This pr also commits the std::max changes we looked at last week in textract.