### PR TITLE
Clean 1520ify pr

### DIFF
--- a/include/tool-1520ify.h
+++ b/include/tool-1520ify.h
@@ -45,6 +45,8 @@ class Tool_1520ify : public HumTool {
 		void        fixEditorialAccidentals(HumdrumFile& infile);
 		void        fixInstrumentAbbreviations(HumdrumFile& infile);
 		void        addTerminalLongs   (HumdrumFile& infile);
+		bool        isInternalSectionBoundary(HumdrumFile& infile, int lineindex);
+		bool        markPreviousNoteAsLong(HTp token, bool stopAtRest);
 		void        deleteDummyTranspositions(HumdrumFile& infile);
 		std::string getDate            (void);
 		int         getYear            (void);
@@ -62,6 +64,4 @@ class Tool_1520ify : public HumTool {
 } // end namespace hum
 
 #endif /* _TOOL_1520IFY_H_INCLUDED */
-
-
 

--- a/include/tool-1520ify.h
+++ b/include/tool-1520ify.h
@@ -47,6 +47,7 @@ class Tool_1520ify : public HumTool {
 		void        addTerminalLongs   (HumdrumFile& infile);
 		bool        isInternalSectionBoundary(HumdrumFile& infile, int lineindex);
 		bool        markPreviousNoteAsLong(HTp token, bool stopAtRest);
+		std::string getVoicesReference(HumdrumFile& infile);
 		void        deleteDummyTranspositions(HumdrumFile& infile);
 		std::string getDate            (void);
 		int         getYear            (void);
@@ -64,4 +65,3 @@ class Tool_1520ify : public HumTool {
 } // end namespace hum
 
 #endif /* _TOOL_1520IFY_H_INCLUDED */
-

--- a/src/tool-1520ify.cpp
+++ b/src/tool-1520ify.cpp
@@ -261,6 +261,64 @@ static std::string getDefaultMetForMensuration(HTp token) {
 }
 
 
+//////////////////////////////
+//
+// addMeasureNumberToBarlineToken -- Add a barnum -a style number to ordinary
+//    barline tokens while preserving non-digit styling characters.  Final
+//    barlines are handled by the caller and are left unnumbered.
+//
+
+static std::string addMeasureNumberToBarlineToken(const std::string& text, int number) {
+	std::string output;
+	for (int i=0; i<(int)text.size(); ++i) {
+		if ((text[i] == '=') && ((i + 1 >= (int)text.size()) || (text[i + 1] != '='))) {
+			output += '=';
+			output += std::to_string(number);
+		} else if (!std::isdigit(static_cast<unsigned char>(text[i]))) {
+			output += text[i];
+		}
+	}
+	return output;
+}
+
+
+//////////////////////////////
+//
+// addAllMeasureNumbers -- Number all non-final barlines from the start of the
+//    file.  This mirrors the cleanup normally done with barnum -a, but keeps
+//    final double barlines unchanged.
+//
+
+static void addAllMeasureNumbers(HumdrumFile& infile) {
+	int number = 1;
+	for (int i=0; i<infile.getLineCount(); ++i) {
+		if (!infile[i].isBarline()) {
+			continue;
+		}
+
+		bool finalQ = false;
+		for (int j=0; j<infile[i].getFieldCount(); ++j) {
+			HTp tok = infile.token(i, j);
+			if (tok && (tok->find("==") != std::string::npos)) {
+				finalQ = true;
+				break;
+			}
+		}
+		if (finalQ) {
+			continue;
+		}
+
+		for (int j=0; j<infile[i].getFieldCount(); ++j) {
+			HTp tok = infile.token(i, j);
+			if (tok) {
+				tok->setText(addMeasureNumberToBarlineToken(tok->getText(), number));
+			}
+		}
+		number++;
+	}
+}
+
+
 /////////////////////////////////
 //
 // Tool_1520ify::Tool_1520ify -- Set the recognized options for the tool.
@@ -655,6 +713,8 @@ void Tool_1520ify::processFile(HumdrumFile& infile) {
 	argv.push_back("s/=/ /g");
 	shed.process(argv);
 	shed.run(infile);
+
+	addAllMeasureNumbers(infile);
 }
 
 

--- a/src/tool-1520ify.cpp
+++ b/src/tool-1520ify.cpp
@@ -702,6 +702,48 @@ void Tool_1520ify::processFile(HumdrumFile& infile) {
 		i += 1;
 	}
 
+	// Refresh token/line relationships after structural edits so section-based
+	// voice counting sees correct line indexes.
+	infile.createLinesFromTokens();
+
+	// Populate !!!voices after labelled section comments have been created.
+	{
+		std::string voiceText = getVoicesReference(infile);
+
+		if (!voiceText.empty()) {
+			for (int li = 0; li < infile.getLineCount(); ++li) {
+				if (!infile[li].isReference()) {
+					continue;
+				}
+				HTp tok = infile.token(li, 0);
+				if (!tok) {
+					continue;
+				}
+				if (tok->compare(0, 10, "!!!voices:") != 0) {
+					continue;
+				}
+
+				std::string cur = tok->getText();
+				size_t colon = cur.find(':');
+				bool hasContent = false;
+				if (colon != std::string::npos) {
+					for (size_t p = colon + 1; p < cur.size(); ++p) {
+						if (!std::isspace(static_cast<unsigned char>(cur[p]))) {
+							hasContent = true;
+							break;
+						}
+					}
+				}
+
+				bool overwriteQ = (voiceText.find('-') != std::string::npos);
+				if (!hasContent || overwriteQ) {
+					tok->setText("!!!voices: " + voiceText);
+				}
+				break;
+			}
+		}
+	}
+
 	// Input lyrics may contain "=" signs which are to be converted into
 	// spaces in **text data, and into elisions when displaying with verovio.
 	Tool_shed shed;
@@ -1000,6 +1042,152 @@ bool Tool_1520ify::markPreviousNoteAsLong(HTp token, bool stopAtRest) {
 	}
 
 	return false;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_1520ify::getVoicesReference -- Return the !!!voices: value for the
+//    whole file.  Count only voices that have sounding attacks in each labelled
+//    internal section; if the section counts differ, report the min/max range
+//    such as "2-4".
+//
+
+std::string Tool_1520ify::getVoicesReference(HumdrumFile& infile) {
+	std::vector<HTp> kerns = infile.getKernSpineStartList();
+	if (kerns.empty()) {
+		return "";
+	}
+
+	auto isLabeledSectionBoundary = [&](int lineindex) -> bool {
+		if ((lineindex < 0) || (lineindex >= infile.getLineCount())) {
+			return false;
+		}
+		if (!infile[lineindex].isBarline()) {
+			return false;
+		}
+
+		bool doubleQ = false;
+		for (int j=0; j<infile[lineindex].getFieldCount(); ++j) {
+			HTp token = infile.token(lineindex, j);
+			if (token && token->find("||") != string::npos) {
+				doubleQ = true;
+				break;
+			}
+		}
+		if (!doubleQ) {
+			return false;
+		}
+
+		for (int i=lineindex + 1; i<infile.getLineCount(); ++i) {
+			if (infile[i].isTerminator()) {
+				return false;
+			}
+			if (infile[i].isBarline()) {
+				return false;
+			}
+			if (infile[i].isGlobalComment()) {
+				HTp token = infile.token(i, 0);
+				if (!token) {
+					continue;
+				}
+				if ((token->compare(0, 10, "!!section:") == 0) ||
+				    (token->compare(0, 7, "!!!OMD:") == 0)) {
+					return true;
+				}
+				continue;
+			}
+			if (infile[i].isLocalComment() || infile[i].isReference() ||
+			    infile[i].isInterpretation() || infile[i].isEmpty()) {
+				continue;
+			}
+			if (infile[i].isData()) {
+				return false;
+			}
+		}
+		return false;
+	};
+
+	std::vector<std::pair<int, int>> sections;
+	int startline = -1;
+	for (int i=0; i<infile.getLineCount(); ++i) {
+		if (infile[i].isData()) {
+			startline = i;
+			break;
+		}
+	}
+	if (startline < 0) {
+		return "";
+	}
+
+	for (int i=0; i<infile.getLineCount(); ++i) {
+		if (!isLabeledSectionBoundary(i)) {
+			continue;
+		}
+		sections.push_back(std::make_pair(startline, i));
+		for (int j=i + 1; j<infile.getLineCount(); ++j) {
+			if (infile[j].isData()) {
+				startline = j;
+				break;
+			}
+		}
+	}
+
+	int endline = -1;
+	for (int i=infile.getLineCount() - 1; i>=0; --i) {
+		if (infile[i].isData()) {
+			endline = i;
+			break;
+		}
+	}
+	if ((startline >= 0) && (endline >= startline)) {
+		sections.push_back(std::make_pair(startline, endline));
+	}
+
+	if (sections.empty()) {
+		return std::to_string((int)kerns.size());
+	}
+
+	int minVoices = (int)kerns.size();
+	int maxVoices = 0;
+
+	for (int i=0; i<(int)sections.size(); ++i) {
+		std::vector<bool> active(kerns.size(), false);
+		for (int line=sections[i].first; line<=sections[i].second; ++line) {
+			if (!infile[line].isData()) {
+				continue;
+			}
+			int kindex = 0;
+			for (int field=0; field<infile[line].getFieldCount(); ++field) {
+				HTp tok = infile.token(line, field);
+				if (!tok || !tok->isKern()) {
+					continue;
+				}
+				if (kindex >= (int)active.size()) {
+					break;
+				}
+				if (!tok->isNull() && !tok->isRest() && !tok->isSecondaryTiedNote()) {
+					active[kindex] = true;
+				}
+				kindex++;
+			}
+		}
+
+		int activeCount = 0;
+		for (int j=0; j<(int)active.size(); ++j) {
+			if (active[j]) {
+				activeCount++;
+			}
+		}
+		minVoices = std::min(minVoices, activeCount);
+		maxVoices = std::max(maxVoices, activeCount);
+	}
+
+	if (minVoices == maxVoices) {
+		return std::to_string(minVoices);
+	}
+	return std::to_string(minVoices) + "-" + std::to_string(maxVoices);
 }
 
 
@@ -1498,51 +1686,6 @@ void Tool_1520ify::addBibliographicRecords(HumdrumFile& infile) {
 	} else if (foundOPR) {
 	    infile.deleteLine(oprLine);
 	}
-
-	// --- Populate voices from number of **kern spines ---
-	{
-		// Count **kern spines
-		std::vector<HTp> kerns = infile.getKernSpineStartList();
-		int voiceCount = static_cast<int>(kerns.size());
-
-		if (voiceCount > 0) {
-			for (int li = 0; li < infile.getLineCount(); ++li) {
-				if (!infile[li].isReference()) {
-					continue;
-				}
-				HTp tok = infile.token(li, 0);
-				if (!tok) {
-					continue;
-				}
-
-				// Find the !!!voices: line
-				if (tok->compare(0, 10, "!!!voices:") != 0){
-					continue;
-				}
-
-				std::string cur = tok->getText();
-
-				// Check if there is already non-whitespace content after the colon
-				size_t colon = cur.find(':');
-				bool hasContent = false;
-				if (colon != std::string::npos) {
-					for (size_t p = colon + 1; p < cur.size(); ++p) {
-						if (!std::isspace(static_cast<unsigned char>(cur[p]))) {
-							hasContent = true;
-							break;
-						}
-					}
-				}
-
-				// Only auto-fill if it was effectively empty
-				if (!hasContent) {
-					tok->setText("!!!voices: " + std::to_string(voiceCount));
-				}
-				break; // done with voices
-			}
-		}
-	}
-
 
 	// --- Auto-fill AGN (genre + optional movement name) based on numeric id ---
 	

--- a/src/tool-1520ify.cpp
+++ b/src/tool-1520ify.cpp
@@ -845,11 +845,28 @@ void Tool_1520ify::fixEditorialAccidentals(HumdrumFile& infile) {
 
 //////////////////////////////
 //
-// Tool_1520ify::addTerminalLongs -- Convert all last notes to terminal longs
-//    Also probably add terminal longs before double barlines as in JRP.
+// Tool_1520ify::addTerminalLongs -- Convert final sounding notes to terminal
+//    longs.  In addition to the final note before *-, also mark the last
+//    sounding note before internal section-ending double barlines.
 //
 
 void Tool_1520ify::addTerminalLongs(HumdrumFile& infile) {
+	for (int i=0; i<infile.getLineCount(); ++i) {
+		if (!isInternalSectionBoundary(infile, i)) {
+			continue;
+		}
+		for (int j=0; j<infile[i].getFieldCount(); ++j) {
+			HTp token = infile.token(i, j);
+			if (!token || !token->isKern()) {
+				continue;
+			}
+			if (token->find("||") == string::npos) {
+				continue;
+			}
+			markPreviousNoteAsLong(token, true);
+		}
+	}
+
 	int scount = infile.getStrandCount();
 	for (int i=0; i<scount; i++) {
 		HTp cur = infile.getStrandEnd(i);
@@ -859,34 +876,130 @@ void Tool_1520ify::addTerminalLongs(HumdrumFile& infile) {
 		if (!cur->isKern()) {
 			continue;
 		}
-		while (cur) {
-			if (!cur->isData()) {
-				cur = cur->getPreviousToken();
-				continue;
-			}
-			if (cur->isNull()) {
-				cur = cur->getPreviousToken();
-				continue;
-			}
-			if (cur->isRest()) {
-				cur = cur->getPreviousToken();
-				continue;
-			}
-			if (cur->isSecondaryTiedNote()) {
-				cur = cur->getPreviousToken();
-				continue;
-			}
-			if (cur->find("l") != std::string::npos) {
-				// already marked so do not do it again
-				break;
-			}
-			// mark this note with "l"
-			string newtext = *cur;
-			newtext += "l";
-			cur->setText(newtext);
+		markPreviousNoteAsLong(cur, false);
+	}
+}
+
+
+
+//////////////////////////////
+//
+// Tool_1520ify::isInternalSectionBoundary -- Identify internal double barlines
+//    that are followed by a new labelled section rather than score termination.
+//    This lets terminal longs be added at section endings without treating the
+//    final double barline as an internal boundary.
+//
+
+bool Tool_1520ify::isInternalSectionBoundary(HumdrumFile& infile, int lineindex) {
+	if ((lineindex < 0) || (lineindex >= infile.getLineCount())) {
+		return false;
+	}
+	if (!infile[lineindex].isBarline()) {
+		return false;
+	}
+
+	bool doubleQ = false;
+	for (int j=0; j<infile[lineindex].getFieldCount(); ++j) {
+		HTp token = infile.token(lineindex, j);
+		if (token && token->find("||") != string::npos) {
+			doubleQ = true;
 			break;
 		}
 	}
+	if (!doubleQ) {
+		return false;
+	}
+
+	bool restartQ = false;
+	for (int i=lineindex + 1; i<infile.getLineCount(); ++i) {
+		if (infile[i].isTerminator()) {
+			return false;
+		}
+		if (infile[i].isBarline()) {
+			return false;
+		}
+		if (infile[i].isGlobalComment()) {
+			HTp token = infile.token(i, 0);
+			if (!token) {
+				continue;
+			}
+			if ((token->compare(0, 10, "!!section:") == 0) ||
+			    (token->compare(0, 7, "!!!OMD:") == 0)) {
+				restartQ = true;
+			}
+			continue;
+		}
+		if (infile[i].isLocalComment() || infile[i].isReference() || infile[i].isEmpty()) {
+			continue;
+		}
+		if (infile[i].isInterpretation()) {
+			for (int j=0; j<infile[i].getFieldCount(); ++j) {
+				HTp token = infile.token(i, j);
+				if (!token || token->isNull()) {
+					continue;
+				}
+				if ((token->compare(0, 2, "*M") == 0) ||
+				    (token->compare(0, 5, "*met(") == 0)) {
+					restartQ = true;
+				}
+			}
+			continue;
+		}
+		if (infile[i].isData()) {
+			return restartQ;
+		}
+	}
+
+	return false;
+}
+
+
+
+//////////////////////////////
+//
+// Tool_1520ify::markPreviousNoteAsLong -- Walk backwards within a strand and
+//    mark the last note attack as a long.  For internal boundaries, stopAtRest
+//    prevents adding a long to a voice that has already dropped out and rests
+//    through the section break.
+//
+
+bool Tool_1520ify::markPreviousNoteAsLong(HTp token, bool stopAtRest) {
+	if (!token) {
+		return false;
+	}
+
+	HTp cur = token->getPreviousToken();
+	while (cur) {
+		if (!cur->isData()) {
+			cur = cur->getPreviousToken();
+			continue;
+		}
+		if (cur->isNull()) {
+			cur = cur->getPreviousToken();
+			continue;
+		}
+		if (cur->isRest()) {
+			if (stopAtRest) {
+				return false;
+			}
+			cur = cur->getPreviousToken();
+			continue;
+		}
+		if (cur->isSecondaryTiedNote()) {
+			cur = cur->getPreviousToken();
+			continue;
+		}
+		if (cur->find("l") != std::string::npos) {
+			return true;
+		}
+
+		string newtext = *cur;
+		newtext += "l";
+		cur->setText(newtext);
+		return true;
+	}
+
+	return false;
 }
 
 

--- a/src/tool-1520ify.cpp
+++ b/src/tool-1520ify.cpp
@@ -32,6 +32,234 @@ namespace hum {
 
 // START_MERGE
 
+//////////////////////////////
+//
+// getMetForMensurationLabel -- Convert text labels exported from notation
+//    programs into the corresponding mensuration interpretation.  These
+//    labels usually arrive in nearby LO:TX/comment material rather than as
+//    Humdrum interpretations, so they need to override the default *M mapping.
+//
+
+static std::string getMetForMensurationLabel(const std::string& text) {
+	static const std::vector<std::pair<std::string, std::string>> mappings = {
+		{"MenCircleOver3", "*met(O/3)"},
+		{"MenCutCircle3", "*met(O|3)"},
+		{"MenCircleDot", "*met(O.)"},
+		{"MenCutCDot", "*met(C.|)"},
+		{"MenReverseC", "*met(Cr)"},
+		{"Men3Over2", "*met(3/2)"},
+		{"MenCutCircle", "*met(O|)"},
+		{"MenCutC3", "*met(C|3)"},
+		{"MenCutC2", "*met(C|2)"},
+		{"MenCircle3", "*met(O3)"},
+		{"MenCircle2", "*met(O2)"},
+		{"MenCutC", "*met(C|)"},
+		{"MenCDot", "*met(C.)"},
+		{"MenC3", "*met(C3)"},
+		{"MenC2", "*met(C2)"},
+		{"MenCircle", "*met(O)"},
+		{"MenC", "*met(C)"},
+		{"Men3", "*met(3)"},
+		{"Men2", "*met(2)"}
+	};
+
+	for (const auto& mapping : mappings) {
+		size_t pos = text.find(mapping.first);
+		if (pos == std::string::npos) {
+			continue;
+		}
+		size_t end = pos + mapping.first.size();
+		if ((end < text.size()) && std::isalnum(static_cast<unsigned char>(text[end]))) {
+			continue;
+		}
+		return mapping.second;
+	}
+
+	return "";
+}
+
+
+//////////////////////////////
+//
+// getNearbyMensurationLabelMet -- Look below a mensuration line for a text
+//    label that specifies the actual mensuration sign.  Stop at music,
+//    barlines, or spine termination so a later section cannot affect the
+//    current mensuration block.
+//
+
+static std::string getNearbyMensurationLabelMet(HumdrumFile& infile, int mensline) {
+	for (int i=mensline + 1; i<infile.getLineCount(); ++i) {
+		if (infile[i].isData() || infile[i].isBarline() || infile[i].isTerminator()) {
+			break;
+		}
+		if (infile[i].isInterpretation()) {
+			continue;
+		}
+		if (!infile[i].isLocalComment() && !infile[i].isGlobalComment()) {
+			continue;
+		}
+		for (int j=0; j<infile[i].getFieldCount(); ++j) {
+			HTp tok = infile.token(i, j);
+			if (!tok) {
+				continue;
+			}
+			std::string met = getMetForMensurationLabel(tok->getText());
+			if (!met.empty()) {
+				return met;
+			}
+		}
+	}
+
+	return "";
+}
+
+
+//////////////////////////////
+//
+// deleteNearbyMensurationLabel -- After a text mensuration label has been
+//    converted into *met(...), remove the source label so it is not rendered as
+//    redundant display text.  For local comments, only delete the whole line if
+//    all fields became empty comments.
+//
+
+static void deleteNearbyMensurationLabel(HumdrumFile& infile, int mensline) {
+	for (int i=mensline + 1; i<infile.getLineCount(); ++i) {
+		if (infile[i].isData() || infile[i].isBarline() || infile[i].isTerminator()) {
+			break;
+		}
+		if (infile[i].isInterpretation()) {
+			continue;
+		}
+		if (!infile[i].isLocalComment() && !infile[i].isGlobalComment()) {
+			continue;
+		}
+
+		bool changed = false;
+		for (int j=0; j<infile[i].getFieldCount(); ++j) {
+			HTp tok = infile.token(i, j);
+			if (!tok) {
+				continue;
+			}
+			if (getMetForMensurationLabel(tok->getText()).empty()) {
+				continue;
+			}
+			if (infile[i].isGlobalComment()) {
+				infile.deleteLine(i);
+				return;
+			}
+			tok->setText("!");
+			changed = true;
+		}
+
+		if (!changed) {
+			continue;
+		}
+
+		bool empty = true;
+		for (int j=0; j<infile[i].getFieldCount(); ++j) {
+			HTp tok = infile.token(i, j);
+			if (tok && (*tok != "!")) {
+				empty = false;
+				break;
+			}
+		}
+		if (empty) {
+			infile.deleteLine(i);
+		}
+		return;
+	}
+}
+
+
+//////////////////////////////
+//
+// applyMensurationLabelMetOverrides -- Replace an existing generated *met(...)
+//    line when a nearby text mensuration label gives a more specific sign than
+//    the default meter-based mapping.
+//
+
+static void applyMensurationLabelMetOverrides(HumdrumFile& infile) {
+	for (int i=0; i<infile.getLineCount(); ++i) {
+		if (!infile[i].isInterpretation()) {
+			continue;
+		}
+
+		bool hasMens = false;
+		for (int j=0; j<infile[i].getFieldCount(); ++j) {
+			HTp tok = infile.token(i, j);
+			if (tok && (tok->compare(0, 2, "*M") == 0)) {
+				hasMens = true;
+				break;
+			}
+		}
+		if (!hasMens) {
+			continue;
+		}
+
+		std::string labelMet = getNearbyMensurationLabelMet(infile, i);
+		if (labelMet.empty()) {
+			continue;
+		}
+
+		for (int j=i + 1; j<infile.getLineCount(); ++j) {
+			if (infile[j].isData() || infile[j].isBarline() || infile[j].isTerminator()) {
+				break;
+			}
+			if (!infile[j].isInterpretation()) {
+				continue;
+			}
+
+			bool hasMet = false;
+			for (int k=0; k<infile[j].getFieldCount(); ++k) {
+				HTp tok = infile.token(j, k);
+				if (tok && (tok->compare(0, 5, "*met(") == 0)) {
+					hasMet = true;
+					break;
+				}
+			}
+			if (!hasMet) {
+				continue;
+			}
+
+			for (int k=0; k<infile[j].getFieldCount(); ++k) {
+				HTp tok = infile.token(j, k);
+				if (tok && !tok->isNull()) {
+					tok->setText(labelMet);
+				}
+			}
+			deleteNearbyMensurationLabel(infile, i);
+			break;
+		}
+	}
+}
+
+
+//////////////////////////////
+//
+// getDefaultMetForMensuration -- Supply the standard *met(...) value for the
+//    mensuration signatures that are common in 1520s Project imports when no
+//    explicit text label is available.
+//
+
+static std::string getDefaultMetForMensuration(HTp token) {
+	if (!token || token->isNull()) {
+		return "";
+	}
+	if (*token == "*M2/1") {
+		return "*met(C|)";
+	}
+	if (*token == "*M3/1") {
+		return "*met(O)";
+	}
+	if (*token == "*M6/2") {
+		return "*met(C.)";
+	}
+	if (*token == "*M9/2") {
+		return "*met(O.)";
+	}
+	return "";
+}
+
 
 /////////////////////////////////
 //
@@ -238,29 +466,31 @@ void Tool_1520ify::processFile(HumdrumFile& infile) {
 		// If there is a mensuration line just above, use it to decide canonical *met(...)
 		int mensLine = i - 1;
 		if (mensLine >= 0 && infile[mensLine].isInterpretation()) {
+			std::string labelMet = getNearbyMensurationLabelMet(infile, mensLine);
 			for (int j = 0; j < infile[i].getFieldCount(); ++j) {
 				HTp metTok  = infile.token(i, j);
 				HTp mensTok = infile.token(mensLine, j);
 
-				// Default: leave non-*met tokens alone on this line
+				// Default: leave non-*met tokens alone on this line unless a
+				// mensuration label applies to the whole mensuration block.
 				if (!metTok || metTok->isNull()) {
 				    continue;
 				}
 
-				if (metTok->compare(0, 5, "*met(") != 0) {
+				if (labelMet.empty() && (metTok->compare(0, 5, "*met(") != 0)) {
 				    continue;
 				}
 
 				// Decide canonical met from the mensuration just above
 				const char* repl = "*";   // if we can’t decide, blank it
 
-				if (mensTok && !mensTok->isNull()) {
-				    if (*mensTok == "*M2/1") {
-				        repl = "*met(C|)";
-				    }
-				    else if (*mensTok == "*M3/1") {
-				        repl = "*met(O)";
-				    }
+				if (!labelMet.empty()) {
+					repl = labelMet.c_str();
+				} else {
+					std::string defaultMet = getDefaultMetForMensuration(mensTok);
+					if (!defaultMet.empty()) {
+						repl = defaultMet.c_str();
+					}
 				}
 				metTok->setText(repl);
 			}
@@ -331,21 +561,24 @@ void Tool_1520ify::processFile(HumdrumFile& infile) {
 			}
 		}
 
-		// Build a *met(...) line (post-normalization we only need to check *M2/1 and *M3/1)
+		// Build a *met(...) line for recognized mensuration signs.
 		std::string newline;
 		bool willInsert = false;
+		std::string labelMet = getNearbyMensurationLabelMet(infile, i);
 
 		for (int j = 0; j < infile[i].getFieldCount(); ++j) {
 			HTp tok = infile.token(i, j);
-			const char* out = "*";
+			std::string out = "*";
 			if (tok && !tok->isNull()) {
-				if (*tok == "*M2/1") { 
-					out = "*met(C|)"; 
+				if (!labelMet.empty() && (tok->compare(0, 2, "*M") == 0)) {
+					out = labelMet;
 					willInsert = true; 
-				}
-				else if (*tok == "*M3/1") { 
-					out = "*met(O)"; 
-					willInsert = true; 
+				} else {
+					std::string defaultMet = getDefaultMetForMensuration(tok);
+					if (!defaultMet.empty()) {
+						out = defaultMet;
+						willInsert = true;
+					}
 				}
 			}
 			newline += out;
@@ -359,6 +592,8 @@ void Tool_1520ify::processFile(HumdrumFile& infile) {
 			i++;  // skip the line we just inserted
 		}
 	}
+
+	applyMensurationLabelMetOverrides(infile);
 
 	// Convert LO:TX Section lines in-place to !!section and !!!OMD
 	for (int i = 0; i < infile.getLineCount(); ++i) {

--- a/src/tool-1520ify.cpp
+++ b/src/tool-1520ify.cpp
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <chrono>
 #include <iomanip>
+#include <sstream>
 
 // include filesystem for grabbing the filename
 #include <filesystem>
@@ -31,6 +32,78 @@ using namespace std;
 namespace hum {
 
 // START_MERGE
+
+//////////////////////////////
+//
+// splitEncoderDate -- The 1520s Project workflow has often stored the encoder
+//    name and encoding date together in !!!ENC:.  Keep !!!ENC: for the person
+//    and move the trailing date to !!!END:, without replacing a non-empty
+//    !!!END: record that is already present.
+//
+
+static void splitEncoderDate(HumdrumFile& infile) {
+	HumRegex hre;
+	int encLine = -1;
+	int endLine = -1;
+	std::string encoder;
+	std::string endDate;
+
+	for (int i=0; i<infile.getLineCount(); ++i) {
+		if (!infile[i].isReference()) {
+			continue;
+		}
+		HTp tok = infile.token(i, 0);
+		if (!tok) {
+			continue;
+		}
+		if ((encLine < 0) && (tok->compare(0, 7, "!!!ENC:") == 0)) {
+			std::string text = tok->getText().substr(7);
+			while (!text.empty() && std::isspace(static_cast<unsigned char>(text.front()))) {
+				text.erase(text.begin());
+			}
+			while (!text.empty() && std::isspace(static_cast<unsigned char>(text.back()))) {
+				text.pop_back();
+			}
+			if (hre.search(text, "^(.+?)\\s+((?:\\d{4}/\\d{1,2}/\\d{1,2})|(?:\\d{1,2}-\\d{1,2}-\\d{4}))/?$")) {
+				encoder = hre.getMatch(1);
+				endDate = hre.getMatch(2);
+				encLine = i;
+			}
+		} else if ((endLine < 0) && (tok->compare(0, 7, "!!!END:") == 0)) {
+			endLine = i;
+		}
+	}
+
+	if (encLine < 0) {
+		return;
+	}
+
+	while (!encoder.empty() && std::isspace(static_cast<unsigned char>(encoder.back()))) {
+		encoder.pop_back();
+	}
+	infile.token(encLine, 0)->setText("!!!ENC: " + encoder);
+
+	if (endLine >= 0) {
+		HTp tok = infile.token(endLine, 0);
+		std::string text = tok ? tok->getText() : "";
+		size_t colon = text.find(':');
+		bool hasContent = false;
+		if (colon != std::string::npos) {
+			for (size_t p=colon + 1; p<text.size(); ++p) {
+				if (!std::isspace(static_cast<unsigned char>(text[p]))) {
+					hasContent = true;
+					break;
+				}
+			}
+		}
+		if (!hasContent && tok) {
+			tok->setText("!!!END: " + endDate);
+		}
+	} else {
+		infile.insertLine(encLine + 1, "!!!END: " + endDate);
+	}
+}
+
 
 //////////////////////////////
 //
@@ -236,33 +309,6 @@ static void applyMensurationLabelMetOverrides(HumdrumFile& infile) {
 
 //////////////////////////////
 //
-// getDefaultMetForMensuration -- Supply the standard *met(...) value for the
-//    mensuration signatures that are common in 1520s Project imports when no
-//    explicit text label is available.
-//
-
-static std::string getDefaultMetForMensuration(HTp token) {
-	if (!token || token->isNull()) {
-		return "";
-	}
-	if (*token == "*M2/1") {
-		return "*met(C|)";
-	}
-	if (*token == "*M3/1") {
-		return "*met(O)";
-	}
-	if (*token == "*M6/2") {
-		return "*met(C.)";
-	}
-	if (*token == "*M9/2") {
-		return "*met(O.)";
-	}
-	return "";
-}
-
-
-//////////////////////////////
-//
 // addMeasureNumberToBarlineToken -- Add a barnum -a style number to ordinary
 //    barline tokens while preserving non-digit styling characters.  Final
 //    barlines are handled by the caller and are left unnumbered.
@@ -316,6 +362,178 @@ static void addAllMeasureNumbers(HumdrumFile& infile) {
 		}
 		number++;
 	}
+}
+
+
+//////////////////////////////
+//
+// getDefaultMetForMensuration -- Supply the standard *met(...) value for the
+//    mensuration signatures that are common in 1520s Project imports when no
+//    explicit text label is available.
+//
+
+static std::string getDefaultMetForMensuration(HTp token) {
+	if (!token || token->isNull()) {
+		return "";
+	}
+	if (*token == "*M2/1") {
+		return "*met(C|)";
+	}
+	if (*token == "*M3/1") {
+		return "*met(O)";
+	}
+	if (*token == "*M6/2") {
+		return "*met(C.)";
+	}
+	if (*token == "*M9/2") {
+		return "*met(O.)";
+	}
+	return "";
+}
+
+
+//////////////////////////////
+//
+// hasNonemptyReference -- True when a reference record exists and has content
+//    after the colon.  Used before choosing defaults that depend on whether
+//    title/opera metadata is actually present.
+//
+
+static bool hasNonemptyReference(HumdrumFile& infile, const std::string& key) {
+	std::string prefix = "!!!" + key + ":";
+	for (int i=0; i<infile.getLineCount(); ++i) {
+		if (!infile[i].isReference()) {
+			continue;
+		}
+		HTp tok = infile.token(i, 0);
+		if (!tok || (tok->compare(0, prefix.size(), prefix) != 0)) {
+			continue;
+		}
+		std::string text = tok->getText();
+		size_t colon = text.find(':');
+		if (colon == std::string::npos) {
+			return false;
+		}
+		for (size_t p=colon + 1; p<text.size(); ++p) {
+			if (!std::isspace(static_cast<unsigned char>(text[p]))) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	return false;
+}
+
+
+//////////////////////////////
+//
+// hasMuse2psRecord -- Check for an existing muse2ps layout comment so the
+//    filter does not add duplicate spacing instructions.
+//
+
+static bool hasMuse2psRecord(HumdrumFile& infile) {
+	for (int i=0; i<infile.getLineCount(); ++i) {
+		if (!infile[i].isGlobalComment()) {
+			continue;
+		}
+		HTp tok = infile.token(i, 0);
+		if (tok && (tok->compare(0, 10, "!!muse2ps:") == 0)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+
+//////////////////////////////
+//
+// hasTextSpines -- Texted scores need slightly different muse2ps spacing from
+//    untexted scores, since **text spines change the vertical layout.
+//
+
+static bool hasTextSpines(HumdrumFile& infile) {
+	for (int i=0; i<infile.getLineCount(); ++i) {
+		if (!infile[i].isExclusive()) {
+			continue;
+		}
+		for (int j=0; j<infile[i].getFieldCount(); ++j) {
+			HTp tok = infile.token(i, j);
+			if (tok && (*tok == "**text")) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+
+//////////////////////////////
+//
+// getMuse2psSpacing -- Return the 1520s Project default muse2ps spacing string
+//    for the current number of voices, with separate defaults for texted and
+//    untexted scores.
+//
+
+static std::string getMuse2psSpacing(int voices, bool texted) {
+	if (texted) {
+		if (voices == 3) {
+			return "i2I150v90,90,120c122z18l2700t130";
+		}
+		if (voices == 4) {
+			return "i2I150v90,90,90,120c122z18l2700t130";
+		}
+		if (voices == 5) {
+			return "i2I150v75,75,75,75,110c122z18l2780t100";
+		}
+		if (voices == 6) {
+			return "i2I150v85,85,85,85,85,100z18l2550t200c122";
+		}
+		return "";
+	}
+
+	if (voices == 3) {
+		return "i2I150v90,90,120c120z18l2770t130";
+	}
+	if (voices == 4) {
+		return "i2I150v90,90,90,120c120z18l2770t130";
+	}
+	if (voices == 5) {
+		return "i2I150v90,90,90,90,120c120z18l2770t130";
+	}
+	if (voices == 6) {
+		return "i2I150v85,85,85,85,85,100z18l2550t200c122";
+	}
+
+	return "";
+}
+
+
+//////////////////////////////
+//
+// addMuse2psRecord -- Add a project-default muse2ps layout line when one is
+//    absent and the voice count has a known spacing profile.
+//
+
+static void addMuse2psRecord(HumdrumFile& infile) {
+	if (hasMuse2psRecord(infile)) {
+		return;
+	}
+
+	int voices = (int)infile.getKernSpineStartList().size();
+	std::string spacing = getMuse2psSpacing(voices, hasTextSpines(infile));
+	if (spacing.empty()) {
+		return;
+	}
+
+	std::string prefix = "C^@{COM}^";
+	if (hasNonemptyReference(infile, "OPR")) {
+		prefix = "T^@{OPR}^u^@{ONM}{. }@{OTL}^C^@{COM}^";
+	}
+
+	infile.appendLine("!!muse2ps: " + prefix + spacing);
 }
 
 
@@ -1493,6 +1711,17 @@ void Tool_1520ify::addBibliographicRecords(HumdrumFile& infile) {
 		}
 	}
 
+	if (!basename.empty()) {
+		size_t dot = basename.find_last_of('.');
+		if ((dot != std::string::npos) && (basename.substr(dot) == ".krn")) {
+			// already in the desired form
+		} else if (dot != std::string::npos) {
+			basename = basename.substr(0, dot) + ".krn";
+		} else {
+			basename += ".krn";
+		}
+	}
+
 	// Build the segment line
 	std::string segmentLine = "!!!!SEGMENT: " + basename;
 
@@ -1953,6 +2182,8 @@ void Tool_1520ify::addBibliographicRecords(HumdrumFile& infile) {
 		infile.appendLine(line);
 	}
 
+	splitEncoderDate(infile);
+
 	// --- Remove !!!SMS: if it contains no content ---
 	{
 	    for (int li = 0; li < infile.getLineCount(); ++li) {
@@ -1989,6 +2220,8 @@ void Tool_1520ify::addBibliographicRecords(HumdrumFile& infile) {
 	        }
 	    }
 	}
+
+	addMuse2psRecord(infile);
 }
 
 


### PR DESCRIPTION
This reopens the 1520ify update in a cleaner form, separated from the JRPize work and organized into smaller commits for review.

Changes by commit:

1. Handle 1520ify mensuration labels
   - converts text mensuration labels into the appropriate *met(...) interpretations
   - adds mappings for signs such as MenCircleDot, MenCutC, MenReverseC, etc.
   - supports additional default mensuration mappings, including *M6/2 and *M9/2

2. Add 1520ify barline numbering
   - incorporates barnum -a-style numbering for ordinary barlines
   - leaves final double barlines unchanged

3. Improve 1520ify terminal longs
   - marks final sounding notes as terminal longs
   - also handles internal section-ending double barlines
   - avoids marking a voice that has already dropped out into rests before a section break

4. Compute 1520ify voices by section
   - computes !!!voices: from active voices in labelled sections
   - records a range such as 2-4 when different sections have different active voice counts
   - keeps !!!voices: as a file-level reference record, following the convention used in the prepared 1520s Project files

5. Normalize 1520ify metadata records
   - normalizes !!!!SEGMENT: filenames to .krn
   - splits encoder/date information from !!!ENC: into !!!ENC: and !!!END: where applicable
   - adds default !!muse2ps: spacing records when absent

I left the generated min/humlib.* files out of this PR so the source changes are easier to review. I can add/regenerate them afterward if you prefer.